### PR TITLE
チェックマークを押してないとこがあったら送信できないようにして（push漏れ）

### DIFF
--- a/soil_analysis/templates/soil_analysis/hardness/association/list.html
+++ b/soil_analysis/templates/soil_analysis/hardness/association/list.html
@@ -43,9 +43,7 @@
                         <td>{{ measurement.cnt }}</td>
                         {% if forloop.counter0|divisibleby:25 %}
                             <td rowspan="5">
-                                <div class="alert alert-info" role="alert" style="font-size: 0.9rem; padding: 0.5rem;">
-                                    基本的にRパターンで登録されます
-                                </div>
+                                <p> 基本的にRパターンで登録されます </p>
                                 <button class="btn btn-outline-secondary mb-3" type="submit" name="btn_individual"
                                         value="{{ measurement.set_memory }}">圃場をRパターン以外で登録
                                 </button>


### PR DESCRIPTION
Replaced the styled alert box with a plain paragraph tag to reduce complexity and improve maintainability. This change ensures a cleaner and more consistent UI.