### PR TITLE
取り込みデータ集計画面で、folderの値を利用して圃場登録を行う

### DIFF
--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -102,9 +102,9 @@ class LandCreateForm(forms.ModelForm):
             ),
             "remark": forms.TextInput(attrs={"class": "form-control", "tabindex": "7"}),
             "cultivation_type": forms.Select(
-                attrs={"class": "form-control", "tabindex": "8"}
+                attrs={"class": "form-select", "tabindex": "8"}
             ),
-            "owner": forms.Select(attrs={"class": "form-control", "tabindex": "9"}),
+            "owner": forms.Select(attrs={"class": "form-select", "tabindex": "9"}),
             "company": forms.HiddenInput(),
         }
         labels = {

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -45,10 +45,12 @@ class CompanyCreateForm(forms.ModelForm):
 
 class LandCreateForm(forms.ModelForm):
     jma_prefecture = forms.ModelChoiceField(
-        queryset=JmaPrefecture.objects.all(), empty_label="選択してください"
+        queryset=JmaPrefecture.objects.all(),
+        empty_label="選択してください",
+        label="都道府県",
     )
     jma_city = forms.ModelChoiceField(
-        queryset=JmaCity.objects.all(), empty_label="選択してください"
+        queryset=JmaCity.objects.all(), empty_label="選択してください", label="市区町村"
     )
 
     class Meta:

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -55,9 +55,9 @@ class LandCreateForm(forms.ModelForm):
         model = Land
         fields = (
             "name",
-            "center",
             "jma_prefecture",
             "jma_city",
+            "center",
             "area",
             "image",
             "remark",
@@ -66,27 +66,26 @@ class LandCreateForm(forms.ModelForm):
         )
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control", "tabindex": "1"}),
-            "center": forms.TextInput(
-                attrs={
-                    "class": "form-control",
-                    "tabindex": "2",
-                    "placeholder": "例: 35.658581,139.745433",
-                }
-            ),
-            # TODO: なぜか bootstrap が反映されない（react化で解決したほうがよさそう）
             "jma_prefecture": forms.Select(
                 attrs={
                     "class": "form-control",
-                    "tabindex": "3",
-                    "placeholder": "例: 兵庫県",
+                    "tabindex": "2",
+                    "placeholder": "都道府県を選択してください",
                 }
             ),
-            # TODO: なぜか bootstrap が反映されない（react化で解決したほうがよさそう）
             "jma_city": forms.Select(
                 attrs={
                     "class": "form-control",
+                    "tabindex": "3",
+                    "placeholder": "市区町村を選択してください",
+                }
+            ),
+            "center": forms.TextInput(
+                attrs={
+                    "class": "form-control",
                     "tabindex": "4",
-                    "placeholder": "例: 姫路市",
+                    "placeholder": "例: 35.658581,139.745433",
+                    "value": "35.658581,139.745433",
                 }
             ),
             "area": forms.TextInput(
@@ -107,15 +106,15 @@ class LandCreateForm(forms.ModelForm):
             "company": forms.HiddenInput(),
         }
         labels = {
-            "name": "圃場名*",
-            "latlon": "緯度・経度*",
-            "jma_prefecture": "都道府県*",
-            "jma_city": "市区町村*",
+            "name": "圃場名",
+            "jma_prefecture": "都道府県",
+            "jma_city": "市区町村",
+            "center": "中心座標",
             "area": "圃場面積（㎡）",
             "image": "画像",
             "remark": "備考",
-            "cultivation_type": "栽培タイプ*",
-            "owner": "所有者*",
+            "cultivation_type": "栽培タイプ",
+            "owner": "所有者",
         }
 
     def clean_name(self):

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -24,7 +24,7 @@ class CompanyCreateForm(forms.ModelForm):
                 attrs={"class": "form-control", "tabindex": "2"}
             ),
             "remark": forms.TextInput(attrs={"class": "form-control", "tabindex": "3"}),
-            "category": forms.Select(attrs={"class": "form-control", "tabindex": "4"}),
+            "category": forms.Select(attrs={"class": "form-select", "tabindex": "4"}),
         }
         labels = {
             "name": "圃場名",

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -70,14 +70,14 @@ class LandCreateForm(forms.ModelForm):
             "name": forms.TextInput(attrs={"class": "form-control", "tabindex": "1"}),
             "jma_prefecture": forms.Select(
                 attrs={
-                    "class": "form-control",
+                    "class": "form-select",
                     "tabindex": "2",
                     "placeholder": "都道府県を選択してください",
                 }
             ),
             "jma_city": forms.Select(
                 attrs={
-                    "class": "form-control",
+                    "class": "form-select",
                     "tabindex": "3",
                     "placeholder": "市区町村を選択してください",
                 }

--- a/soil_analysis/management/commands/fetch_weather_forecast.py
+++ b/soil_analysis/management/commands/fetch_weather_forecast.py
@@ -45,8 +45,8 @@ def update_prefecture_ids(prefecture_ids: list[str]) -> tuple[list[str], dict]:
     Example:
         prefecture_ids = ["014030", "460040"]
         updated_ids, special_add_region_ids = update_prefecture_ids(prefecture_ids)
-        print(updated_ids)  # Output: ["014100", "460100"]
-        print(special_add_region_ids)  # Output: {"014100": "014030", "460100": "460040"}
+        print(updated_ids) # Output: ["014100", "460100"]
+        print(special_add_region_ids) # Output: {"014100": "014030", "460100": "460040"}
     """
     pairs_to_check = [("014030", "014100"), ("460040", "460100")]
     special_add_region_ids = {}

--- a/soil_analysis/static/soil_analysis/css/land/create.css
+++ b/soil_analysis/static/soil_analysis/css/land/create.css
@@ -1,0 +1,106 @@
+.card {
+    border-radius: 15px;
+    transition: transform 0.2s ease-in-out;
+}
+
+.card:hover {
+    transform: translateY(-2px);
+}
+
+/* フォームフィールドのBootstrapスタイル適用 */
+.form-group input[type="text"],
+.form-group input[type="email"],
+.form-group input[type="number"],
+.form-group input[type="date"],
+.form-group input[type="datetime-local"],
+.form-group input[type="file"],
+.form-group textarea {
+    display: block;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    border-radius: 8px;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.form-group select {
+    display: block;
+    width: 100%;
+    padding: 0.75rem 2.25rem 0.75rem 1rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 6 7 7 7-7'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 1rem center;
+    background-size: 16px 12px;
+    border: 1px solid #ced4da;
+    border-radius: 8px;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    appearance: none;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    border-color: #0d6efd;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.15);
+    outline: 0;
+}
+
+.form-group input:invalid,
+.form-group select:invalid,
+.form-group textarea:invalid {
+    border-color: #dc3545;
+}
+
+.breadcrumb {
+    border-radius: 10px;
+}
+
+.breadcrumb-item + .breadcrumb-item::before {
+    content: ">";
+    color: #6c757d;
+}
+
+.btn-lg {
+    padding: 0.75rem 2rem;
+    border-radius: 8px;
+}
+
+.alert {
+    border-radius: 10px;
+    border: none;
+}
+
+.disabled-field {
+    background-color: #f8f9fa !important;
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.input-wrapper {
+    position: relative;
+}
+
+.form-label {
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.invalid-feedback {
+    color: #dc3545;
+    font-size: 0.875rem;
+}
+
+.form-text {
+    font-size: 0.875rem;
+}

--- a/soil_analysis/templates/soil_analysis/hardness/success.html
+++ b/soil_analysis/templates/soil_analysis/hardness/success.html
@@ -91,6 +91,66 @@
                             <li>測定期間が適切な範囲内であることを確認してください</li>
                         </ul>
                     </div>
+
+                    <!-- 不足している圃場の情報 -->
+                    {% if missing_lands %}
+                        <div class="alert alert-warning mt-3">
+                            <h6><i class="fas fa-exclamation-triangle"></i> 圃場の事前作成が必要</h6>
+                            <p class="mb-2">
+                                以下のフォルダに対応する圃場が見つかりません。帳簿作成の前に圃場を作成してください：</p>
+                            <div class="table-responsive">
+                                <table class="table table-sm table-bordered">
+                                    <thead>
+                                    <tr>
+                                        <th>フォルダ名</th>
+                                        <th>推定圃場名</th>
+                                        <th>操作</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {% for missing in missing_lands %}
+                                        <tr>
+                                            <td><code>{{ missing.folder_name }}</code></td>
+                                            <td><strong>{{ missing.suggested_land_name }}</strong></td>
+                                            <td>
+                                                <div class="dropdown">
+                                                    <button class="btn btn-outline-primary btn-sm dropdown-toggle"
+                                                            type="button" id="landCreateDropdown{{ forloop.counter }}"
+                                                            data-bs-toggle="dropdown" aria-expanded="false">
+                                                        <i class="fas fa-plus"></i> 圃場作成
+                                                    </button>
+                                                    <ul class="dropdown-menu"
+                                                        aria-labelledby="landCreateDropdown{{ forloop.counter }}">
+                                                        {% for company in companies %}
+                                                            <li>
+                                                                <a class="dropdown-item"
+                                                                   href="{% url 'soil:land_create' company_id=company.id %}?suggested_name={{ missing.suggested_land_name|urlencode }}">
+                                                                    {{ company.name }}
+                                                                </a>
+                                                            </li>
+                                                        {% empty %}
+                                                            <li>
+                                                                    <span class="dropdown-item-text text-muted">
+                                                                        <i class="fas fa-info-circle"></i> 利用可能な会社がありません
+                                                                    </span>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="mt-2">
+                                <small class="text-muted">
+                                    <i class="fas fa-info-circle"></i>
+                                    会社を選択して圃場作成画面へ進んでください。圃場名は自動で入力されます。
+                                </small>
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -1,39 +1,199 @@
 {% extends "soil_analysis/base.html" %}
 {% load static %}
 
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'soil_analysis/css/land/create.css' %}">
+{% endblock %}
+
 {% block content %}
-    <div class="container">
-        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
-                <li class="breadcrumb-item"><a href="{% url 'soil:land_list' company.id %}">Land List</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Create</li>
-            </ol>
-        </nav>
+    <div class="container-fluid bg-light min-vh-100 py-4">
         <div class="container">
-            <h1>新規作成</h1>
-            {% if messages %}
-                <ul class="messages">
-                    {% for message in messages %}
-                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            <form method="post" enctype="multipart/form-data">
-                {% csrf_token %}
-                {{ form.as_p }}
-                <input type="hidden" name="company-id" value="{{ company.pk }}">
-                <button type="submit" class="btn btn-outline-primary mb-3">送信</button>
-            </form>
+            <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                    <li class="breadcrumb-item"><a href="{% url 'soil:land_list' company.id %}">Land List</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Create</li>
+                </ol>
+            </nav>
+
+            <!-- Main Content Card -->
+            <div class="card shadow-lg border-0">
+                <div class="card-header bg-primary text-white py-3">
+                    <h1 class="card-title mb-0 h3">
+                        <i class="fas fa-plus-circle me-2"></i>新規圃場作成
+                    </h1>
+                    <p class="card-text mb-0 text-light">新しい圃場情報を入力してください</p>
+                </div>
+
+                <div class="card-body p-4">
+                    <!-- Messages Section -->
+                    {% if messages %}
+                        <div class="mb-4">
+                            {% for message in messages %}
+                                <div class="alert alert-{% if message.tags == 'error' %}danger{% elif message.tags == 'warning' %}warning{% elif message.tags == 'success' %}success{% else %}info{% endif %} alert-dismissible fade show"
+                                     role="alert">
+                                    <i class="fas fa-{% if message.tags == 'error' %}exclamation-triangle{% elif message.tags == 'warning' %}exclamation-circle{% elif message.tags == 'success' %}check-circle{% else %}info-circle{% endif %} me-2"></i>
+                                    {{ message }}
+                                    <button type="button" class="btn-close" data-bs-dismiss="alert"
+                                            aria-label="Close"></button>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+
+                    <!-- Form Section -->
+                    <form method="post" enctype="multipart/form-data" class="needs-validation" novalidate>
+                        {% csrf_token %}
+
+                        <!-- 圃場名（1行全体） -->
+                        <div class="row">
+                            <div class="col-12 mb-4">
+                                <div class="form-group">
+                                    {% if form.name.label %}
+                                        <label for="{{ form.name.id_for_label }}"
+                                               class="form-label text-muted fw-semibold mb-2">
+                                            {{ form.name.label }}
+                                            {% if form.name.field.required %}
+                                                <span class="text-danger ms-1">*</span>
+                                            {% endif %}
+                                        </label>
+                                    {% endif %}
+
+                                    <div class="input-wrapper">
+                                        {{ form.name }}
+                                    </div>
+
+                                    {% if form.name.errors %}
+                                        {% for error in form.name.errors %}
+                                            <div class="invalid-feedback d-block mt-1">
+                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                            </div>
+                                        {% endfor %}
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 都道府県・市区町村（横並び） -->
+                        <div class="row">
+                            <div class="col-md-6 mb-4">
+                                <div class="form-group">
+                                    {% if form.jma_prefecture.label %}
+                                        <label for="{{ form.jma_prefecture.id_for_label }}"
+                                               class="form-label text-muted fw-semibold mb-2">
+                                            {{ form.jma_prefecture.label }}
+                                            {% if form.jma_prefecture.field.required %}
+                                                <span class="text-danger ms-1">*</span>
+                                            {% endif %}
+                                        </label>
+                                    {% endif %}
+
+                                    <div class="input-wrapper">
+                                        {{ form.jma_prefecture }}
+                                    </div>
+
+                                    {% if form.jma_prefecture.errors %}
+                                        {% for error in form.jma_prefecture.errors %}
+                                            <div class="invalid-feedback d-block mt-1">
+                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                            </div>
+                                        {% endfor %}
+                                    {% endif %}
+                                </div>
+                            </div>
+
+                            <div class="col-md-6 mb-4">
+                                <div class="form-group">
+                                    {% if form.jma_city.label %}
+                                        <label for="{{ form.jma_city.id_for_label }}"
+                                               class="form-label text-muted fw-semibold mb-2">
+                                            {{ form.jma_city.label }}
+                                            {% if form.jma_city.field.required %}
+                                                <span class="text-danger ms-1">*</span>
+                                            {% endif %}
+                                        </label>
+                                    {% endif %}
+
+                                    <div class="input-wrapper">
+                                        {{ form.jma_city }}
+                                    </div>
+
+                                    {% if form.jma_city.errors %}
+                                        {% for error in form.jma_city.errors %}
+                                            <div class="invalid-feedback d-block mt-1">
+                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                            </div>
+                                        {% endfor %}
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- その他のフィールド -->
+                        <div class="row">
+                            {% for field in form %}
+                                {% if field.name != 'name' and field.name != 'jma_prefecture' and field.name != 'jma_city' %}
+                                    <div class="col-md-6 mb-4">
+                                        <div class="form-group">
+                                            {% if field.label %}
+                                                <label for="{{ field.id_for_label }}"
+                                                       class="form-label text-muted fw-semibold mb-2">
+                                                    {{ field.label }}
+                                                    {% if field.field.required %}
+                                                        <span class="text-danger ms-1">*</span>
+                                                    {% endif %}
+                                                </label>
+                                            {% endif %}
+
+                                            <div class="input-wrapper">
+                                                {{ field }}
+                                            </div>
+
+                                            {% if field.help_text %}
+                                                <div class="form-text text-muted small mt-1">
+                                                    <i class="fas fa-info-circle me-1"></i>{{ field.help_text }}
+                                                </div>
+                                            {% endif %}
+
+                                            {% if field.errors %}
+                                                {% for error in field.errors %}
+                                                    <div class="invalid-feedback d-block mt-1">
+                                                        <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                                    </div>
+                                                {% endfor %}
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+
+                        <input type="hidden" name="company-id" value="{{ company.pk }}">
+
+                        <!-- Submit Button -->
+                        <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4 pt-3 border-top">
+                            <a href="{% url 'soil:land_list' company.id %}"
+                               class="btn btn-outline-secondary btn-lg me-md-2">
+                                <i class="fas fa-times me-2"></i>キャンセル
+                            </a>
+                            <button type="submit" class="btn btn-primary btn-lg">
+                                <i class="fas fa-save me-2"></i>作成する
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <script>
-            function clearDropdown(selectElement) {
-                const defaultOption = document.createElement('option')
-                defaultOption.value = ""
-                defaultOption.text = "選択してください"
-                defaultOption.selected = true
-                selectElement.appendChild(defaultOption)
-            }
+    </div>
+
+    <script>
+        function clearDropdown(selectElement) {
+            const defaultOption = document.createElement('option')
+            defaultOption.value = ""
+            defaultOption.text = "選択してください"
+            defaultOption.selected = true
+            selectElement.appendChild(defaultOption)
+        }
 
             function setDropdownList(optionsData, selectElement) {
                 optionsData.map(item => {

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -199,14 +199,22 @@
             selectElement.appendChild(defaultOption)
         }
 
-            function setDropdownList(optionsData, selectElement) {
-                optionsData.map(item => {
-                    const option = document.createElement('option')
-                    option.value = item.id
-                    option.text = item.name
-                    selectElement.appendChild(option)
-                })
-            }
+        /**
+         * ドロップダウンにオプションリストを設定し、確実にenableにします
+         *
+         * @param {Array<{id: string, name: string}>} optionsData - 設定するオプションデータの配列
+         * @param {HTMLSelectElement} selectElement - オプションを設定するセレクト要素
+         */
+        function setDropdownList(optionsData, selectElement) {
+            selectElement.disabled = false
+            selectElement.classList.remove('disabled-field')
+            optionsData.map(item => {
+                const option = document.createElement('option')
+                option.value = item.id
+                option.text = item.name
+                selectElement.appendChild(option)
+            })
+        }
 
         /**
          * 市区町村セレクトボックスを無効化し、初期状態にリセットします

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -261,40 +261,22 @@
             }
         }
 
-            /**
-             * 土地の緯度経度に基づいてその位置情報を取得します
-             *
-             * @param {string} latlon - 緯度経度のペア。
-             */
-            async function fetchLandLocationInfo(latlon) {
-                const response = await fetch("{% url 'soil:land_location_info' %}", {
-                    method: "POST",
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': Cookies.get('csrftoken')
-                    },
-                    body: JSON.stringify({latlon})
-                })
-                return response.json()
-            }
+        /**
+         * フォームフィールドに適切なBootstrapクラスを適用します
+         * DjangoのFormフィールドにBootstrapのスタイリングクラスを動的に追加し、
+         * 統一されたUIデザインを実現します
+         */
+        function applyBootstrapClasses() {
+            const formFields = document.querySelectorAll('input, select, textarea')
+            formFields.forEach(field => {
+                if (field.type === 'hidden') return
 
-            document.getElementById("id_latlon").addEventListener("change", async function () {
-                const latlon = this.value
-                const prefectureSelect = document.getElementById("id_jma_prefecture")
-                const citySelect = document.getElementById("id_jma_city")
-
-                if (latlon) {
-                    const landLocationInfo = await fetchLandLocationInfo(latlon)
-                    if (landLocationInfo.error) {
-                        alert(landLocationInfo.error)
-                    } else {
-                        await fetchPrefectures()
-                        prefectureSelect.value = landLocationInfo.jma_prefecture_id
-                        await fetchCities(landLocationInfo.jma_prefecture_id)
-                        citySelect.value = landLocationInfo.jma_city_id
-                    }
+                if (field.tagName.toLowerCase() === 'select') {
+                    field.classList.add('form-select')
+                } else if (field.tagName.toLowerCase() === 'textarea') {
+                    field.classList.add('form-control')
                 } else {
-                    await fetchCities(undefined)
+                    field.classList.add('form-control')
                 }
             })
 

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -208,18 +208,36 @@
                 })
             }
 
-            /**
-             * 都道府省のデータをフェッチし、それに応じて都道府県ドロップダウンオプションを設定します。
-             */
-            async function fetchPrefectures() {
-                const prefectureSelect = document.getElementById("id_jma_prefecture")
-                prefectureSelect.innerHTML = ''
-                clearDropdown(prefectureSelect)
+        /**
+         * 市区町村セレクトボックスを無効化し、初期状態にリセットします
+         *
+         * 都道府県が未選択の場合に実行され、データの整合性を保つため
+         * 市区町村の選択を無効化します。
+         */
+        function disableCitySelect() {
+            const citySelect = document.getElementById("id_jma_city")
+            citySelect.innerHTML = ''
+            clearDropdown(citySelect)
+            citySelect.disabled = true
+            citySelect.classList.add('disabled-field')
+        }
 
+        /**
+         * 都道府省のデータをフェッチし、それに応じて都道府県ドロップダウンオプションを設定します。
+         */
+        async function fetchPrefectures() {
+            const prefectureSelect = document.getElementById("id_jma_prefecture")
+            prefectureSelect.innerHTML = ''
+            clearDropdown(prefectureSelect)
+
+            try {
                 const response = await fetch('{% url 'soil:prefectures' %}')
                 const data = await response.json()
                 setDropdownList(data.prefectures, prefectureSelect)
+            } catch (error) {
+                console.error('都道府県の取得に失敗しました:', error)
             }
+        }
 
         /**
          * 指定された都道府県 ID に基づいて都市データを取得し、それに応じて都市ドロップダウン オプションを設定します

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -187,6 +187,10 @@
     </div>
 
     <script>
+        /**
+         * ドロップダウンを初期化し、デフォルトオプション「選択してください」を追加します
+         * @param {HTMLSelectElement} selectElement - 初期化するセレクト要素
+         */
         function clearDropdown(selectElement) {
             const defaultOption = document.createElement('option')
             defaultOption.value = ""

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -221,23 +221,45 @@
                 setDropdownList(data.prefectures, prefectureSelect)
             }
 
-            /**
-             * 指定された都道府県 ID に基づいて都市データを取得し、それに応じて都市ドロップダウン オプションを設定します
-             * 都道府県 ID が指定されていない場合、都市のドロップダウンはクリアされます
-             *
-             * @param {string} prefectureId - The ID of the prefecture.
-             */
-            async function fetchCities(prefectureId) {
-                const citySelect = document.getElementById("id_jma_city")
-                citySelect.innerHTML = ''
-                clearDropdown(citySelect)
+        /**
+         * 指定された都道府県 ID に基づいて都市データを取得し、それに応じて都市ドロップダウン オプションを設定します
+         * 都道府県 ID が指定されていない場合、都市のドロップダウンはクリアされ無効化されます
+         *
+         * 【詳細な動作の流れ】
+         * - 都道府県が選択されていない間: disableCitySelect()を実行してreturnで処理をスキップ
+         * - 都道府県選択時のみ以下を実行:
+         *   1. 市区町村セレクトボックスを一旦無効化（API通信中の状態）
+         *   2. APIから市区町村データを非同期取得
+         *   3. setDropdownList()でデータセット＋セレクトボックス有効化
+         *
+         * @param {string} prefectureId - 都道府県ID（空文字の場合は処理をスキップ）
+         */
+        async function fetchCities(prefectureId) {
+            const citySelect = document.getElementById("id_jma_city")
 
-                if (prefectureId) {
-                    const response = await fetch(`/soil_analysis/prefecture/${prefectureId}/cities`)
-                    const data = await response.json()
-                    setDropdownList(data.cities, citySelect)
-                }
+            // 都道府県が選択されていない間は市区町村を無効化したままスキップ
+            if (!prefectureId) {
+                disableCitySelect()
+                return
             }
+
+            // ステップ1: 市区町村セレクトボックスを一旦無効化（API通信中の状態）
+            citySelect.innerHTML = ''
+            clearDropdown(citySelect)
+            citySelect.disabled = true
+            citySelect.classList.add('disabled-field')
+
+            try {
+                // ステップ2: APIから市区町村データを取得（この間disabled状態が続く）
+                const response = await fetch(`/soil_analysis/prefecture/${prefectureId}/cities`)
+                const data = await response.json()
+                // ステップ3: データセット＋セレクトボックス有効化
+                setDropdownList(data.cities, citySelect)
+            } catch (error) {
+                console.error('都市の取得に失敗しました:', error)
+                disableCitySelect()
+            }
+        }
 
             /**
              * 土地の緯度経度に基づいてその位置情報を取得します

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -261,29 +261,19 @@
             }
         }
 
-        /**
-         * フォームフィールドに適切なBootstrapクラスを適用します
-         * DjangoのFormフィールドにBootstrapのスタイリングクラスを動的に追加し、
-         * 統一されたUIデザインを実現します
-         */
-        function applyBootstrapClasses() {
-            const formFields = document.querySelectorAll('input, select, textarea')
-            formFields.forEach(field => {
-                if (field.type === 'hidden') return
+        // ページ読み込み時の初期化
+        document.addEventListener('DOMContentLoaded', function () {
+            // 初期状態では都市選択を無効化
+            disableCitySelect()
 
-                if (field.tagName.toLowerCase() === 'select') {
-                    field.classList.add('form-select')
-                } else if (field.tagName.toLowerCase() === 'textarea') {
-                    field.classList.add('form-control')
-                } else {
-                    field.classList.add('form-control')
-                }
-            })
-
-            document.getElementById("id_jma_prefecture").addEventListener("change", function () {
-                const prefectureId = this.value
-                fetchCities(prefectureId)
-            })
-        </script>
-    </div>
+            // 都道府県選択の変更イベント
+            const prefectureSelect = document.getElementById("id_jma_prefecture")
+            if (prefectureSelect) {
+                prefectureSelect.addEventListener("change", function () {
+                    const prefectureId = this.value
+                    fetchCities(prefectureId)
+                })
+            }
+        })
+    </script>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/land/detail.html
+++ b/soil_analysis/templates/soil_analysis/land/detail.html
@@ -61,7 +61,7 @@
                                 <strong><i class="fas fa-crosshairs"></i> 緯度経度</strong>
                             </div>
                             <div class="col-sm-7">
-                                <span class="text-muted">{{ object.latlon|default:"未設定" }}</span>
+                                <span class="text-muted">{{ object.center|default:"未設定" }}</span>
                             </div>
                         </div>
                     </div>

--- a/soil_analysis/urls.py
+++ b/soil_analysis/urls.py
@@ -26,11 +26,6 @@ urlpatterns = [
     ),
     path("prefectures/", views.PrefecturesView.as_view(), name="prefectures"),
     path(
-        "api/land/location/info",
-        views.LocationInfoView.as_view(),
-        name="land_location_info",
-    ),
-    path(
         "prefecture/<int:prefecture_id>/cities",
         views.PrefectureCitiesView.as_view(),
         name="prefecture_cities",

--- a/soil_analysis/urls.py
+++ b/soil_analysis/urls.py
@@ -36,6 +36,11 @@ urlpatterns = [
         name="prefecture_cities",
     ),
     path(
+        "city/<int:city_id>/coordinates",
+        views.CityCoordinatesView.as_view(),
+        name="city_coordinates",
+    ),
+    path(
         "company/<int:company_id>/land/<int:pk>/detail",
         views.LandDetailView.as_view(),
         name="land_detail",

--- a/soil_analysis/urls.py
+++ b/soil_analysis/urls.py
@@ -31,11 +31,6 @@ urlpatterns = [
         name="prefecture_cities",
     ),
     path(
-        "city/<int:city_id>/coordinates",
-        views.CityCoordinatesView.as_view(),
-        name="city_coordinates",
-    ),
-    path(
         "company/<int:company_id>/land/<int:pk>/detail",
         views.LandDetailView.as_view(),
         name="land_detail",

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -484,6 +484,12 @@ class HardnessSuccessView(TemplateView):
         context["total_records"] = SoilHardnessMeasurement.objects.count()
         context["missing_lands"] = missing_lands
 
+        # 圃場作成用の会社一覧を追加（農業法人のみ）
+        if missing_lands:
+            context["companies"] = Company.objects.filter(category_id=1).order_by(
+                "name"
+            )
+
         return context
 
 

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -491,6 +492,29 @@ class HardnessSuccessView(TemplateView):
             )
 
         return context
+
+    @staticmethod
+    def _extract_land_name_from_folder(folder_name: str) -> str:
+        """フォルダ名から圃場名を抽出
+
+        変換パターン例:
+        - "静岡ススムA1_20230701" → "静岡ススムA1"
+        - "静岡ススムA1_20230701_1" → "静岡ススムA1"
+        - "静岡ススムA120230701" → "静岡ススムA1"
+        - "静岡ススムA120230701_extra" → "静岡ススムA1"
+        - "静岡ススムA1" → "静岡ススムA1"
+        """
+        # アンダースコアがある場合は最初の部分を取得
+        if "_" in folder_name:
+            base_name = folder_name.split("_")[0]
+        else:
+            base_name = folder_name
+
+        # 8桁日付パターン（YYYYMMDD）以降をすべて除去
+        date_pattern = r"\d{8}.*$"
+        base_name = re.sub(date_pattern, "", base_name)
+
+        return base_name.strip()
 
 
 class HardnessAssociationView(ListView):

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -149,6 +149,14 @@ class LandCreateView(CreateView):
         context["company"] = Company(pk=self.kwargs["company_id"])
         return context
 
+    def get_initial(self):
+        initial = super().get_initial()
+        # URLパラメータから圃場名を事前設定
+        suggested_name = self.request.GET.get("suggested_name")
+        if suggested_name:
+            initial["name"] = suggested_name
+        return initial
+
     def form_valid(self, form):
         form.instance.company_id = self.kwargs["company_id"]
         lat, lon = form.instance.latlon.split(", ")

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -164,42 +164,7 @@ class LandCreateView(CreateView):
         return super().form_valid(form)
 
     def get_success_url(self):
-        company = Company(pk=self.kwargs["company_id"])
-        return reverse(
-            "soil:land_detail", kwargs={"company_id": company.id, "pk": self.object.pk}
-        )
-
-
-class LocationInfoView(View):
-    """
-    圃場新規作成時のフォームで latlon 入力が終了した際に非同期で情報を取得
-    """
-
-    @staticmethod
-    def post(request, *args, **kwargs):
-        data = json.loads(request.body.decode("utf-8"))
-        lat_str, lon_str = data.get("latlon").split(",")
-        lat = float(lat_str.strip())
-        lon = float(lon_str.strip())
-
-        coord = GoogleMapsCoord(latitude=lat, longitude=lon)
-        ydf = ReverseGeocoderService.get_ydf_from_coord(coord)
-
-        try:
-            jma_city = ReverseGeocoderService.get_jma_city(ydf)
-        except JmaCity.DoesNotExist:
-            return JsonResponse(
-                {
-                    "error": f"{ydf.feature.prefecture.name} {ydf.feature.city.name} が見つかりませんでした"
-                }
-            )
-
-        return JsonResponse(
-            {
-                "jma_city_id": jma_city.id,
-                "jma_prefecture_id": jma_city.jma_region.jma_prefecture.id,
-            }
-        )
+        return reverse("soil:hardness_success")
 
 
 class PrefecturesView(View):

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -469,8 +469,20 @@ class HardnessSuccessView(TemplateView):
             associated_only=False
         )
 
+        # フォルダ名に基づいて新規登録が必要な圃場を特定
+        missing_lands = []
+        for stats in folder_stats:
+            folder_name = stats["folder"]
+            land_name = self._extract_land_name_from_folder(folder_name)
+
+            if land_name and not Land.objects.filter(name=land_name).exists():
+                missing_lands.append(
+                    {"folder_name": folder_name, "suggested_land_name": land_name}
+                )
+
         context["folder_stats"] = folder_stats
         context["total_records"] = SoilHardnessMeasurement.objects.count()
+        context["missing_lands"] = missing_lands
 
         return context
 

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -165,7 +165,13 @@ class LandCreateView(CreateView):
         return super().form_valid(form)
 
     def get_success_url(self):
-        return reverse("soil:hardness_success")
+        # suggested_nameがある場合（硬度測定データからの圃場作成）は硬度測定画面に戻る
+        suggested_name = self.request.GET.get("suggested_name")
+        if suggested_name:
+            return reverse("soil:hardness_success")
+
+        # 通常の圃場作成の場合は圃場詳細画面に遷移
+        return reverse("soil:land_detail", kwargs={"pk": self.object.pk})
 
 
 class PrefecturesView(View):

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 from pathlib import Path
@@ -21,14 +20,13 @@ from django.views.generic import (
     FormView,
 )
 
-from lib.geo.valueobject.coord import GoogleMapsCoord, XarvioCoord
+from lib.geo.valueobject.coord import XarvioCoord
 from lib.zipfileservice import ZipFileService
 from soil_analysis.domain.repository.company import CompanyRepository
 from soil_analysis.domain.repository.hardness_measurement import (
     SoilHardnessMeasurementRepository,
 )
 from soil_analysis.domain.repository.land import LandRepository
-from soil_analysis.domain.service.geocode.yahoo import ReverseGeocoderService
 from soil_analysis.domain.service.kml import KmlService
 from soil_analysis.domain.service.photo_processing import PhotoProcessingService
 from soil_analysis.domain.service.reports.reportlayout1 import ReportLayout1
@@ -159,8 +157,10 @@ class LandCreateView(CreateView):
 
     def form_valid(self, form):
         form.instance.company_id = self.kwargs["company_id"]
-        lat, lon = form.instance.latlon.split(", ")
-        form.instance.latlon = ",".join([lat, lon])
+        if form.instance.center:
+            # center フィールドの値を正規化（スペースを除去）
+            lat, lon = form.instance.center.split(",")
+            form.instance.center = ",".join([lat.strip(), lon.strip()])
         return super().form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
## テストシナリオ: 圃場作成後の遷移先分岐
### ✅ **シナリオ1: 硬度データ登録画面からの圃場作成**
**前提条件:**
- 硬度測定データがインポート済み
- 新規登録が必要な圃場が存在する状態

**テスト手順:**
1. 硬度測定成功画面 (`/soil_analysis/hardness/success/`) にアクセス
2. 「新規登録が必要」セクションで圃場作成ボタンをクリック
3. 圃場作成画面のURLに `?suggested_name=静岡ススムA1` が含まれることを確認
4. 圃場名フィールドに推奨名が自動入力されていることを確認
5. 必要項目を入力して「作成する」ボタンをクリック
6. **硬度測定成功画面 (`/soil_analysis/hardness/success/`) に戻ることを確認**

### ✅ **シナリオ2: 圃場一覧からの通常の圃場作成**
**前提条件:**
- 会社が作成済み

**テスト手順:**
1. 圃場一覧画面 (`/soil_analysis/company/{company_id}/land/`) にアクセス
2. 「新規圃場作成」ボタンをクリック
3. 圃場作成画面のURLに `suggested_name` パラメータが**含まれない**ことを確認
4. 圃場名フィールドが空であることを確認
5. 必要項目を入力して「作成する」ボタンをクリック
6. **作成した圃場の詳細画面 (`/soil_analysis/land/{land_id}/`) に遷移することを確認**

### 🔍 **確認ポイント:**
- シナリオ1では硬度測定画面に戻る
- シナリオ2では圃場詳細画面に遷移する
- URLパラメータの有無で遷移先が正しく分岐している
- どちらのパターンでも圃場が正常に作成されている