### PR TITLE
測量の手製ライブラリで写真位置から最寄り圃場の特定（djangoフロント）

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{jquery-3.6.0, jquery-ui}" />
     <includedPredefinedLibrary name="Node.js Core" />
   </component>
 </project>

--- a/lib/geo/valueobject/test_coord.py
+++ b/lib/geo/valueobject/test_coord.py
@@ -10,7 +10,10 @@ class TestCoord(TestCase):
         XarvioCoord (経度,緯度) と GoogleMapsCoord (緯度,経度) の
         相互変換と文字列表現をテストします。
         """
-        xarvio_coord = XarvioCoord(34.7443565, 137.6489657)
+        xarvio_coord = XarvioCoord(
+            longitude=137.6489657,
+            latitude=34.7443565,
+        )
         self.assertEqual((137.6489657, 34.7443565), xarvio_coord.to_tuple())
         self.assertEqual("137.6489657,34.7443565", xarvio_coord.to_str())
 

--- a/soil_analysis/domain/service/photo_processing_service.py
+++ b/soil_analysis/domain/service/photo_processing_service.py
@@ -80,7 +80,7 @@ class PhotoProcessingService:
 
     @staticmethod
     def calculate_distance(
-        coord1: XarvioCoord, coord2: LandLocation, unit: str = Unit.METERS
+        photo_spot: XarvioCoord, land_spot: LandLocation, unit: str = Unit.METERS
     ) -> float:
         """２つの座標間の距離を計算します。
 
@@ -89,15 +89,15 @@ class PhotoProcessingService:
         そのため、haversineライブラリを使用する際に座標のタプルを逆にしています。
 
         Args:
-            coord1: 開始座標
-            coord2: 終了座標
+            photo_spot: 開始座標
+            land_spot: 終了座標
             unit: 距離の単位（デフォルトはメートル）
 
         Returns:
             float: 指定単位での2点間の距離
         """
         return haversine(
-            coord1.to_google().to_tuple(),
-            coord2.to_google().to_tuple(),
+            photo_spot.to_google().to_tuple(),
+            land_spot.to_google().to_tuple(),
             unit=unit,
         )

--- a/soil_analysis/domain/valueobject/land.py
+++ b/soil_analysis/domain/valueobject/land.py
@@ -36,7 +36,9 @@ class LandLocation(BaseCoord):
             lng_float = float(lng)
             lat_float = float(lat)
             # XarvioCoordは(latitude, longitude)の順で引数を取る
-            original_coord_list.append(XarvioCoord(lat_float, lng_float))
+            original_coord_list.append(
+                XarvioCoord(longitude=lng_float, latitude=lat_float)
+            )
             longitude_sum += lng_float
             latitude_sum += lat_float
 
@@ -46,7 +48,7 @@ class LandLocation(BaseCoord):
 
         # 中心点を XarvioCoord として保持
         # XarvioCoordは(latitude, longitude)の順で引数を取る
-        self.center = XarvioCoord(center_lat, center_lng)
+        self.center = XarvioCoord(longitude=center_lng, latitude=center_lat)
         self.original_coord_list = original_coord_list
         self.name = name
 

--- a/soil_analysis/templates/soil_analysis/company/create.html
+++ b/soil_analysis/templates/soil_analysis/company/create.html
@@ -2,14 +2,14 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:company_list' %}">Company list</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Create</li>
-        </ol>
-    </nav>
     <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:company_list' %}">Company list</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Create</li>
+            </ol>
+        </nav>
         <h1>会社の作成</h1>
         <form method="post" enctype="multipart/form-data">
             {% csrf_token %}

--- a/soil_analysis/templates/soil_analysis/company/detail.html
+++ b/soil_analysis/templates/soil_analysis/company/detail.html
@@ -2,26 +2,28 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:company_list' %}">Company list</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Detail</li>
-        </ol>
-    </nav>
     <div class="container">
-        <h1>会社の詳細</h1>
-        {% if object.image %}
-            <img src="{{ object.image.url }}" alt="Company Image">
-        {% endif %}
-        <ul>
-            <li>名称: {{ object.name }}</li>
-            <li>備考: {{ object.remark|default:'-' }}</li>
-            <li>カテゴリー: {{ object.category }}</li>
-        </ul>
-        <form method="GET" class="registration" action="{% url 'soil:company_list' %}">
-            {% csrf_token %}
-            <button type="submit">戻る</button>
-        </form>
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:company_list' %}">Company list</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Detail</li>
+            </ol>
+        </nav>
+        <div class="container">
+            <h1>会社の詳細</h1>
+            {% if object.image %}
+                <img src="{{ object.image.url }}" alt="Company Image">
+            {% endif %}
+            <ul>
+                <li>名称: {{ object.name }}</li>
+                <li>備考: {{ object.remark|default:'-' }}</li>
+                <li>カテゴリー: {{ object.category }}</li>
+            </ul>
+            <form method="GET" class="registration" action="{% url 'soil:company_list' %}">
+                {% csrf_token %}
+                <button type="submit">戻る</button>
+            </form>
+        </div>
     </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/company/list.html
+++ b/soil_analysis/templates/soil_analysis/company/list.html
@@ -2,41 +2,43 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Company list</li>
-        </ol>
-    </nav>
-    <a class="btn btn-outline-primary mb-3" href="{% url 'soil:company_create' %}"
-       role="button">＋農業法人の追加</a>
-    {% for a_company in object_list %}
-        {% if not forloop.counter|divisibleby:"2" %}
-            <div class="row mb-4">
-        {% endif %}
-    <div class="col-sm-6">
-        <div class="card">
-            {% if a_company.image %}
-                <img src="{{ a_company.image.url }}" width="100%" height="180" alt="Land Image">
-            {% else %}
-                <svg class="bd-placeholder-img card-img-top" width="100%" height="180"
-                     xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false"
-                     role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title>
-                    <rect fill="#868e96" width="100%" height="100%"/>
-                    <text fill="#dee2e6" dy=".3em" x="38%" y="50%">Image cap</text>
-                </svg>
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Company list</li>
+            </ol>
+        </nav>
+        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:company_create' %}"
+           role="button">＋農業法人の追加</a>
+        {% for a_company in object_list %}
+            {% if not forloop.counter|divisibleby:"2" %}
+                <div class="row mb-4">
             {% endif %}
-            <div class="card-body">
-                <a href="{% url 'soil:company_detail' a_company.pk %}"><h5
-                        class="card-title">{{ a_company.name }}</h5></a>
-                <p class="card-text">備考: {{ a_company.remark|default:"-" }}</p>
-                <a href="{% url 'soil:land_list' a_company.pk %}"
-                   class="btn btn-outline-primary">圃場リスト</a>
+        <div class="col-sm-6">
+            <div class="card">
+                {% if a_company.image %}
+                    <img src="{{ a_company.image.url }}" width="100%" height="180" alt="Land Image">
+                {% else %}
+                    <svg class="bd-placeholder-img card-img-top" width="100%" height="180"
+                         xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false"
+                         role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title>
+                        <rect fill="#868e96" width="100%" height="100%"/>
+                        <text fill="#dee2e6" dy=".3em" x="38%" y="50%">Image cap</text>
+                    </svg>
+                {% endif %}
+                <div class="card-body">
+                    <a href="{% url 'soil:company_detail' a_company.pk %}"><h5
+                            class="card-title">{{ a_company.name }}</h5></a>
+                    <p class="card-text">備考: {{ a_company.remark|default:"-" }}</p>
+                    <a href="{% url 'soil:land_list' a_company.pk %}"
+                       class="btn btn-outline-primary">圃場リスト</a>
+                </div>
             </div>
         </div>
+        {% if forloop.counter|divisibleby:"2" %}
+            </div>
+        {% endif %}
+        {% endfor %}
     </div>
-    {% if forloop.counter|divisibleby:"2" %}
-        </div>
-    {% endif %}
-    {% endfor %}
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/hardness/association/individual/list.html
+++ b/soil_analysis/templates/soil_analysis/hardness/association/individual/list.html
@@ -2,47 +2,49 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
-            </li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:hardness_association' %}">Association</a>
-            </li>
-            <li class="breadcrumb-item active" aria-current="page">Individual</li>
-        </ol>
-    </nav>
-    <h1>データの関連付け</h1>
-    <form method="post" action="{% url 'soil:hardness_association_individual' memory_anchor land_ledger %}"
-          enctype="multipart/form-data">
-        {% csrf_token %}
-        <input class="btn btn-outline-primary mb-3" type="submit" name="button" value="送信">
-        <table class="table table-bordered table-gray table-striped">
-            <thead>
-            <tr>
-                <th>memory</th>
-                <th>datetime</th>
-                <th>count</th>
-                <th class="centered">圃場ブロック</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for measurement in object_list %}
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
+                </li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:hardness_association' %}">Association</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">Individual</li>
+            </ol>
+        </nav>
+        <h1>データの関連付け</h1>
+        <form method="post" action="{% url 'soil:hardness_association_individual' memory_anchor land_ledger %}"
+              enctype="multipart/form-data">
+            {% csrf_token %}
+            <input class="btn btn-outline-primary mb-3" type="submit" name="button" value="送信">
+            <table class="table table-bordered table-gray table-striped">
+                <thead>
                 <tr>
-                    <td>{{ measurement.set_memory }}</td>
-                    <td>{{ measurement.set_datetime|date:"Y-m-d" }}</td>
-                    <td>{{ measurement.cnt }}</td>
-                    <td>
-                        <select class="form-select" name="land-blocks[]" required aria-label="圃場ブロックを選択">
-                            <option selected disabled value="">選択してください</option>
-                            {% for land_block in land_blocks %}
-                                <option value="{{ land_block.pk }}">{{ land_block.name }}</option>
-                            {% endfor %}
-                        </select>
-                    </td>
+                    <th>memory</th>
+                    <th>datetime</th>
+                    <th>count</th>
+                    <th class="centered">圃場ブロック</th>
                 </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </form>
+                </thead>
+                <tbody>
+                {% for measurement in object_list %}
+                    <tr>
+                        <td>{{ measurement.set_memory }}</td>
+                        <td>{{ measurement.set_datetime|date:"Y-m-d" }}</td>
+                        <td>{{ measurement.cnt }}</td>
+                        <td>
+                            <select class="form-select" name="land-blocks[]" required aria-label="圃場ブロックを選択">
+                                <option selected disabled value="">選択してください</option>
+                                {% for land_block in land_blocks %}
+                                    <option value="{{ land_block.pk }}">{{ land_block.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </form>
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/hardness/association/list.html
+++ b/soil_analysis/templates/soil_analysis/hardness/association/list.html
@@ -1,70 +1,72 @@
 {% extends "soil_analysis/base.html" %}
 {% load static %}
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
-            </li>
-            <li class="breadcrumb-item active" aria-current="page">Association</li>
-        </ol>
-    </nav>
-    <h1>データの関連付け</h1>
-    <form method="post" action="{% url 'soil:hardness_association' %}" enctype="multipart/form-data">
-        {% csrf_token %}
-        <div class="row">
-            <div class="dropdown col-6">
-                <select class="form-select" name="land_ledger" required aria-label="帳簿を選択">
-                    <option selected disabled value="">帳簿を選択</option>
-                    {% for land_ledger in land_ledgers %}
-                        <option value="{{ land_ledger.pk }}">{{ land_ledger.land.company.name }} {{ land_ledger.land.name }} {{ land_ledger.sampling_date|date:"Ym" }} {{ land_ledger.land_period.name }}</option>
-                    {% endfor %}
-                    <option value="{{ land_ledger.pk }}">新規作成（未実装）</option>
-                </select>
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">Association</li>
+            </ol>
+        </nav>
+        <h1>データの関連付け</h1>
+        <form method="post" action="{% url 'soil:hardness_association' %}" enctype="multipart/form-data">
+            {% csrf_token %}
+            <div class="row">
+                <div class="dropdown col-6">
+                    <select class="form-select" name="land_ledger" required aria-label="帳簿を選択">
+                        <option selected disabled value="">帳簿を選択</option>
+                        {% for land_ledger in land_ledgers %}
+                            <option value="{{ land_ledger.pk }}">{{ land_ledger.land.company.name }} {{ land_ledger.land.name }} {{ land_ledger.sampling_date|date:"Ym" }} {{ land_ledger.land_period.name }}</option>
+                        {% endfor %}
+                        <option value="{{ land_ledger.pk }}">新規作成（未実装）</option>
+                    </select>
+                </div>
+                <input class="btn btn-outline-primary mb-3 col-2" type="submit" name="button" value="送信">
             </div>
-            <input class="btn btn-outline-primary mb-3 col-2" type="submit" name="button" value="送信">
-        </div>
 
-        <table class="table table-bordered table-gray table-striped">
-            <thead>
-            <tr>
-                <th>memory</th>
-                <th>datetime</th>
-                <th>count</th>
-                <th class="centered">R</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for measurement in object_list %}
+            <table class="table table-bordered table-gray table-striped">
+                <thead>
                 <tr>
-                    <td>{{ measurement.set_memory }}</td>
-                    <td>{{ measurement.set_datetime|date:"Y-m-d" }}</td>
-                    <td>{{ measurement.cnt }}</td>
-                    {% if forloop.counter0|divisibleby:25 %}
-                        <td rowspan="5">
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" name="form_checkboxes[]"
-                                       value="{{ measurement.set_memory }}" id="form_checkbox">
-                                <label class="form-check-label" for="form_checkbox">
-                                    圃場をRパターンで登録
-                                </label>
-                            </div>
-                            <button class="btn btn-outline-secondary mb-3" type="submit" name="btn_individual"
-                                    value="{{ measurement.set_memory }}">圃場をRパターン以外で登録
-                            </button>
-                        </td>
-                    {% endif %}
+                    <th>memory</th>
+                    <th>datetime</th>
+                    <th>count</th>
+                    <th class="centered">R</th>
                 </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-        <input type="hidden" name="form_land_ledger" id="selected_land_ledger" value="">
-    </form>
-    <script>
-        const dropdown = document.querySelector('.dropdown select');
-        const hiddenInput = document.getElementById('selected_land_ledger');
-        dropdown.addEventListener('change', (event) => {
-            hiddenInput.value = event.target.value;
-        });
-    </script>
+                </thead>
+                <tbody>
+                {% for measurement in object_list %}
+                    <tr>
+                        <td>{{ measurement.set_memory }}</td>
+                        <td>{{ measurement.set_datetime|date:"Y-m-d" }}</td>
+                        <td>{{ measurement.cnt }}</td>
+                        {% if forloop.counter0|divisibleby:25 %}
+                            <td rowspan="5">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="form_checkboxes[]"
+                                           value="{{ measurement.set_memory }}" id="form_checkbox">
+                                    <label class="form-check-label" for="form_checkbox">
+                                        圃場をRパターンで登録
+                                    </label>
+                                </div>
+                                <button class="btn btn-outline-secondary mb-3" type="submit" name="btn_individual"
+                                        value="{{ measurement.set_memory }}">圃場をRパターン以外で登録
+                                </button>
+                            </td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            <input type="hidden" name="form_land_ledger" id="selected_land_ledger" value="">
+        </form>
+        <script>
+            const dropdown = document.querySelector('.dropdown select');
+            const hiddenInput = document.getElementById('selected_land_ledger');
+            dropdown.addEventListener('change', (event) => {
+                hiddenInput.value = event.target.value;
+            });
+        </script>
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/hardness/association/success.html
+++ b/soil_analysis/templates/soil_analysis/hardness/association/success.html
@@ -2,39 +2,41 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
-            </li>
-            <li class="breadcrumb-item active" aria-current="page">Upload hardness</li>
-        </ol>
-    </nav>
-    <h1>Association Successful</h1>
-    {% if import_errors %}
-        <p>処理は成功しましたが、エラーが発生したデータがあります。詳細は以下のテーブルをご確認ください。</p>
-        <table class="table table-bordered table-gray table-striped">
-            <thead>
-            <tr>
-                <th>CSV File</th>
-                <th>CSV Folder</th>
-                <th>Message</th>
-                <th>Created At</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for error in import_errors %}
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">Upload hardness</li>
+            </ol>
+        </nav>
+        <h1>Association Successful</h1>
+        {% if import_errors %}
+            <p>処理は成功しましたが、エラーが発生したデータがあります。詳細は以下のテーブルをご確認ください。</p>
+            <table class="table table-bordered table-gray table-striped">
+                <thead>
                 <tr>
-                    <td>{{ error.file }}</td>
-                    <td>{{ error.folder }}</td>
-                    <td>{{ error.message }}</td>
-                    <td>{{ error.created_at }}</td>
+                    <th>CSV File</th>
+                    <th>CSV Folder</th>
+                    <th>Message</th>
+                    <th>Created At</th>
                 </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <p>関連付けが成功しました！</p>
-        <a class="btn btn-outline-primary mb-3" href="#" role="button">XXXXへ進む</a>
-    {% endif %}
+                </thead>
+                <tbody>
+                {% for error in import_errors %}
+                    <tr>
+                        <td>{{ error.file }}</td>
+                        <td>{{ error.folder }}</td>
+                        <td>{{ error.message }}</td>
+                        <td>{{ error.created_at }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>関連付けが成功しました！</p>
+            <a class="btn btn-outline-primary mb-3" href="#" role="button">XXXXへ進む</a>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/hardness/form.html
+++ b/soil_analysis/templates/soil_analysis/hardness/form.html
@@ -1,17 +1,19 @@
 {% extends "soil_analysis/base.html" %}
 {% load static %}
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Upload hardness</li>
-        </ol>
-    </nav>
-    <h1>土壌硬度データのアップロード</h1>
-    <p>取り込みCSV フォルダをzip化してアップロードしてください</p>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button class="btn btn-outline-primary mb-3" type="submit">Upload</button>
-    </form>
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Upload hardness</li>
+            </ol>
+        </nav>
+        <h1>土壌硬度データのアップロード</h1>
+        <p>取り込みCSV フォルダをzip化してアップロードしてください</p>
+        <form method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button class="btn btn-outline-primary mb-3" type="submit">Upload</button>
+        </form>
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/hardness/success.html
+++ b/soil_analysis/templates/soil_analysis/hardness/success.html
@@ -2,39 +2,41 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
-            </li>
-            <li class="breadcrumb-item active" aria-current="page">Upload success</li>
-        </ol>
-    </nav>
-    <h1>Upload Successful</h1>
-    {% if import_errors %}
-        <p>処理は成功しましたが、エラーが発生したデータがあります。詳細は以下のテーブルをご確認ください。</p>
-        <table class="table table-bordered table-gray table-striped">
-            <thead>
-            <tr>
-                <th>CSV File</th>
-                <th>CSV Folder</th>
-                <th>Message</th>
-                <th>Created At</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for error in import_errors %}
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:hardness_upload' %}">Upload hardness</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">Upload success</li>
+            </ol>
+        </nav>
+        <h1>Upload Successful</h1>
+        {% if import_errors %}
+            <p>処理は成功しましたが、エラーが発生したデータがあります。詳細は以下のテーブルをご確認ください。</p>
+            <table class="table table-bordered table-gray table-striped">
+                <thead>
                 <tr>
-                    <td>{{ error.file }}</td>
-                    <td>{{ error.folder }}</td>
-                    <td>{{ error.message }}</td>
-                    <td>{{ error.created_at }}</td>
+                    <th>CSV File</th>
+                    <th>CSV Folder</th>
+                    <th>Message</th>
+                    <th>Created At</th>
                 </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <p>アップロードデータに異常はありませんでした！</p>
-        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:hardness_association' %}" role="button">取り込みデータのアサインへ進む</a>
-    {% endif %}
+                </thead>
+                <tbody>
+                {% for error in import_errors %}
+                    <tr>
+                        <td>{{ error.file }}</td>
+                        <td>{{ error.folder }}</td>
+                        <td>{{ error.message }}</td>
+                        <td>{{ error.created_at }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>アップロードデータに異常はありませんでした！</p>
+            <a class="btn btn-outline-primary mb-3" href="{% url 'soil:hardness_association' %}" role="button">取り込みデータのアサインへ進む</a>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -13,5 +13,7 @@
            role="button">土壌硬度データ取り込み</a>
         <a class="btn btn-outline-primary mb-3" href="{% url 'soil:route_suggest_upload' %}"
            role="button">圃場ルートサジェスト（試作）</a>
+        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:associate_picture_and_land' %}"
+           role="button">写真と圃場の自動紐づけ</a>
     </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -2,14 +2,16 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item">Home</li>
-        </ol>
-    </nav>
-    <a class="btn btn-outline-primary mb-3" href="{% url 'soil:company_list' %}" role="button">農業法人の一覧</a>
-    <a class="btn btn-outline-primary mb-3" href="{% url 'soil:hardness_upload' %}"
-       role="button">土壌硬度データ取り込み</a>
-    <a class="btn btn-outline-primary mb-3" href="{% url 'soil:route_suggest_upload' %}"
-       role="button">圃場ルートサジェスト（試作）</a>
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item">Home</li>
+            </ol>
+        </nav>
+        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:company_list' %}" role="button">農業法人の一覧</a>
+        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:hardness_upload' %}"
+           role="button">土壌硬度データ取り込み</a>
+        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:route_suggest_upload' %}"
+           role="button">圃場ルートサジェスト（試作）</a>
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -2,119 +2,120 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:land_list' company.id %}">Land List</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Create</li>
-        </ol>
-    </nav>
     <div class="container">
-        <h1>新規作成</h1>
-        {% if messages %}
-            <ul class="messages">
-                {% for message in messages %}
-                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-        <form method="post" enctype="multipart/form-data">
-            {% csrf_token %}
-            {{ form.as_p }}
-            <input type="hidden" name="company-id" value="{{ company.pk }}">
-            <button type="submit" class="btn btn-outline-primary mb-3">送信</button>
-        </form>
-    </div>
-    <script>
-        function clearDropdown(selectElement) {
-            const defaultOption = document.createElement('option')
-            defaultOption.value = ""
-            defaultOption.text = "選択してください"
-            defaultOption.selected = true
-            selectElement.appendChild(defaultOption)
-        }
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:land_list' company.id %}">Land List</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Create</li>
+            </ol>
+        </nav>
+        <div class="container">
+            <h1>新規作成</h1>
+            {% if messages %}
+                <ul class="messages">
+                    {% for message in messages %}
+                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+            <form method="post" enctype="multipart/form-data">
+                {% csrf_token %}
+                {{ form.as_p }}
+                <input type="hidden" name="company-id" value="{{ company.pk }}">
+                <button type="submit" class="btn btn-outline-primary mb-3">送信</button>
+            </form>
+        </div>
+        <script>
+            function clearDropdown(selectElement) {
+                const defaultOption = document.createElement('option')
+                defaultOption.value = ""
+                defaultOption.text = "選択してください"
+                defaultOption.selected = true
+                selectElement.appendChild(defaultOption)
+            }
 
-        function setDropdownList(optionsData, selectElement) {
-            optionsData.map(item => {
-                const option = document.createElement('option')
-                option.value = item.id
-                option.text = item.name
-                selectElement.appendChild(option)
-            })
-        }
+            function setDropdownList(optionsData, selectElement) {
+                optionsData.map(item => {
+                    const option = document.createElement('option')
+                    option.value = item.id
+                    option.text = item.name
+                    selectElement.appendChild(option)
+                })
+            }
 
-        /**
-         * 都道府省のデータをフェッチし、それに応じて都道府県ドロップダウンオプションを設定します。
-         */
-        async function fetchPrefectures() {
-            const prefectureSelect = document.getElementById("id_jma_prefecture")
-            prefectureSelect.innerHTML = ''
-            clearDropdown(prefectureSelect)
+            /**
+             * 都道府省のデータをフェッチし、それに応じて都道府県ドロップダウンオプションを設定します。
+             */
+            async function fetchPrefectures() {
+                const prefectureSelect = document.getElementById("id_jma_prefecture")
+                prefectureSelect.innerHTML = ''
+                clearDropdown(prefectureSelect)
 
-            const response = await fetch('{% url 'soil:prefectures' %}')
-            const data = await response.json()
-            setDropdownList(data.prefectures, prefectureSelect)
-        }
-
-        /**
-         * 指定された都道府県 ID に基づいて都市データを取得し、それに応じて都市ドロップダウン オプションを設定します
-         * 都道府県 ID が指定されていない場合、都市のドロップダウンはクリアされます
-         *
-         * @param {string} prefectureId - The ID of the prefecture.
-         */
-        async function fetchCities(prefectureId) {
-            const citySelect = document.getElementById("id_jma_city")
-            citySelect.innerHTML = ''
-            clearDropdown(citySelect)
-
-            if (prefectureId) {
-                const response = await fetch(`/soil_analysis/prefecture/${prefectureId}/cities`)
+                const response = await fetch('{% url 'soil:prefectures' %}')
                 const data = await response.json()
-                setDropdownList(data.cities, citySelect)
+                setDropdownList(data.prefectures, prefectureSelect)
             }
-        }
 
-        /**
-         * 土地の緯度経度に基づいてその位置情報を取得します
-         *
-         * @param {string} latlon - 緯度経度のペア。
-         */
-        async function fetchLandLocationInfo(latlon) {
-            const response = await fetch("{% url 'soil:land_location_info' %}", {
-                method: "POST",
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': Cookies.get('csrftoken')
-                },
-                body: JSON.stringify({latlon})
-            })
-            return response.json()
-        }
+            /**
+             * 指定された都道府県 ID に基づいて都市データを取得し、それに応じて都市ドロップダウン オプションを設定します
+             * 都道府県 ID が指定されていない場合、都市のドロップダウンはクリアされます
+             *
+             * @param {string} prefectureId - The ID of the prefecture.
+             */
+            async function fetchCities(prefectureId) {
+                const citySelect = document.getElementById("id_jma_city")
+                citySelect.innerHTML = ''
+                clearDropdown(citySelect)
 
-        document.getElementById("id_latlon").addEventListener("change", async function () {
-            const latlon = this.value
-            const prefectureSelect = document.getElementById("id_jma_prefecture")
-            const citySelect = document.getElementById("id_jma_city")
-
-            if (latlon) {
-                const landLocationInfo = await fetchLandLocationInfo(latlon)
-                if (landLocationInfo.error) {
-                    alert(landLocationInfo.error)
-                } else {
-                    await fetchPrefectures()
-                    prefectureSelect.value = landLocationInfo.jma_prefecture_id
-                    await fetchCities(landLocationInfo.jma_prefecture_id)
-                    citySelect.value = landLocationInfo.jma_city_id
+                if (prefectureId) {
+                    const response = await fetch(`/soil_analysis/prefecture/${prefectureId}/cities`)
+                    const data = await response.json()
+                    setDropdownList(data.cities, citySelect)
                 }
-            } else {
-                await fetchCities(undefined)
             }
-        })
 
-        document.getElementById("id_jma_prefecture").addEventListener("change", function () {
-            const prefectureId = this.value
-            fetchCities(prefectureId)
-        })
-    </script>
+            /**
+             * 土地の緯度経度に基づいてその位置情報を取得します
+             *
+             * @param {string} latlon - 緯度経度のペア。
+             */
+            async function fetchLandLocationInfo(latlon) {
+                const response = await fetch("{% url 'soil:land_location_info' %}", {
+                    method: "POST",
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': Cookies.get('csrftoken')
+                    },
+                    body: JSON.stringify({latlon})
+                })
+                return response.json()
+            }
+
+            document.getElementById("id_latlon").addEventListener("change", async function () {
+                const latlon = this.value
+                const prefectureSelect = document.getElementById("id_jma_prefecture")
+                const citySelect = document.getElementById("id_jma_city")
+
+                if (latlon) {
+                    const landLocationInfo = await fetchLandLocationInfo(latlon)
+                    if (landLocationInfo.error) {
+                        alert(landLocationInfo.error)
+                    } else {
+                        await fetchPrefectures()
+                        prefectureSelect.value = landLocationInfo.jma_prefecture_id
+                        await fetchCities(landLocationInfo.jma_prefecture_id)
+                        citySelect.value = landLocationInfo.jma_city_id
+                    }
+                } else {
+                    await fetchCities(undefined)
+                }
+            })
+
+            document.getElementById("id_jma_prefecture").addEventListener("change", function () {
+                const prefectureId = this.value
+                fetchCities(prefectureId)
+            })
+        </script>
+    </div>
 {% endblock %}
-

--- a/soil_analysis/templates/soil_analysis/land/detail.html
+++ b/soil_analysis/templates/soil_analysis/land/detail.html
@@ -5,30 +5,32 @@
     <link rel="stylesheet" href="{% static 'soil_analysis/css/land/detail.css' %}">
 {% endblock %}
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:land_list' object.company.pk %}">Land list</a>
-            </li>
-            <li class="breadcrumb-item active" aria-current="page">Detail</li>
-        </ol>
-    </nav>
     <div class="container">
-        <h1>{{ object.name }}の詳細</h1>
-        {% if object.image %}
-            <img class="land-image" src="{{ object.image.url }}" alt="Land Image">
-        {% endif %}
-        <ul>
-            <li>都道府県: {{ object.jma_prefecture.name|default:"-" }}</li>
-            <li>市区町村: {{ object.jma_city.name|default:"-" }}</li>
-            <li>緯度経度: {{ object.latlon|default:"-" }}</li>
-            <li>作型: {{ object.cultivation_type|default:"-" }}</li>
-            <li>オーナー: {{ object.owner.username|default:"-" }}</li>
-            <li>備考: {{ object.remark|default:"-" }}</li>
-        </ul>
-        <form method="GET" class="registration" action="{% url 'soil:land_list' object.company.pk %}">
-            {% csrf_token %}
-            <button type="submit">戻る</button>
-        </form>
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:land_list' object.company.pk %}">Land list</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page">Detail</li>
+            </ol>
+        </nav>
+        <div class="container">
+            <h1>{{ object.name }}の詳細</h1>
+            {% if object.image %}
+                <img class="land-image" src="{{ object.image.url }}" alt="Land Image">
+            {% endif %}
+            <ul>
+                <li>都道府県: {{ object.jma_prefecture.name|default:"-" }}</li>
+                <li>市区町村: {{ object.jma_city.name|default:"-" }}</li>
+                <li>緯度経度: {{ object.latlon|default:"-" }}</li>
+                <li>作型: {{ object.cultivation_type|default:"-" }}</li>
+                <li>オーナー: {{ object.owner.username|default:"-" }}</li>
+                <li>備考: {{ object.remark|default:"-" }}</li>
+            </ul>
+            <form method="GET" class="registration" action="{% url 'soil:land_list' object.company.pk %}">
+                {% csrf_token %}
+                <button type="submit">戻る</button>
+            </form>
+        </div>
     </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/land/list.html
+++ b/soil_analysis/templates/soil_analysis/land/list.html
@@ -6,89 +6,93 @@
     <link rel="stylesheet" href="{% static 'soil_analysis/css/land/list.css' %}">
 {% endblock %}
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:company_list' %}">{{ company.name }}</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Land list</li>
-        </ol>
-    </nav>
-    <a class="btn btn-outline-primary mb-3" href="{% url 'soil:land_create' company.id %}"
-       role="button">＋圃場の追加</a>
-    {% for a_land in object_list %}
-        {% if not forloop.counter|divisibleby:"2" %}
-            <div class="row mb-4">
-        {% endif %}
-    <div class="col-sm-6">
-        <div class="card">
-            <div class="image-placeholder">
-                {% if a_land.image %}
-                    <img src="{{ a_land.image.url }}" alt="Land Image">
-                {% else %}
-                    <p>Now Printing</p>
-                {% endif %}
-            </div>
-            <div class="card-body">
-                <a href="{% url 'soil:land_detail' a_land.company.pk a_land.pk %}"><h5
-                        class="card-title">{{ a_land.name }}</h5></a>
-                <div class="weather-list">
-                    {% for weather in a_land.jma_city.jma_region.weathers %}
-                        {% with 'soil_analysis/images/weather/svg/'|add:weather.jma_weather_code.summary_code|add:'.svg' as weather_svg_path %}
-                            <div class="weather-item">
-                                <img width="50" src="{% static weather_svg_path %}" alt="Weather Image">
-                                <p>{{ weather.reporting_date|date:"m/d" }}</p>
-                            </div>
-                        {% endwith %}
-                    {% empty %}
-                        <p>（該当天気なし）</p>
-                    {% endfor %}
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:company_list' %}">{{ company.name }}</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Land list</li>
+            </ol>
+        </nav>
+        <a class="btn btn-outline-primary mb-3" href="{% url 'soil:land_create' company.id %}"
+           role="button">＋圃場の追加</a>
+        {% for a_land in object_list %}
+            {% if not forloop.counter|divisibleby:"2" %}
+                <div class="row mb-4">
+            {% endif %}
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="image-placeholder">
+                    {% if a_land.image %}
+                        <img src="{{ a_land.image.url }}" alt="Land Image">
+                    {% else %}
+                        <p>Now Printing</p>
+                    {% endif %}
                 </div>
-                <div class="warning-list">
-                    {% for warning in a_land.jma_city.jma_region.warnings %}
-                        <div class="warning-item">
-                            <span class="label">{{ warning.warnings }}</span>
-                        </div>
-                    {% empty %}
-                        <p>（該当警報なし）</p>
-                    {% endfor %}
-                </div>
-
-                <ul class="card-text">
-                    <li>都道府県: {{ a_land.jma_city.jma_region.jma_prefecture.name|default:"-" }}</li>
-                    <li>市区町村: {{ a_land.jma_city.name|default:"-" }}</li>
-                    <li>緯度経度: {% if a_land.latlon %}<a href="https://www.google.co.jp/maps/@{{ a_land.latlon }},17z"
-                                                           target="_blank">{{ a_land.latlon }}</a>{% else %}-{% endif %}
-                    </li>
-                    <li>面積: {{ a_land.area|default:"-" }} ㎡</li>
-                    <li>作型: {{ a_land.cultivation_type|default:"-" }}</li>
-                    <li>オーナー: {{ a_land.owner.username|default:"-" }}</li>
-                    <li>備考: {{ a_land.remark|default:"-" }}</li>
-                </ul>
-
-                <div class="dropdown">
-                    <button class="m-1 btn btn-outline-primary dropdown-toggle" type="button" id="dropdownMenuButton1"
-                            data-bs-toggle="dropdown" aria-expanded="false">
-                        -- 化学レポートを選択 --
-                    </button>
-                    <ul class="dropdown-menu" aria-labelledby="select a report">
-                        {% for land_ledger in land_ledger_map|get_value:a_land %}
-                            <li><a class="dropdown-item"
-                                   href="{% url 'soil:land_report_chemical' a_land.company.id land_ledger.pk %}">{{ land_ledger.sampling_date|date:"Ym" }} {{ land_ledger.land_period.name }}</a>
-                            </li>
+                <div class="card-body">
+                    <a href="{% url 'soil:land_detail' a_land.company.pk a_land.pk %}"><h5
+                            class="card-title">{{ a_land.name }}</h5></a>
+                    <div class="weather-list">
+                        {% for weather in a_land.jma_city.jma_region.weathers %}
+                            {% with 'soil_analysis/images/weather/svg/'|add:weather.jma_weather_code.summary_code|add:'.svg' as weather_svg_path %}
+                                <div class="weather-item">
+                                    <img width="50" src="{% static weather_svg_path %}" alt="Weather Image">
+                                    <p>{{ weather.reporting_date|date:"m/d" }}</p>
+                                </div>
+                            {% endwith %}
+                        {% empty %}
+                            <p>（該当天気なし）</p>
                         {% endfor %}
+                    </div>
+                    <div class="warning-list">
+                        {% for warning in a_land.jma_city.jma_region.warnings %}
+                            <div class="warning-item">
+                                <span class="label">{{ warning.warnings }}</span>
+                            </div>
+                        {% empty %}
+                            <p>（該当警報なし）</p>
+                        {% endfor %}
+                    </div>
+
+                    <ul class="card-text">
+                        <li>都道府県: {{ a_land.jma_city.jma_region.jma_prefecture.name|default:"-" }}</li>
+                        <li>市区町村: {{ a_land.jma_city.name|default:"-" }}</li>
+                        <li>緯度経度: {% if a_land.latlon %}
+                            <a href="https://www.google.co.jp/maps/@{{ a_land.latlon }},17z"
+                               target="_blank">{{ a_land.latlon }}</a>{% else %}-{% endif %}
+                        </li>
+                        <li>面積: {{ a_land.area|default:"-" }} ㎡</li>
+                        <li>作型: {{ a_land.cultivation_type|default:"-" }}</li>
+                        <li>オーナー: {{ a_land.owner.username|default:"-" }}</li>
+                        <li>備考: {{ a_land.remark|default:"-" }}</li>
                     </ul>
-                </div>
-                <div class="dropdown">
-                    <button class="m-1 btn btn-outline-primary dropdown-toggle disabled" type="button"
-                            id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
-                        -- 物理レポートを選択 --
-                    </button>
+
+                    <div class="dropdown">
+                        <button class="m-1 btn btn-outline-primary dropdown-toggle" type="button"
+                                id="dropdownMenuButton1"
+                                data-bs-toggle="dropdown" aria-expanded="false">
+                            -- 化学レポートを選択 --
+                        </button>
+                        <ul class="dropdown-menu" aria-labelledby="select a report">
+                            {% for land_ledger in land_ledger_map|get_value:a_land %}
+                                <li><a class="dropdown-item"
+                                       href="{% url 'soil:land_report_chemical' a_land.company.id land_ledger.pk %}">{{ land_ledger.sampling_date|date:"Ym" }} {{ land_ledger.land_period.name }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    <div class="dropdown">
+                        <button class="m-1 btn btn-outline-primary dropdown-toggle disabled" type="button"
+                                id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+                            -- 物理レポートを選択 --
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
+        {% if forloop.counter|divisibleby:"2" %}
+            </div>
+        {% endif %}
+        {% endfor %}
     </div>
-    {% if forloop.counter|divisibleby:"2" %}
-        </div>
-    {% endif %}
-    {% endfor %}
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/land_report/chemical.html
+++ b/soil_analysis/templates/soil_analysis/land_report/chemical.html
@@ -4,34 +4,34 @@
     <link rel="stylesheet" href="{% static 'soil_analysis/css/landreport/chemical.css' %}">
 {% endblock %}
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:land_list' company.id %}">Land list</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Land report chemical</li>
-        </ol>
-    </nav>
-    <div class="row mb-4">
-        <div class="col-sm-6">
-            <img src="data:image/png;base64,{{ charts.chart1 | safe }}" alt="窒素関連">
-        </div>
-        <div class="col-sm-6">
-            <img src="data:image/png;base64,{{ charts.chart2 | safe }}" alt="塩基類関連">
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
-            <img src="data:image/png;base64,{{ charts.chart3 | safe }}" alt="リン酸関連">
-        </div>
-        <div class="col-sm-6">
-            <img src="data:image/png;base64,{{ charts.chart4 | safe }}" alt="土壌ポテンシャル関連">
-        </div>
-    </div>
-    <div class="alert alert-primary m-4" role="alert">
-        {{ land_review.first.comment }}
-    </div>
-
     <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:land_list' company.id %}">Land list</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Land report chemical</li>
+            </ol>
+        </nav>
+        <div class="row mb-4">
+            <div class="col-sm-6">
+                <img src="data:image/png;base64,{{ charts.chart1 | safe }}" alt="窒素関連">
+            </div>
+            <div class="col-sm-6">
+                <img src="data:image/png;base64,{{ charts.chart2 | safe }}" alt="塩基類関連">
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-6">
+                <img src="data:image/png;base64,{{ charts.chart3 | safe }}" alt="リン酸関連">
+            </div>
+            <div class="col-sm-6">
+                <img src="data:image/png;base64,{{ charts.chart4 | safe }}" alt="土壌ポテンシャル関連">
+            </div>
+        </div>
+        <div class="alert alert-primary m-4" role="alert">
+            {{ land_review.first.comment }}
+        </div>
+
         <table class="table table-sm">
             <tbody>
             <tr>
@@ -76,53 +76,53 @@
             </tr>
             </tbody>
         </table>
-    </div>
 
-    <div class="card-group justify-content-center">
-        {% for land_score in land_scores %}
-            {% if forloop.first %}
-                <div class="row mb-4">
-            {% endif %}
-        <div class="col-sm-4">
-            <div class="card">
-                <svg class="bd-placeholder-img card-img-top" width="100%" height="180"
-                     xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false"
-                     role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title>
-                    <rect fill="#868e96" width="100%" height="100%"/>
-                    <text fill="#dee2e6" dy=".3em" x="38%" y="50%">Image cap</text>
-                </svg>
-                <div class="card-body">
-                    <h5 class="card-title">{{ land_score.land_block.name }}</h5>
-                    <ul class="card-text">
-                        <li>電気伝導率: {{ land_score.ec }}</li>
-                        <li>アンモニア態窒素: {{ land_score.nh4n }}</li>
-                        <li>硝酸態窒素: {{ land_score.no3n }}</li>
-                        <li>無機態窒素: {{ land_score.total_nitrogen }}</li>
-                        <li>アンモニア態窒素比: {{ land_score.nh4_per_nitrogen }}</li>
-                        <li>水素イオン濃度: {{ land_score.ph }}</li>
-                        <li>交換性石灰: {{ land_score.cao }}</li>
-                        <li>交換性苦土: {{ land_score.mgo }}</li>
-                        <li>交換性加里: {{ land_score.k2o }}</li>
-                        <li>塩基飽和度: {{ land_score.base_saturation }}</li>
-                        <li>交換性石灰/交換性苦土: {{ land_score.cao_per_mgo }}</li>
-                        <li>交換性苦土/交換性加里: {{ land_score.mgo_per_k2o }}</li>
-                        <li>リン酸吸収係数: {{ land_score.phosphorus_absorption }}</li>
-                        <li>可給態リン酸: {{ land_score.p2o5 }}</li>
-                        <li>塩基置換容量: {{ land_score.cec }}</li>
-                        <li>腐植: {{ land_score.humus }}</li>
-                        <li>仮比重: {{ land_score.bulk_density }}</li>
-                        <li>備考: {{ land_score.remark|default:"-" }}</li>
-                    </ul>
+        <div class="card-group justify-content-center">
+            {% for land_score in land_scores %}
+                {% if forloop.first %}
+                    <div class="row mb-4">
+                {% endif %}
+            <div class="col-sm-4">
+                <div class="card">
+                    <svg class="bd-placeholder-img card-img-top" width="100%" height="180"
+                         xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false"
+                         role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title>
+                        <rect fill="#868e96" width="100%" height="100%"/>
+                        <text fill="#dee2e6" dy=".3em" x="38%" y="50%">Image cap</text>
+                    </svg>
+                    <div class="card-body">
+                        <h5 class="card-title">{{ land_score.land_block.name }}</h5>
+                        <ul class="card-text">
+                            <li>電気伝導率: {{ land_score.ec }}</li>
+                            <li>アンモニア態窒素: {{ land_score.nh4n }}</li>
+                            <li>硝酸態窒素: {{ land_score.no3n }}</li>
+                            <li>無機態窒素: {{ land_score.total_nitrogen }}</li>
+                            <li>アンモニア態窒素比: {{ land_score.nh4_per_nitrogen }}</li>
+                            <li>水素イオン濃度: {{ land_score.ph }}</li>
+                            <li>交換性石灰: {{ land_score.cao }}</li>
+                            <li>交換性苦土: {{ land_score.mgo }}</li>
+                            <li>交換性加里: {{ land_score.k2o }}</li>
+                            <li>塩基飽和度: {{ land_score.base_saturation }}</li>
+                            <li>交換性石灰/交換性苦土: {{ land_score.cao_per_mgo }}</li>
+                            <li>交換性苦土/交換性加里: {{ land_score.mgo_per_k2o }}</li>
+                            <li>リン酸吸収係数: {{ land_score.phosphorus_absorption }}</li>
+                            <li>可給態リン酸: {{ land_score.p2o5 }}</li>
+                            <li>塩基置換容量: {{ land_score.cec }}</li>
+                            <li>腐植: {{ land_score.humus }}</li>
+                            <li>仮比重: {{ land_score.bulk_density }}</li>
+                            <li>備考: {{ land_score.remark|default:"-" }}</li>
+                        </ul>
+                    </div>
                 </div>
             </div>
+            {% if forloop.counter|divisibleby:"3" and not forloop.last %}
+                </div>
+                <div class="row mb-4">
+            {% endif %}
+            {% if forloop.last %}
+                </div>
+            {% endif %}
+            {% endfor %}
         </div>
-        {% if forloop.counter|divisibleby:"3" and not forloop.last %}
-            </div>
-            <div class="row mb-4">
-        {% endif %}
-        {% if forloop.last %}
-            </div>
-        {% endif %}
-        {% endfor %}
     </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/picture_land_associate/form.html
+++ b/soil_analysis/templates/soil_analysis/picture_land_associate/form.html
@@ -1,0 +1,41 @@
+{% extends "soil_analysis/base.html" %}
+{% load static %}
+
+{% block content %}
+    <div class="container">
+        <h2>写真と圃場の自動紐づけ</h2>
+
+        <form method="post">
+            {% csrf_token %}
+
+            <div class="row mb-4">
+                <div class="col-md-6">
+                    <h3>写真一覧</h3>
+                    {% for photo_spot in photo_spots %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="photo_spot"
+                                   id="photo_spot_{{ forloop.counter }}"
+                                   value="{{ forloop.counter0 }}">
+                            <label class="form-check-label" for="photo_spot_{{ forloop.counter }}">
+                                座標 {{ forloop.counter }}: {{ photo_spot.to_google.to_str }}
+                            </label>
+                        </div>
+                    {% endfor %}
+                </div>
+
+                <div class="col-md-6">
+                    <h3>圃場一覧</h3>
+                    <div class="list-group">
+                        {% for land in lands %}
+                            <div class="list-group-item">
+                                {{ land.name }} {{ land.to_google.to_str }}
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+
+            <button type="submit" class="btn btn-primary">最も近い圃場を特定</button>
+        </form>
+    </div>
+{% endblock %}

--- a/soil_analysis/templates/soil_analysis/picture_land_associate/form.html
+++ b/soil_analysis/templates/soil_analysis/picture_land_associate/form.html
@@ -10,7 +10,7 @@
 
             <div class="row mb-4">
                 <div class="col-md-6">
-                    <h3>写真一覧</h3>
+                    <h3>写真（撮影位置）一覧</h3>
                     {% for photo_spot in photo_spots %}
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="photo_spot"

--- a/soil_analysis/templates/soil_analysis/picture_land_associate/result.html
+++ b/soil_analysis/templates/soil_analysis/picture_land_associate/result.html
@@ -10,7 +10,7 @@
                 <div class="card">
                     <div class="card-header">選択された撮影地点</div>
                     <div class="card-body">
-                        <p>座標: {{ photo_spot }}</p>
+                        <p>座標: {{ photo_spot_coord }}</p>
                     </div>
                 </div>
             </div>

--- a/soil_analysis/templates/soil_analysis/picture_land_associate/result.html
+++ b/soil_analysis/templates/soil_analysis/picture_land_associate/result.html
@@ -1,0 +1,35 @@
+{% extends "soil_analysis/base.html" %}
+{% load static %}
+
+{% block content %}
+    <div class="container">
+        <h2>写真と圃場の紐づけ結果</h2>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">選択された撮影地点</div>
+                    <div class="card-body">
+                        <p>座標: {{ photo_spot }}</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">最も近い圃場</div>
+                    <div class="card-body">
+                        <h5>{{ nearest_land.name }}</h5>
+                        <p>位置: {{ nearest_land.location }}</p>
+                        <p>面積: xxxx ㎡</p>
+                        <p>所有者: {{ nearest_land.owner }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-4">
+            <a href="{% url 'soil:associate_picture_and_land' %}" class="btn btn-secondary">戻る</a>
+        </div>
+    </div>
+{% endblock %}

--- a/soil_analysis/templates/soil_analysis/route_suggest/form.html
+++ b/soil_analysis/templates/soil_analysis/route_suggest/form.html
@@ -2,28 +2,30 @@
 {% load static %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item active" aria-current="page">KML Upload</li>
-        </ol>
-    </nav>
-    <h1>KMLのアップロード</h1>
-    {% if messages %}
-        <ul class="messages">
-            {% for message in messages %}
-                {% if message.tags and message.tags == 'error' %}
-                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                {% endif %}
-            {% endfor %}
-        </ul>
-    {% endif %}
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item active" aria-current="page">KML Upload</li>
+            </ol>
+        </nav>
+        <h1>KMLのアップロード</h1>
+        {% if messages %}
+            <ul class="messages">
+                {% for message in messages %}
+                    {% if message.tags and message.tags == 'error' %}
+                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        {% endif %}
 
-    <p><a href="https://fm.xarvio.com/jp/ja_jp/login" target="_blank" rel="noopener noreferrer">Xarvio</a>
-        から地点データをKMLでダウンロードしてアップロードしてください</p>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button class="btn btn-outline-primary mb-3" type="submit">Upload</button>
-    </form>
+        <p><a href="https://fm.xarvio.com/jp/ja_jp/login" target="_blank" rel="noopener noreferrer">Xarvio</a>
+            から地点データをKMLでダウンロードしてアップロードしてください</p>
+        <form method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button class="btn btn-outline-primary mb-3" type="submit">Upload</button>
+        </form>
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/route_suggest/ordering.html
+++ b/soil_analysis/templates/soil_analysis/route_suggest/ordering.html
@@ -16,33 +16,35 @@
 {% endblock %}
 
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:route_suggest_upload' %}">KML Upload</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Ordering</li>
-        </ol>
-    </nav>
-    <h1>並べ替えしましょう</h1>
-    <p>一番上が始点、一番下が終点。はさまれている地点が最適化されます</p>
-    <ul id="sortable-list">
-        {% for land in object_list %}
-            <li id="{{ land.id }}" class="list-group-item">圃場名: {{ land.name }}, 座標: {{ land.coord }}</li>
-        {% endfor %}
-    </ul>
-    <form id="orderForm" method="POST" action="{% url 'soil:route_suggest_ordering' %}">
-        {% csrf_token %}
-        <input type="hidden" id="orderData" name="order_data">
-        <button class="btn btn-outline-primary mb-3" type="submit">送信</button>
-    </form>
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:route_suggest_upload' %}">KML Upload</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Ordering</li>
+            </ol>
+        </nav>
+        <h1>並べ替えしましょう</h1>
+        <p>一番上が始点、一番下が終点。はさまれている地点が最適化されます</p>
+        <ul id="sortable-list">
+            {% for land in object_list %}
+                <li id="{{ land.id }}" class="list-group-item">圃場名: {{ land.name }}, 座標: {{ land.coord }}</li>
+            {% endfor %}
+        </ul>
+        <form id="orderForm" method="POST" action="{% url 'soil:route_suggest_ordering' %}">
+            {% csrf_token %}
+            <input type="hidden" id="orderData" name="order_data">
+            <button class="btn btn-outline-primary mb-3" type="submit">送信</button>
+        </form>
 
-    <script>
-        $(function () {
-            $('.list-group-item').hover(function () {
-                $(this).addClass('active');
-            }, function () {
-                $(this).removeClass('active');
+        <script>
+            $(function () {
+                $('.list-group-item').hover(function () {
+                    $(this).addClass('active');
+                }, function () {
+                    $(this).removeClass('active');
+                });
             });
-        });
-    </script>
+        </script>
+    </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/route_suggest/success.html
+++ b/soil_analysis/templates/soil_analysis/route_suggest/success.html
@@ -11,73 +11,75 @@
     {% endautoescape %}
 {% endblock %}
 {% block content %}
-    <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:route_suggest_upload' %}">KML Upload</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'soil:route_suggest_ordering' %}">Ordering</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Success</li>
-        </ol>
-    </nav>
-    <h1>作業指示書</h1>
-    <p>TODO: placeオブジェクトにラップして、マウスオーバー時に圃場の名前を表示する<br>TODO: ピンと圃場名が違うかもしれない<br>TODO:
-        印刷用の余白ゼロのページを作る</p>
+    <div class="container">
+        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:route_suggest_upload' %}">KML Upload</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:route_suggest_ordering' %}">Ordering</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Success</li>
+            </ol>
+        </nav>
+        <h1>作業指示書</h1>
+        <p>TODO: placeオブジェクトにラップして、マウスオーバー時に圃場の名前を表示する<br>TODO: ピンと圃場名が違うかもしれない<br>TODO:
+            印刷用の余白ゼロのページを作る</p>
 
-    <p>発行日: YYYY-MM-DD</p>
-    <p>依頼者: X XX</p>
-    <p>作業者: Aさん</p>
-    <p>作業日: YYYY-MM-DD</p>
-    <p>シーズン: 施肥前測定</p>
-    <p>作業単価（円/件） 1,000円／件</p>
+        <p>発行日: YYYY-MM-DD</p>
+        <p>依頼者: X XX</p>
+        <p>作業者: Aさん</p>
+        <p>作業日: YYYY-MM-DD</p>
+        <p>シーズン: 施肥前測定</p>
+        <p>作業単価（円/件） 1,000円／件</p>
 
-    <h4 class="mt-4">作業内容</h4>
-    <ul>
-        <li>化学性測定
-            <ul>
-                <li>（現地作業マニュアルを単に表示するだけでもよさそう）</li>
-            </ul>
-        </li>
-        <li>物理性測定
-            <ul>
-                <li>（現地作業マニュアルを単に表示するだけでもよさそう）</li>
-            </ul>
-        </li>
-    </ul>
+        <h4 class="mt-4">作業内容</h4>
+        <ul>
+            <li>化学性測定
+                <ul>
+                    <li>（現地作業マニュアルを単に表示するだけでもよさそう）</li>
+                </ul>
+            </li>
+            <li>物理性測定
+                <ul>
+                    <li>（現地作業マニュアルを単に表示するだけでもよさそう）</li>
+                </ul>
+            </li>
+        </ul>
 
-    <h4 class="mt-4">作業場所</h4>
-    <div class="flex-container">
-        <div id="map" class="flex-item"></div>
-        <ol class="list-group list-group-numbered flex-item">
-            {% for land in land_list %}
-                <li id="{{ land.id }}" class="list-group-item">{{ land.name }}（{{ land.coord }}）</li>
-            {% endfor %}
-        </ol>
+        <h4 class="mt-4">作業場所</h4>
+        <div class="flex-container">
+            <div id="map" class="flex-item"></div>
+            <ol class="list-group list-group-numbered flex-item">
+                {% for land in land_list %}
+                    <li id="{{ land.id }}" class="list-group-item">{{ land.name }}（{{ land.coord }}）</li>
+                {% endfor %}
+            </ol>
+        </div>
+
+        <h4 class="mt-4">提出物</h4>
+        <ul>
+            <li>土</li>
+            <li>物理性測定データ</li>
+        </ul>
+
+        <h4 class="mt-4">その他</h4>
+        共通する事項は基本契約で交わしておく
+        <ul>
+            <li>データの取り扱いについて</li>
+            <li>秘密保持について</li>
+            <li>支払い条件について</li>
+            <li>保険（作業中に倒れるとか、怪我するとか）</li>
+        </ul>
+
+        <!--
+          The `defer` attribute causes the callback to execute after the full HTML
+          document has been parsed. For non-blocking uses, avoiding race conditions,
+          and consistent behavior across browsers, consider loading using Promises.
+          See https://developers.google.com/maps/documentation/javascript/load-maps-js-api
+          for more information.
+          -->
+        <script
+                src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}&libraries=places&callback=initMap&v=weekly"
+                defer
+        ></script>
     </div>
-
-    <h4 class="mt-4">提出物</h4>
-    <ul>
-        <li>土</li>
-        <li>物理性測定データ</li>
-    </ul>
-
-    <h4 class="mt-4">その他</h4>
-    共通する事項は基本契約で交わしておく
-    <ul>
-        <li>データの取り扱いについて</li>
-        <li>秘密保持について</li>
-        <li>支払い条件について</li>
-        <li>保険（作業中に倒れるとか、怪我するとか）</li>
-    </ul>
-
-    <!--
-      The `defer` attribute causes the callback to execute after the full HTML
-      document has been parsed. For non-blocking uses, avoiding race conditions,
-      and consistent behavior across browsers, consider loading using Promises.
-      See https://developers.google.com/maps/documentation/javascript/load-maps-js-api
-      for more information.
-      -->
-    <script
-            src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}&libraries=places&callback=initMap&v=weekly"
-            defer
-    ></script>
 {% endblock %}

--- a/soil_analysis/tests/domain/service/test_photo_processing_service.py
+++ b/soil_analysis/tests/domain/service/test_photo_processing_service.py
@@ -126,6 +126,23 @@ class TestPhotoProcessingService(TestCase):
         self.assertEqual(self.land4, nearest_land)
 
     def test_process_photos(self):
+        """
+        写真処理サービスのprocess_photos機能を検証するテストです。
+
+        このテストでは以下の内容を確認します：
+        1. 複数の写真を一括処理する機能が正しく動作すること
+        2. 各写真に対して適切な圃場（最も近い圃場）が関連付けられること
+        3. 写真と圃場の距離が正確に計算されること
+
+        テスト手法：
+        - 4枚の写真をモックし、それぞれ異なる位置情報を持たせる
+        - それぞれの写真に対して、最も近い圃場が正しく特定されるか検証
+        - 写真処理サービスのprocess_photosメソッドの戻り値を検証
+
+        検証項目：
+        - 結果のリストが入力写真数と同じ長さであること
+        - 各写真に対して、期待される最寄り圃場が正しく関連付けられていること
+        """
         # AndroidPhotoのモックを作成
         with patch(
             "soil_analysis.domain.service.photo_processing_service.AndroidPhoto"

--- a/soil_analysis/tests/domain/service/test_photo_processing_service.py
+++ b/soil_analysis/tests/domain/service/test_photo_processing_service.py
@@ -24,26 +24,10 @@ class TestPhotoProcessingService(TestCase):
     """
 
     def setUp(self) -> None:
-        """テストの前提条件とテストデータを設定します。
-
-        テストデータとして「ススムA1」〜「ススムA4」という4つの圃場と、
-        それぞれの圃場の正面から撮影したと想定される座標を使用しています。
-
-        圃場データ:
-        - ススムA1: (139.6, 35.7) 付近に位置する圃場
-        - ススムA2: (139.7, 35.7) 付近に位置する圃場
-        - ススムA3: (139.6, 35.6) 付近に位置する圃場
-        - ススムA4: (139.7, 35.6) 付近に位置する圃場
-
-        写真データ:
-        - 各圃場の代表的な位置から撮影したと仮定
-        - カメラの方向情報を含む位置データを使用
-        - AndroidPhotoクラスをモック化して撮影位置を制御
-
-        Notes:
-        - 実際の写真ファイルは使用せず、モックオブジェクトで代用
-        - 座標はテスト用の仮想的な値であり、実際の地理情報とは異なる
-        - 圃場間の距離は十分に離れており、最寄り判定が明確になるよう設計
+        """
+        テストの前準備を行います。
+        - 4つの異なる地点（Land）を作成
+        - それらをLandCandidatesクラスに登録
         """
         self.land1 = LandLocation(
             "137.6489657,34.7443565 137.6491266,34.744123 137.648613,34.7438929 "
@@ -71,33 +55,6 @@ class TestPhotoProcessingService(TestCase):
         self.land_candidates.list = MagicMock(
             return_value=[self.land1, self.land2, self.land3, self.land4]
         )
-
-        # テスト用の写真パス（実際のファイルパスは使わない）
-        self.photo_paths = ["テスト写真パス1", "テスト写真パス2"]
-
-        # AndroidPhotoとIphonePhotoのモックを設定
-        self.android_photo_patcher = patch(
-            "soil_analysis.domain.service.photo_processing_service.AndroidPhoto"
-        )
-        self.mock_android_photo = self.android_photo_patcher.start()
-
-        # モック写真オブジェクトを作成
-        self.android_photo_instance = MagicMock()
-        self.mock_android_photo.return_value = self.android_photo_instance
-
-        # 写真の位置情報を設定（実際の土地に近い位置）
-        test_location = MagicMock()
-        test_location.adjusted_position = MagicMock()
-        test_location.adjusted_position.to_google = MagicMock()
-        test_location.adjusted_position.to_google.return_value = MagicMock()
-        test_location.adjusted_position.to_google.return_value.to_tuple = MagicMock(
-            return_value=(34.7440, 137.6490)
-        )
-
-        self.android_photo_instance.location = test_location
-        self.android_photo_instance.filepath = "テスト写真パス1"
-        self.android_photo_instance.filename = "android_photo.jpg"
-        self.android_photo_instance.date = "2023-08-27"
 
     def test_calculate_distance(self):
         """座標間の距離計算機能をテストします。
@@ -169,80 +126,65 @@ class TestPhotoProcessingService(TestCase):
         self.assertEqual(self.land4, nearest_land)
 
     def test_process_photos(self):
-        """process_photosメソッドのテスト：複数写真の処理と最寄り圃場の関連付け機能
+        # AndroidPhotoのモックを作成
+        with patch(
+            "soil_analysis.domain.service.photo_processing_service.AndroidPhoto"
+        ) as mock_android_photo:
+            # 各写真に対応するモックオブジェクトのリスト
+            mock_photos = []
 
-        このテストでは、様々な位置情報を持つ複数の写真ファイルを処理し、
-        各写真に最も近い圃場を正確に関連付けられるかを検証します。
+            # 各写真の座標を設定
+            coordinates = [
+                XarvioCoord(longitude=137.64905, latitude=34.74424),  # A1用
+                XarvioCoord(longitude=137.64921, latitude=34.744),  # A2用
+                XarvioCoord(longitude=137.64938, latitude=34.74374),  # A3用
+                XarvioCoord(longitude=137.6496, latitude=34.7434),  # A4用
+            ]
 
-        検証内容:
-        1. 複数の写真（4枚）を正しく処理できること
-        2. 各写真に対して、実際の座標計算に基づいて最寄りの圃場を特定できること
-        3. 全ての写真が期待通りの圃場と関連付けられること（A1～A4）
+            # 各写真のモックを準備
+            for coord in coordinates:
+                mock_photo = MagicMock()
+                mock_location = MagicMock()
+                mock_location.adjusted_position = coord
+                mock_photo.location = mock_location
+                mock_photos.append(mock_photo)
 
-        テストアプローチ:
-        - 各写真パスに対応する特定の座標を設定（圃場A1～A4にそれぞれ最も近くなる座標）
-        - AndroidPhotoクラスのモックは、写真ファイルパスに応じて異なる座標情報を返すように設定
-        - 実際のfind_nearest_landメソッドとcalculate_distanceメソッドを使用して
-          座標ベースの距離計算と最寄り圃場の特定を検証
+            # AndroidPhotoが順番に異なるモックを返すように設定
+            mock_android_photo.side_effect = mock_photos
 
-        データ設定:
-        - 写真1: ススムA1圃場に最も近い座標（経度:137.6487867, 緯度:34.7441225）
-        - 写真2: ススムA2圃場に最も近い座標（経度:137.648955, 緯度:34.7438825）
-        - 写真3: ススムA3圃場に最も近い座標（経度:137.6491916, 緯度:34.7436416）
-        - 写真4: ススムA4圃場に最も近い座標（経度:137.6505066, 緯度:34.7433425）
-
-        期待結果:
-        - 写真1がススムA1圃場と関連付けられること
-        - 写真2がススムA2圃場と関連付けられること
-        - 写真3がススムA3圃場と関連付けられること
-        - 写真4がススムA4圃場と関連付けられること
-        """
-        # 各写真パスと対応する座標をマッピング
-        photo_location_map = {
-            "path/to/photo1.jpg": XarvioCoord(longitude=137.64905, latitude=34.74424),
-            "path/to/photo2.jpg": XarvioCoord(longitude=137.64921, latitude=34.744),
-            "path/to/photo3.jpg": XarvioCoord(longitude=137.64938, latitude=34.74374),
-            "path/to/photo4.jpg": XarvioCoord(longitude=137.6496, latitude=34.7434),
-        }
-
-        # AndroidPhotoのモックが毎回異なる座標を返すように設定
-        def android_photo_side_effect(file_path):
-            mock = MagicMock()
-            location_mock = MagicMock()
-            location_mock.adjusted_position = photo_location_map[file_path]
-            mock.location = location_mock
-            return mock
-
-        # モックの設定
-        self.mock_android_photo.side_effect = android_photo_side_effect
-
-        # テスト実行
-        service = PhotoProcessingService()
-        result = service.process_photos(
-            list(photo_location_map.keys()), self.land_candidates
-        )
-
-        # 検証
-        self.assertEqual(self.land1, result[0].nearest_land)
-        self.assertEqual(self.land2, result[1].nearest_land)
-        self.assertEqual(self.land3, result[2].nearest_land)
-        self.assertEqual(self.land4, result[3].nearest_land)
-
-        # デバッグ出力（Googleマップで確認できる形式）
-        for i, r in enumerate(result):
-            photo_path = list(photo_location_map.keys())[i]
-            nearest_land = r.nearest_land
-            print(f"結果 {i + 1}: ファイル={photo_path}, 圃場={nearest_land.name}")
-
-            # 写真の座標をGoogleマップ形式で出力
-            photo_coord = photo_location_map[photo_path]
-            print(f"  写真の座標: {photo_coord.to_google().to_str()}")
-
-            # 最寄り圃場の座標をGoogleマップ形式で出力
-            land_coord = nearest_land.center
-            print(f"  圃場の座標: {land_coord.to_google().to_str()}")
-
-            # 距離も表示 - 更新された引数名でメソッドを呼び出す
-            print(
-                f"  距離: {service.calculate_distance(photo_spot=photo_coord, land_spot=nearest_land, unit='m'):.2f}m"
+            # テスト実行
+            service = PhotoProcessingService()
+            result = service.process_photos(
+                [
+                    "path/to/photo1.jpg",
+                    "path/to/photo2.jpg",
+                    "path/to/photo3.jpg",
+                    "path/to/photo4.jpg",
+                ],
+                self.land_candidates,
             )
+
+            # 検証
+            self.assertEqual(self.land1, result[0].nearest_land)
+            self.assertEqual(self.land2, result[1].nearest_land)
+            self.assertEqual(self.land3, result[2].nearest_land)
+            self.assertEqual(self.land4, result[3].nearest_land)
+
+            # デバッグ出力（Googleマップで確認できる形式）
+            for i, r in enumerate(result):
+                photo_path = r.photo_path
+                nearest_land = r.nearest_land
+                print(f"結果 {i + 1}: ファイル={photo_path}, 圃場={nearest_land.name}")
+
+                # 写真の座標をGoogleマップ形式で出力
+                photo_coord = coordinates[i]
+                print(f"  写真の座標: {photo_coord.to_google().to_str()}")
+
+                # 最寄り圃場の座標をGoogleマップ形式で出力
+                land_coord = nearest_land.center
+                print(f"  圃場の座標: {land_coord.to_google().to_str()}")
+
+                # 距離も表示 - 更新された引数名でメソッドを呼び出す
+                print(
+                    f"  距離: {service.calculate_distance(photo_spot=photo_coord, land_spot=nearest_land, unit='m'):.2f}m"
+                )

--- a/soil_analysis/tests/domain/service/test_photo_processing_service.py
+++ b/soil_analysis/tests/domain/service/test_photo_processing_service.py
@@ -169,69 +169,78 @@ class TestPhotoProcessingService(TestCase):
         self.assertEqual(self.land4, nearest_land)
 
     def test_process_photos(self):
-        """process_photosメソッドのテスト：複数写真の一括処理機能
+        """process_photosメソッドのテスト：複数写真の処理と最寄り圃場の関連付け機能
 
-        複数の写真ファイルを処理して、各写真に最も近い圃場を関連付ける
-        機能を検証します。
+        このテストでは、様々な位置情報を持つ複数の写真ファイルを処理し、
+        各写真に最も近い圃場を正確に関連付けられるかを検証します。
 
         検証内容:
         1. 複数の写真（4枚）を正しく処理できること
-        2. 各写真に対して適切な最寄りの圃場を関連付けできること
-        3. 写真と圃場の距離が正確に計算されること
-        4. 全ての処理結果が期待通りのフォーマットで返されること
+        2. 各写真に対して、実際の座標計算に基づいて最寄りの圃場を特定できること
+        3. 全ての写真が期待通りの圃場と関連付けられること（A1～A4）
 
         テストアプローチ:
-        - find_nearest_landメソッドをモック化してside_effectを使用
-        - 各写真に対して異なる最寄り圃場（A1～A4）を順に返すよう設定
-        - calculate_distanceメソッドも固定値を返すようモック化
+        - 各写真パスに対応する特定の座標を設定（圃場A1～A4にそれぞれ最も近くなる座標）
+        - AndroidPhotoクラスのモックは、写真ファイルパスに応じて異なる座標情報を返すように設定
+        - 実際のfind_nearest_landメソッドとcalculate_distanceメソッドを使用して
+          座標ベースの距離計算と最寄り圃場の特定を検証
 
-        想定シナリオ:
-        圃場A1～A4それぞれの前から撮影した4枚の写真（距離は常に10m）があり、システムが
-        各写真をそれぞれ正しい圃場と関連付けできることを確認します。
+        データ設定:
+        - 写真1: ススムA1圃場に最も近い座標（経度:137.6487867, 緯度:34.7441225）
+        - 写真2: ススムA2圃場に最も近い座標（経度:137.648955, 緯度:34.7438825）
+        - 写真3: ススムA3圃場に最も近い座標（経度:137.6491916, 緯度:34.7436416）
+        - 写真4: ススムA4圃場に最も近い座標（経度:137.6505066, 緯度:34.7433425）
 
-        Notes:
-        モックを使用しているため、実際の位置計算ロジックはテスト対象外です。
-        位置計算の正確性は別のテスト（test_find_nearest_land_*）で検証しています。
+        期待結果:
+        - 写真1がススムA1圃場と関連付けられること
+        - 写真2がススムA2圃場と関連付けられること
+        - 写真3がススムA3圃場と関連付けられること
+        - 写真4がススムA4圃場と関連付けられること
         """
-        # 写真のパスリスト（複数）
-        photo_paths = [
-            "path/to/photo1.jpg",
-            "path/to/photo2.jpg",
-            "path/to/photo3.jpg",
-            "path/to/photo4.jpg",
-        ]
+        # 各写真パスと対応する座標をマッピング
+        photo_location_map = {
+            "path/to/photo1.jpg": XarvioCoord(longitude=137.64905, latitude=34.74424),
+            "path/to/photo2.jpg": XarvioCoord(longitude=137.64921, latitude=34.744),
+            "path/to/photo3.jpg": XarvioCoord(longitude=137.64938, latitude=34.74374),
+            "path/to/photo4.jpg": XarvioCoord(longitude=137.6496, latitude=34.7434),
+        }
 
+        # AndroidPhotoのモックが毎回異なる座標を返すように設定
+        def android_photo_side_effect(photo_path):
+            mock = MagicMock()
+            location_mock = MagicMock()
+            location_mock.adjusted_position = photo_location_map[photo_path]
+            mock.location = location_mock
+            return mock
+
+        # モックの設定
+        self.mock_android_photo.side_effect = android_photo_side_effect
+
+        # テスト実行
         service = PhotoProcessingService()
+        result = service.process_photos(
+            list(photo_location_map.keys()), self.land_candidates
+        )
 
-        # find_nearest_landメソッドをモック化
-        with patch.object(service, "find_nearest_land") as mock_find_nearest_land:
-            # 写真ごとに異なる最寄りの土地を設定
-            mock_find_nearest_land.side_effect = [
-                self.land1,  # 1枚目の写真はススムA1に最も近い
-                self.land2,  # 2枚目の写真はススムA2に最も近い
-                self.land3,  # 3枚目の写真はススムA3に最も近い
-                self.land4,  # 4枚目の写真はススムA4に最も近い
-            ]
+        # 検証
+        self.assertEqual(self.land1, result[0].nearest_land)
+        self.assertEqual(self.land2, result[1].nearest_land)
+        self.assertEqual(self.land3, result[2].nearest_land)
+        self.assertEqual(self.land4, result[3].nearest_land)
 
-            # calculate_distanceメソッドもモック化して一定の距離を返す
-            with patch.object(service, "calculate_distance", return_value=10.0):
-                # 処理を実行
-                result = service.process_photos(photo_paths, self.land_candidates)
+        # デバッグ出力（Googleマップで確認できる形式）
+        for i, r in enumerate(result):
+            photo_path = list(photo_location_map.keys())[i]
+            land = r.nearest_land
+            print(f"結果 {i + 1}: ファイル={photo_path}, 圃場={land.name}")
 
-                # 結果の検証
-                self.assertEqual(4, len(result))
-                self.assertEqual(
-                    self.land1, result[0].nearest_land
-                )  # 1枚目はA1に紐づく
-                self.assertEqual(
-                    self.land2, result[1].nearest_land
-                )  # 2枚目はA2に紐づく
-                self.assertEqual(
-                    self.land3, result[2].nearest_land
-                )  # 3枚目はA3に紐づく
-                self.assertEqual(
-                    self.land4, result[3].nearest_land
-                )  # 4枚目はA4に紐づく
+            # 写真の座標をGoogleマップ形式で出力
+            photo_coord = photo_location_map[photo_path]
+            print(f"  写真の座標: {photo_coord.to_google().to_str()}")
 
-                # モックが正しく呼び出されたことを確認
-                self.assertEqual(len(photo_paths), mock_find_nearest_land.call_count)
+            # 最寄り圃場の座標をGoogleマップ形式で出力
+            land_coord = land.center
+            print(f"  圃場の座標: {land_coord.to_google().to_str()}")
+
+            # 距離も表示
+            print(f"  距離: {service.calculate_distance(photo_coord, land_coord):.2f}m")

--- a/soil_analysis/tests/domain/service/test_photo_processing_service.py
+++ b/soil_analysis/tests/domain/service/test_photo_processing_service.py
@@ -206,10 +206,10 @@ class TestPhotoProcessingService(TestCase):
         }
 
         # AndroidPhotoのモックが毎回異なる座標を返すように設定
-        def android_photo_side_effect(photo_path):
+        def android_photo_side_effect(file_path):
             mock = MagicMock()
             location_mock = MagicMock()
-            location_mock.adjusted_position = photo_location_map[photo_path]
+            location_mock.adjusted_position = photo_location_map[file_path]
             mock.location = location_mock
             return mock
 
@@ -231,16 +231,18 @@ class TestPhotoProcessingService(TestCase):
         # デバッグ出力（Googleマップで確認できる形式）
         for i, r in enumerate(result):
             photo_path = list(photo_location_map.keys())[i]
-            land = r.nearest_land
-            print(f"結果 {i + 1}: ファイル={photo_path}, 圃場={land.name}")
+            nearest_land = r.nearest_land
+            print(f"結果 {i + 1}: ファイル={photo_path}, 圃場={nearest_land.name}")
 
             # 写真の座標をGoogleマップ形式で出力
             photo_coord = photo_location_map[photo_path]
             print(f"  写真の座標: {photo_coord.to_google().to_str()}")
 
             # 最寄り圃場の座標をGoogleマップ形式で出力
-            land_coord = land.center
+            land_coord = nearest_land.center
             print(f"  圃場の座標: {land_coord.to_google().to_str()}")
 
-            # 距離も表示
-            print(f"  距離: {service.calculate_distance(photo_coord, land_coord):.2f}m")
+            # 距離も表示 - 更新された引数名でメソッドを呼び出す
+            print(
+                f"  距離: {service.calculate_distance(photo_spot=photo_coord, land_spot=nearest_land, unit='m'):.2f}m"
+            )

--- a/soil_analysis/urls.py
+++ b/soil_analysis/urls.py
@@ -85,4 +85,14 @@ urlpatterns = [
         views.RouteSuggestSuccessView.as_view(),
         name="route_suggest_success",
     ),
+    path(
+        "picture/land/associate",
+        views.AssociatePictureAndLandView.as_view(),
+        name="associate_picture_and_land",
+    ),
+    path(
+        "picture/land/associate/result",
+        views.AssociatePictureAndLandResultView.as_view(),
+        name="associate_picture_and_land_result",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -472,7 +472,11 @@ class AssociatePictureAndLandView(TemplateView):
 
     @staticmethod
     def get_dummy_land_candidates() -> LandCandidates:
-        """テスト用の圃場データを返します"""
+        """
+        テスト用の圃場データを返します
+        注: これは開発時のダミーデータ用関数で、本番環境では削除して
+            データベースから取得する実装に置き換えること
+        """
         return LandCandidates(
             [
                 LandLocation(
@@ -513,7 +517,11 @@ class AssociatePictureAndLandView(TemplateView):
 
     @staticmethod
     def get_dummy_photo_spots() -> list[XarvioCoord]:
-        """テスト用の撮影位置データを返します"""
+        """
+        テスト用の撮影位置データを返します
+        注: これは開発時のダミーデータ用関数で、本番環境では削除して
+            データベースから取得する実装に置き換えること
+        """
         return [
             XarvioCoord(longitude=137.64905, latitude=34.74424),  # A1用
             XarvioCoord(longitude=137.64921, latitude=34.744),  # A2用
@@ -531,7 +539,6 @@ class AssociatePictureAndLandView(TemplateView):
         return context
 
     def post(self, request, *args, **kwargs):
-        # フォームクラスを使わないのでフォーム検証は不要
         if "photo_spot" not in request.POST:
             return self.render_to_response(self.get_context_data())
 
@@ -571,7 +578,6 @@ class AssociatePictureAndLandResultView(TemplateView):
                 "location": land.to_google().to_str(),
                 "owner": "テスト所有者",
             }
-            # 撮影地点情報
             context["photo_spot_coord"] = photo_spot_coord
 
         return context

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -471,7 +471,8 @@ class AssociatePictureAndLandView(TemplateView):
     success_url = reverse_lazy("soil:associate_picture_and_land_result")
 
     @staticmethod
-    def get_dummy_land_list() -> LandCandidates:
+    def get_dummy_land_candidates() -> LandCandidates:
+        """テスト用の圃場データを返します"""
         return LandCandidates(
             [
                 LandLocation(
@@ -498,13 +499,13 @@ class AssociatePictureAndLandView(TemplateView):
         )
 
     @staticmethod
-    def get_land_by_name(name: str) -> LandLocation:
+    def get_land_by_name(name: str) -> LandLocation | None:
         """
         圃場名から圃場データを取得する関数
         注: これは開発時のダミーデータ用関数で、本番環境では削除して
             データベースから取得する実装に置き換えること
         """
-        land_candidates = AssociatePictureAndLandView.get_dummy_land_list()
+        land_candidates = AssociatePictureAndLandView.get_dummy_land_candidates()
         for land in land_candidates.list():
             if land.name == name:
                 return land
@@ -512,7 +513,7 @@ class AssociatePictureAndLandView(TemplateView):
 
     @staticmethod
     def get_dummy_photo_spots() -> list[XarvioCoord]:
-        """テスト用の座標データを返します"""
+        """テスト用の撮影位置データを返します"""
         return [
             XarvioCoord(longitude=137.64905, latitude=34.74424),  # A1用
             XarvioCoord(longitude=137.64921, latitude=34.744),  # A2用
@@ -522,11 +523,9 @@ class AssociatePictureAndLandView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        # Picture.objects.all()は使わず、代わりに座標データを追加
         context["photo_spots"] = self.get_dummy_photo_spots()
 
-        # Land.objects.all()の代わりにget_dummy_land_listを使用
-        land_candidates = self.get_dummy_land_list()
+        land_candidates = self.get_dummy_land_candidates()
         context["lands"] = land_candidates.list()
 
         return context
@@ -540,7 +539,7 @@ class AssociatePictureAndLandView(TemplateView):
         photo_spots = self.get_dummy_photo_spots()
 
         selected_spot = CaptureLocation(photo_spots[spot_index])
-        land_candidates = self.get_dummy_land_list()
+        land_candidates = self.get_dummy_land_candidates()
 
         service = PhotoProcessingService()
         nearest_land = service.find_nearest_land(selected_spot, land_candidates)

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -560,19 +560,18 @@ class AssociatePictureAndLandResultView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         nearest_land_name = self.request.session.get("nearest_land_name")
-        photo_spot = self.request.session.get("photo_spot")
+        photo_spot_coord = self.request.session.get("photo_spot")
 
-        if nearest_land_name and photo_spot:
+        if nearest_land_name and photo_spot_coord:
             # 圃場名から圃場データを取得
             land = AssociatePictureAndLandView.get_land_by_name(nearest_land_name)
 
-            # ダミーデータを使用するため、Landオブジェクトの代わりに名前と座標を渡す
             context["nearest_land"] = {
-                "name": nearest_land_name,
+                "name": land.name,
                 "location": land.to_google().to_str(),
                 "owner": "テスト所有者",
             }
             # 撮影地点情報
-            context["photo_spot"] = photo_spot
+            context["photo_spot_coord"] = photo_spot_coord
 
         return context

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -18,12 +18,16 @@ from django.views.generic import (
     FormView,
 )
 
-from lib.geo.valueobject.coord import GoogleMapsCoord
+from lib.geo.valueobject.coord import GoogleMapsCoord, XarvioCoord
 from lib.zipfileservice import ZipFileService
 from soil_analysis.domain.repository.landrepository import LandRepository
 from soil_analysis.domain.service.geocode.yahoo import ReverseGeocoderService
 from soil_analysis.domain.service.kml import KmlService
+from soil_analysis.domain.service.photo_processing_service import PhotoProcessingService
 from soil_analysis.domain.service.reports.reportlayout1 import ReportLayout1
+from soil_analysis.domain.valueobject.capturelocation import CaptureLocation
+from soil_analysis.domain.valueobject.land import LandLocation
+from soil_analysis.domain.valueobject.landcandidates import LandCandidates
 from soil_analysis.forms import CompanyCreateForm, LandCreateForm, UploadForm
 from soil_analysis.models import (
     Company,
@@ -458,5 +462,120 @@ class RouteSuggestSuccessView(TemplateView):
         context["land_list"] = land_list
         context["coord_list"] = list(land["coord"] for land in land_list)
         context["google_maps_api_key"] = os.getenv("GOOGLE_MAPS_API_KEY")
+
+        return context
+
+
+class AssociatePictureAndLandView(TemplateView):
+    template_name = "soil_analysis/picture_land_associate/form.html"
+    success_url = reverse_lazy("soil:associate_picture_and_land_result")
+
+    @staticmethod
+    def get_dummy_land_list() -> LandCandidates:
+        return LandCandidates(
+            [
+                LandLocation(
+                    "137.6489657,34.7443565 137.6491266,34.744123 137.648613,34.7438929 "
+                    "137.6484413,34.7441175 137.6489657,34.7443565",
+                    "ススムA1",
+                ),
+                LandLocation(
+                    "137.649128,34.7441119 137.6492862,34.7438795 137.6487833,34.7436526 "
+                    "137.6486224,34.7438861 137.649128,34.7441119",
+                    "ススムA2",
+                ),
+                LandLocation(
+                    "137.6492809,34.743865 137.6494646,34.7436029 137.6489644,34.7433683 "
+                    "137.6487806,34.7436403 137.6492809,34.743865",
+                    "ススムA3",
+                ),
+                LandLocation(
+                    "137.6489738,34.7433604 137.6494633,34.7435774 137.6497127,34.7432096 "
+                    "137.6492192,34.7429904 137.6489738,34.7433604",
+                    "ススムA4",
+                ),
+            ]
+        )
+
+    @staticmethod
+    def get_land_by_name(name: str) -> LandLocation:
+        """
+        圃場名から圃場データを取得する関数
+        注: これは開発時のダミーデータ用関数で、本番環境では削除して
+            データベースから取得する実装に置き換えること
+        """
+        land_candidates = AssociatePictureAndLandView.get_dummy_land_list()
+        for land in land_candidates.list():
+            if land.name == name:
+                return land
+        return None
+
+    @staticmethod
+    def get_dummy_photo_spots() -> list[XarvioCoord]:
+        """テスト用の座標データを返します"""
+        return [
+            XarvioCoord(longitude=137.64905, latitude=34.74424),  # A1用
+            XarvioCoord(longitude=137.64921, latitude=34.744),  # A2用
+            XarvioCoord(longitude=137.64938, latitude=34.74374),  # A3用
+            XarvioCoord(longitude=137.6496, latitude=34.7434),  # A4用
+        ]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Picture.objects.all()は使わず、代わりに座標データを追加
+        context["photo_spots"] = self.get_dummy_photo_spots()
+
+        # Land.objects.all()の代わりにget_dummy_land_listを使用
+        land_candidates = self.get_dummy_land_list()
+        context["lands"] = land_candidates.list()
+
+        return context
+
+    def post(self, request, *args, **kwargs):
+        # フォームクラスを使わないのでフォーム検証は不要
+        if "photo_spot" not in request.POST:  # 名前も変更
+            # エラー処理
+            return self.render_to_response(self.get_context_data())
+
+        spot_index = int(request.POST["photo_spot"])  # 名前も変更
+        photo_spots = self.get_dummy_photo_spots()
+
+        selected_spot = CaptureLocation(photo_spots[spot_index])
+        land_candidates = self.get_dummy_land_list()
+
+        service = PhotoProcessingService()
+        nearest_land = service.find_nearest_land(selected_spot, land_candidates)
+
+        # セッションに結果を保存
+        self.request.session["nearest_land_name"] = nearest_land.name
+        self.request.session["photo_spot"] = [
+            selected_spot.adjusted_position.longitude,
+            selected_spot.adjusted_position.latitude,
+        ]  # 名前も変更
+
+        return HttpResponseRedirect(self.success_url)
+
+
+class AssociatePictureAndLandResultView(TemplateView):
+    template_name = "soil_analysis/picture_land_associate/result.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        nearest_land_name = self.request.session.get("nearest_land_name")
+        photo_spot = self.request.session.get("photo_spot")
+
+        if nearest_land_name and photo_spot:
+            # 圃場名から圃場データを取得
+            land = AssociatePictureAndLandView.get_land_by_name(nearest_land_name)
+
+            # ダミーデータを使用するため、Landオブジェクトの代わりに名前と座標を渡す
+            context["nearest_land"] = {
+                "name": nearest_land_name,
+                "location": land.to_google().to_str(),
+                "owner": "テスト所有者",
+            }
+            # 撮影地点情報
+            context["photo_spot"] = photo_spot
 
         return context

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -533,11 +533,10 @@ class AssociatePictureAndLandView(TemplateView):
 
     def post(self, request, *args, **kwargs):
         # フォームクラスを使わないのでフォーム検証は不要
-        if "photo_spot" not in request.POST:  # 名前も変更
-            # エラー処理
+        if "photo_spot" not in request.POST:
             return self.render_to_response(self.get_context_data())
 
-        spot_index = int(request.POST["photo_spot"])  # 名前も変更
+        spot_index = int(request.POST["photo_spot"])
         photo_spots = self.get_dummy_photo_spots()
 
         selected_spot = CaptureLocation(photo_spots[spot_index])
@@ -548,10 +547,9 @@ class AssociatePictureAndLandView(TemplateView):
 
         # セッションに結果を保存
         self.request.session["nearest_land_name"] = nearest_land.name
-        self.request.session["photo_spot"] = [
-            selected_spot.adjusted_position.longitude,
-            selected_spot.adjusted_position.latitude,
-        ]  # 名前も変更
+        self.request.session["photo_spot"] = (
+            selected_spot.original_position.to_google().to_str()
+        )
 
         return HttpResponseRedirect(self.success_url)
 


### PR DESCRIPTION
1. **モックからの実際の計算への変更**：
    - 以前：`find_nearest_land`メソッドと`calculate_distance`メソッドをモック化し、結果を強制的に指定していた
    - 変更後：実際の座標計算ロジックを使用して、写真と圃場の距離を実際に計算するように変更
1. **実際の座標データの活用**：
    - 各写真に対して特定の座標を定義し、その座標に基づいて最寄りの圃場を特定する実装に変更
    - 写真パスと座標のマッピングを作成し、`android_photo_side_effect`関数で利用

1. **問題点の発見**：
    - 同じ`AndroidPhoto`インスタンスを使い回していたために、常に同じ座標が返されていた可能性がある
    - 新しい実装では、写真ごとに異なる座標を持つインスタンスを生成するようになった

```
C:\Users\yoshi\OneDrive\dev\portfolio\venv\Scripts\python.exe "C:/Program Files/JetBrains/PyCharm 2024.3.1.1/plugins/python-ce/helpers/pycharm/_jb_unittest_runner.py" --target test_photo_processing_service.TestPhotoProcessingService 
Testing started at 12:56 ...
Launching unittests with arguments python -m unittest test_photo_processing_service.TestPhotoProcessingService in C:\Users\yoshi\OneDrive\dev\portfolio\soil_analysis\tests\domain\service

結果 1: ファイル=path/to/photo1.jpg, 圃場=ススムA1
  写真の座標: 34.74424,137.64905
  圃場の座標: 34.7441225,137.6487867
  距離: 27.38m
結果 2: ファイル=path/to/photo2.jpg, 圃場=ススムA2
  写真の座標: 34.744,137.64921
  圃場の座標: 34.7438825,137.648955
  距離: 26.71m
結果 3: ファイル=path/to/photo3.jpg, 圃場=ススムA3
  写真の座標: 34.74374,137.64938
  圃場の座標: 34.7436191,137.6491226
  距離: 27.09m
結果 4: ファイル=path/to/photo4.jpg, 圃場=ススムA4
  写真の座標: 34.7434,137.6496
  圃場の座標: 34.7432844,137.6493423
  距離: 26.83m


Ran 6 tests in 0.005s

OK

Process finished with exit code 0

```

- [x] djangoでフロントを整える（ルートサジェスト（試作）のとなりにつくればよい）
<img width="400" src="https://github.com/user-attachments/assets/4cdd9cf8-efa5-4dd4-8ea4-4bf56e753575">
