### PR TITLE
Queue化してバッチでまとめて処理するスタイルにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,10 @@ Userが「食べた」と答えた回数を集計して、最近「食べた」�
 - [仕様書](docs/taxonomy/specification.md)
 - 興味のある動物の分類を関係図に表示
 - タグ付けをして分析のサポートができる
+
+## soil analysis
+
+## securities report
+
+- edinet data を zip でダウンロードする
+    - `python manage.py download_edinet_data` のバッチをまわす

--- a/securities/domain/valueobject/edinet.py
+++ b/securities/domain/valueobject/edinet.py
@@ -29,27 +29,52 @@ class RequestData:
 
 @dataclass
 class CountingData:
+    """
+    CountingData
+
+    計数データを表すクラス
+
+    Attributes:
+        edinet_code (str | None): The EDINET code of the entity.
+        filer_name_jp (str | None): The name of the entity in Japanese.
+        avg_salary (str | None): The average salary of the entity.
+        avg_tenure_years (str | None): The average tenure of employees in years.
+        avg_tenure_months (str | None): The average tenure of employees in months.
+        avg_age_years (str | None): The average age of employees in years.
+        avg_age_months (str | None): The average age of employees in months.
+        number_of_employees (str | None): The number of employees in the entity.
+
+    Properties:
+        avg_tenure_years_combined (str | None): 従業員の合計平均勤続年数。
+            self.avg_tenure_months が存在する場合、平均在職期間の小数部分が計算されます。
+            self.avg_tenure_months を 12 で割って、avg_tenure_years に加算します。
+            結合された平均在職期間値の文字列表現を返します。
+
+        avg_age_years_combined (str | None): 従業員の平均年齢を合計した年数。
+            self.avg_age_months が指定されている場合、平均年齢の小数部分が計算されます。
+            self.avg_age_months を 12 で割って、avg_age_years に加算します。
+            結合された平均年齢値の文字列表現を返します。
+    """
+
     edinet_code: str | None = None
     filer_name_jp: str | None = None
-    avg_salary: str | None = None
-    avg_tenure_years: str | None = None
-    avg_tenure_months: str | None = None
-    avg_age_years: str | None = None
-    avg_age_months: str | None = None
-    number_of_employees: str | None = None
+    avg_salary: int = 0
+    avg_tenure_years: int = 0
+    avg_tenure_months: int = 0
+    avg_age_years: int = 0
+    avg_age_months: int = 0
+    number_of_employees: int = 0
 
     @property
-    def avg_tenure_years_combined(self) -> str | None:
+    def avg_tenure_years_combined(self) -> float:
         if self.avg_tenure_months:
             avg_tenure_decimal = round(int(self.avg_tenure_months) / 12, 1)
-            avg_tenure = int(self.avg_tenure_years) + avg_tenure_decimal
-            return str(avg_tenure)
+            return int(self.avg_tenure_years) + avg_tenure_decimal
         return self.avg_tenure_years
 
     @property
-    def avg_age_years_combined(self) -> str | None:
+    def avg_age_years_combined(self) -> float:
         if self.avg_age_months:
             age_years_decimal = round(int(self.avg_age_months) / 12, 1)
-            age_years = int(self.avg_age_years) + age_years_decimal
-            return str(age_years)
+            return int(self.avg_age_years) + age_years_decimal
         return self.avg_age_years

--- a/securities/management/commands/download_edinet_data.py
+++ b/securities/management/commands/download_edinet_data.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand
+
+from securities.models import ReportDocument
+
+
+class Command(BaseCommand):
+    help = "Download edinet data"
+
+    def handle(self, *args, **options):
+        # 処理対象
+        report_documents = ReportDocument.objects.filter(download_reserved=True)[:20]
+
+        # edinet_list = []
+        # for _, row in df.iterrows():
+        #     edinet_list.append(
+        #         Company(
+        #             edinet_code=na(row["ＥＤＩＮＥＴコード"]),
+        #             type_of_submitter=na(row["提出者種別"]),
+        #             listing_status=na(row["上場区分"]),
+        #             consolidated_status=na(row["連結の有無"]),
+        #             capital=(int(row["資本金"]) if pd.notna(row["資本金"]) else None),
+        #             end_fiscal_year=na(row["決算日"]),
+        #             submitter_name=na(row["提出者名"]),
+        #             submitter_name_en=na(row["提出者名（英字）"]),
+        #             submitter_name_kana=na(row["提出者名（ヨミ）"]),
+        #             address=na(row["所在地"]),
+        #             submitter_industry=na(row["提出者業種"]),
+        #             securities_code=na(row["証券コード"]),
+        #             corporate_number=na(row["提出者法人番号"]),
+        #         )
+        #     )
+        # Company.objects.bulk_create(edinet_list)
+
+        # 処理対象のフラグを落とす
+        ReportDocument.objects.filter(
+            id__in=[report_document.id for report_document in report_documents]
+        ).update(download_reserved=False)
+
+        self.stdout.write(self.style.SUCCESS("Successfully download edinet data"))

--- a/securities/models.py
+++ b/securities/models.py
@@ -80,25 +80,12 @@ class ReportDocument(models.Model):
     english_doc_flag = models.BooleanField(verbose_name="英文ファイル有無フラグ")
     csv_flag = models.BooleanField(verbose_name="CSV有無フラグ")
     legal_status = models.BooleanField(verbose_name="縦覧区分")
+    download_reserved = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f"{self.doc_id} - {self.edinet_code}"
-
-
-class DownloadQueue(models.Model):
-    """
-    Class representing a download queue.
-
-
-    Attributes:
-        doc_id (CharField): The document ID or number.
-        created_at (DateTimeField): The datetime when the download queue is created.
-
-    """
-    doc_id = models.CharField(verbose_name="書類管理番号", max_length=8, unique=True)
-    created_at = models.DateTimeField(auto_now_add=True)
 
 
 class Company(models.Model):

--- a/securities/models.py
+++ b/securities/models.py
@@ -87,6 +87,20 @@ class ReportDocument(models.Model):
         return f"{self.doc_id} - {self.edinet_code}"
 
 
+class DownloadQueue(models.Model):
+    """
+    Class representing a download queue.
+
+
+    Attributes:
+        doc_id (CharField): The document ID or number.
+        created_at (DateTimeField): The datetime when the download queue is created.
+
+    """
+    doc_id = models.CharField(verbose_name="書類管理番号", max_length=8, unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+
 class Company(models.Model):
     """
     提出書類一覧APIで返ってくる顔ぶれから書類を取得してできあがる、企業マスタ

--- a/securities/models.py
+++ b/securities/models.py
@@ -35,6 +35,7 @@ class ReportDocument(models.Model):
         english_doc_flag (models.BooleanField): A flag indicating whether the document has an English file.
         csv_flag (models.BooleanField): A flag indicating whether the document has a CSV file.
         legal_status (models.BooleanField): A flag indicating whether the document is vertical reading.
+        download_reserved (models.BooleanField): ダウンロード予約済みかどうか
         created_at (models.DateTimeField): The date and time when the document was created.
         updated_at (models.DateTimeField): The date and time when the document was last updated.
     """

--- a/securities/templates/securities/report/index.html
+++ b/securities/templates/securities/report/index.html
@@ -36,9 +36,11 @@
             <button type="submit" class="btn btn-primary">指定した期間の書類一覧を取得</button>
         </form>
         <div class="container mt-5 pt-5">
+            <button id="submit-for-reserve" class="btn btn-primary">ダウンロード予約する</button>
             <table class="table table-striped table-bordered">
                 <thead class="bg-primary text-white">
                 <tr>
+                    <th scope="col"></th>
                     <th scope="col">Doc ID</th>
                     <th scope="col">EDINET Code</th>
                     <th scope="col">Sec Code</th>
@@ -54,11 +56,9 @@
                 <tbody>
                 {% for report_document in object_list %}
                     <tr>
-                        <td>
-                            <a href="{% url 'securities:download' doc_id=report_document.doc_id %}">
-                                {{ report_document.doc_id }}
-                            </a>
-                        </td>
+                        {# TODO: reservedだったらチェックボックスを disabled にする #}
+                        <td><input type="checkbox" value="{{ report_document.id }}" class="report-checkbox"></td>
+                        <td>{{ report_document.doc_id }}</td>
                         <td>{{ report_document.edinet_code }}</td>
                         <td>{{ report_document.sec_code }}</td>
                         <td>{{ report_document.jcn }}</td>
@@ -100,4 +100,25 @@
             </ul>
         </nav>
     </div>
+    <script>
+        document.querySelector('#submit-for-reserve').addEventListener('click', function () {
+            const ids = Array.from(document.querySelectorAll('.report-checkbox:checked')).map(box => box.value);
+
+            fetch('{% url 'securities:download_reserve' %}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': '{{ csrf_token }}',
+                },
+                body: JSON.stringify(ids)
+            }).then(function (response) {
+                if (response.ok) {
+                    return response.json();
+                }
+                throw new Error('Network response was not ok');
+            }).then(function (json) {
+                console.log(json);
+            });
+        });
+    </script>
 {% endblock %}

--- a/securities/templates/securities/report/index.html
+++ b/securities/templates/securities/report/index.html
@@ -63,8 +63,9 @@
                 <tbody>
                 {% for report_document in object_list %}
                     <tr>
-                        {# TODO: reservedだったらチェックボックスを disabled にする #}
-                        <td><input type="checkbox" value="{{ report_document.id }}" class="report-checkbox"></td>
+                        <td>{% if request.GET.reserved != 'yes' %}
+                            <input type="checkbox" value="{{ report_document.id }}" class="report-checkbox">{% endif %}
+                        </td>
                         <td>{{ report_document.doc_id }}</td>
                         <td>{{ report_document.edinet_code }}</td>
                         <td>{{ report_document.sec_code }}</td>

--- a/securities/templates/securities/report/index.html
+++ b/securities/templates/securities/report/index.html
@@ -36,7 +36,14 @@
             <button type="submit" class="btn btn-primary">指定した期間の書類一覧を取得</button>
         </form>
         <div class="container mt-5 pt-5">
-            <button id="submit-for-reserve" class="btn btn-primary">ダウンロード予約する</button>
+            <button id="submit-for-reserve" class="btn btn-outline-primary">ダウンロード予約する</button>
+            <a class="btn btn-outline-info{% if request.GET.reserved == 'yes' %} active{% endif %}"
+               href="
+
+
+                       {% url 'securities:index' %}{% if request.GET.reserved != 'yes' %}?reserved=yes{% else %}{% endif %}">
+                ダウンロード予約済みリスト
+            </a>
             <table class="table table-striped table-bordered">
                 <thead class="bg-primary text-white">
                 <tr>

--- a/securities/urls.py
+++ b/securities/urls.py
@@ -4,13 +4,13 @@ from securities.views import (
     IndexView,
     EdinetCodeUploadView,
     EdinetCodeUploadSuccessView,
-    DownloadView,
+    DownloadReserveView,
 )
 
 app_name = "securities"
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),
-    path("download/<str:doc_id>/", DownloadView.as_view(), name="download"),
+    path("download_reserve/", DownloadReserveView.as_view(), name="download_reserve"),
     path(
         "edinet_code_upload/upload",
         EdinetCodeUploadView.as_view(),

--- a/securities/views.py
+++ b/securities/views.py
@@ -57,32 +57,6 @@ class IndexView(ListView):
         return redirect("securities:index")
 
 
-# class DownloadView(View):
-#     """
-#     リンクをクリックしたときにダウンロードする処理をまとめた
-#     TODO: cronバッチに移管して削除予定
-#     """
-#
-#     @staticmethod
-#     def get(request, **kwargs):
-#         service = XbrlService()
-#
-#         work_dir = Path(settings.MEDIA_ROOT) / "securities"
-#         if not work_dir.exists():
-#             work_dir.mkdir(parents=True, exist_ok=True)
-#         temp_dir = work_dir / "temp"
-#         if not temp_dir.exists():
-#             temp_dir.mkdir(parents=True, exist_ok=True)
-#
-#         report_doc = service.download_xbrl(doc_id=kwargs["doc_id"], work_dir=work_dir)
-#         service.repository.delete_existing_records(report_doc)
-#         counting_data = service.make_counting_data(work_dir=work_dir, temp_dir=temp_dir)
-#         service.repository.insert(report_doc=report_doc, counting_data=counting_data)
-#         logging.info(f"{report_doc.doc_id} の計数データ作成完了")
-#
-#         return redirect("securities:index")
-
-
 @method_decorator(ensure_csrf_cookie, name="dispatch")
 class DownloadReserveView(View):
     @staticmethod

--- a/securities/views.py
+++ b/securities/views.py
@@ -26,6 +26,10 @@ class IndexView(ListView):
 
     def get_queryset(self):
         queryset = super().get_queryset()
+        if self.request.GET.get("reserved") == "yes":
+            queryset = queryset.filter(download_reserved=True)
+        else:
+            queryset = queryset.filter(download_reserved=False)
         queryset = queryset.order_by("doc_id")
         return queryset
 

--- a/securities/views.py
+++ b/securities/views.py
@@ -60,7 +60,7 @@ class IndexView(ListView):
 # class DownloadView(View):
 #     """
 #     リンクをクリックしたときにダウンロードする処理をまとめた
-#     TODO: 削除予定
+#     TODO: cronバッチに移管して削除予定
 #     """
 #
 #     @staticmethod

--- a/securities/views.py
+++ b/securities/views.py
@@ -26,20 +26,7 @@ class IndexView(ListView):
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        queryset = queryset.values(
-            "id",
-            "doc_id",
-            "edinet_code",
-            "sec_code",
-            "jcn",
-            "filer_name",
-            "period_start",
-            "period_end",
-            "submit_date_time",
-            "doc_description",
-            "xbrl_flag",
-            "download_reserved",
-        ).order_by("doc_id")
+        queryset = queryset.order_by("doc_id")
         return queryset
 
     def get_context_data(self, **kwargs):

--- a/securities/views.py
+++ b/securities/views.py
@@ -1,15 +1,17 @@
-import logging
+import json
 from datetime import datetime
-from pathlib import Path
 
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views import View
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView, FormView, ListView
 
-from config import settings
 from securities.domain.service.upload import UploadService
 from securities.domain.service.xbrl import XbrlService
 from securities.domain.valueobject.edinet import RequestData
@@ -25,6 +27,7 @@ class IndexView(ListView):
     def get_queryset(self):
         queryset = super().get_queryset()
         queryset = queryset.values(
+            "id",
             "doc_id",
             "edinet_code",
             "sec_code",
@@ -35,6 +38,7 @@ class IndexView(ListView):
             "submit_date_time",
             "doc_description",
             "xbrl_flag",
+            "download_reserved",
         ).order_by("doc_id")
         return queryset
 
@@ -62,25 +66,48 @@ class IndexView(ListView):
         return redirect("securities:index")
 
 
-class DownloadView(View):
+# class DownloadView(View):
+#     """
+#     リンクをクリックしたときにダウンロードする処理をまとめた
+#     TODO: 削除予定
+#     """
+#
+#     @staticmethod
+#     def get(request, **kwargs):
+#         service = XbrlService()
+#
+#         work_dir = Path(settings.MEDIA_ROOT) / "securities"
+#         if not work_dir.exists():
+#             work_dir.mkdir(parents=True, exist_ok=True)
+#         temp_dir = work_dir / "temp"
+#         if not temp_dir.exists():
+#             temp_dir.mkdir(parents=True, exist_ok=True)
+#
+#         report_doc = service.download_xbrl(doc_id=kwargs["doc_id"], work_dir=work_dir)
+#         service.repository.delete_existing_records(report_doc)
+#         counting_data = service.make_counting_data(work_dir=work_dir, temp_dir=temp_dir)
+#         service.repository.insert(report_doc=report_doc, counting_data=counting_data)
+#         logging.info(f"{report_doc.doc_id} の計数データ作成完了")
+#
+#         return redirect("securities:index")
+
+
+@method_decorator(ensure_csrf_cookie, name="dispatch")
+class DownloadReserveView(View):
     @staticmethod
-    def get(request, **kwargs):
-        service = XbrlService()
-
-        work_dir = Path(settings.MEDIA_ROOT) / "securities"
-        if not work_dir.exists():
-            work_dir.mkdir(parents=True, exist_ok=True)
-        temp_dir = work_dir / "temp"
-        if not temp_dir.exists():
-            temp_dir.mkdir(parents=True, exist_ok=True)
-
-        report_doc = service.download_xbrl(doc_id=kwargs["doc_id"], work_dir=work_dir)
-        service.repository.delete_existing_records(report_doc)
-        counting_data = service.make_counting_data(work_dir=work_dir, temp_dir=temp_dir)
-        service.repository.insert(report_doc=report_doc, counting_data=counting_data)
-        logging.info(f"{report_doc.doc_id} の計数データ作成完了")
-
-        return redirect("securities:index")
+    def post(request):
+        ids = json.loads(request.body)
+        for identifier in ids:
+            try:
+                doc = ReportDocument.objects.get(pk=identifier)
+                doc.download_reserved = True
+                doc.save()
+            except ObjectDoesNotExist:
+                return JsonResponse(
+                    {"error": f"No ReportDocument exists with ID {identifier}"},
+                    status=400,
+                )
+        return JsonResponse({"status": "success"})
 
 
 class EdinetCodeUploadView(FormView):


### PR DESCRIPTION
## 概要
リンクを押して処理をまわすと、単一ファイルの処理でも意外と重くて同期処理のためずっとぐるぐるしてmysqlのエラーが出ることがわかった

- [x] 「ダウンロード予約」リンクを押したら（チェックをpostしたら）、ReportDocumentテーブルの `download_reserved` にTrueをupdate
- [x] docダウンロード処理バッチを作成
  - [x] ReportDocumentテーブルの `download_reserved` が True のもの top20 を処理する
  - [x] 処理済みの `download_reserved` を False
- [x] バッチとしてcronでまとめて処理
  - [x] 日次で実行する
- [x] toggleでダウンロード予約済みを表示するリストをつくる
  - [x] 予約済みのレコードはチェックボックスを表示しないこと