### PR TITLE
 使用済み帳簿の除外機能実装

### DIFF
--- a/soil_analysis/templates/soil_analysis/hardness/association/field_group.html
+++ b/soil_analysis/templates/soil_analysis/hardness/association/field_group.html
@@ -123,7 +123,9 @@
                         {% if folder_name %}
                             <div class="form-text">
                                 <i class="fas fa-info-circle"></i>
-                                フォルダ名「{{ folder_name }}」に適した帳簿が優先表示されています
+                                フォルダ名「{{ folder_name }}」に適した帳簿が優先表示されています<br>
+                                <i class="fas fa-shield-alt text-success"></i>
+                                <small class="text-success">使用済み帳簿は自動的に除外されます</small>
                             </div>
                         {% endif %}
                         {% if not land_ledgers %}


### PR DESCRIPTION
<img width="657" height="464" alt="image" src="https://github.com/user-attachments/assets/69f0e5fc-bef7-486d-8891-88fe07c16601" />

# 使用済み帳簿除外機能のテストシナリオ
## 目的
硬度データ関連付け時に、既に他の硬度データに使用されている帳簿が選択肢から除外されることを確認する
## 事前準備
### データ状態の確認
1. **利用可能な帳簿データ**
    - ID 1: 静岡農園A1 (2022年夏期) - 分析番号2206064
    - ID 2: 静岡農園A1 (2022年秋期) - 分析番号2206065
    - ID 3: 静岡農園A1 (2023年春期) - 分析番号2206073
    - ID 4: 静岡農園A2 (2023年春期) - 分析番号2206074
    - ID 5: 静岡農園A2 (2023年夏期) - 分析番号2206075

2. **硬度測定データ**
    - 複数のフォルダ（例：静岡ススムA1_20230701、静岡ススムA2_20230701）
    - 各フォルダに未処理の硬度測定データが存在

## テストシナリオ
### シナリオ1: 初回関連付け - 全帳簿が選択可能
**目的**: まだ使用されていない状態で全帳簿が表示されることを確認
**手順**:
1. 硬度データ関連付け画面にアクセス
2. 任意のフォルダグループ（例：静岡ススムA1_20230701）を選択
3. 帳簿選択画面に遷移

**期待結果**:
- 帳簿選択ドロップダウンに5件の帳簿すべてが表示される
- フォルダ名「静岡ススムA1」に適した帳簿（静岡農園A1関連）が優先表示される
- 説明文「使用済み帳簿は自動的に除外されます」が表示される

### シナリオ2: 帳簿を使用済みに設定
**目的**: テスト用に帳簿を使用済み状態にする
**手順**:
1. シナリオ1の続きで、帳簿ID 1（静岡農園A1 2022年夏期）を選択
2. 「この帳簿で処理実行」ボタンをクリック
3. 処理完了を確認

**期待結果**:
- 処理完了メッセージが表示される
- 硬度データ関連付け一覧画面に戻る
- 処理済みグループ数が1増加している

### シナリオ3: 使用済み帳簿の除外確認
**目的**: 使用済み帳簿が選択肢から除外されることを確認
**手順**:
1. 別のフォルダグループ（例：静岡ススムA2_20230701）を選択
2. 帳簿選択画面に遷移
3. 帳簿選択ドロップダウンの内容を確認

**期待結果**:
- ✅ **帳簿ID 1が選択肢に表示されない**（使用済みのため除外）
- 残り4件の帳簿（ID 2, 3, 4, 5）のみが表示される
- フォルダ名「静岡ススムA2」に適した帳簿（静岡農園A2関連）が優先表示される
- 説明文「使用済み帳簿は自動的に除外されます」が表示される

### シナリオ4: 複数帳簿使用後の確認
**目的**: 複数の帳簿が使用済みになった場合の動作確認
**手順**:
1. シナリオ3で帳簿ID 4（静岡農園A2 2023年春期）を選択して処理実行
2. さらに別のフォルダがあれば、追加で処理
3. 新しいフォルダグループで帳簿選択画面を確認

**期待結果**:
- 使用済み帳簿（ID 1, 4）が選択肢から除外される
- 未使用帳簿（ID 2, 3, 5）のみが表示される
- 処理済みグループ数が適切にカウントされている

### シナリオ5: 帳簿不足時の表示確認
**目的**: すべての帳簿が使用済みになった場合の動作確認
**手順**:
1. 残りの帳簿をすべて使用済みにする（可能であれば）
2. 新しいフォルダグループで帳簿選択画面を確認

**期待結果**:
- 帳簿選択ドロップダウンが空になる
- 警告メッセージ「このフォルダに適した帳簿が見つかりません」が表示される
- 「新規帳簿作成」ボタンが利用可能

## 視覚的確認ポイント
### ✅ 主要確認項目
- **帳簿リスト変化**: 処理前後での選択肢数の変化
- **除外メッセージ**: 緑色のシールドアイコン付き説明文
- **警告表示**: 帳簿不足時の黄色い警告ボックス
- **進捗表示**: 右上の「X/Y 完了」バッジの更新

### ✅ 操作確認項目
- 使用済み帳簿を選択しようとしてもドロップダウンに存在しない
- フォルダ名による絞り込みが正常に動作する
- 処理完了後の画面遷移が正常

## 境界値テスト
### エッジケース
1. **同時処理**: 複数ユーザーが同じ帳簿を選択しようとした場合
2. **データ不整合**: 手動でDBを操作して land_ledger が設定された場合
3. **フォルダ名マッチング**: 特殊文字を含むフォルダ名での動作

## 合格基準
- ✅ 使用済み帳簿が視覚的に選択肢から消える
- ✅ フォルダ名による絞り込み機能が維持される
- ✅ 適切な説明文とアイコンが表示される
- ✅ 既存の処理フローに影響しない
- ✅ 帳簿不足時に適切な警告が表示される

このテストシナリオにより、業務ルール「各帳簿は特定クライアントの特定時期の唯一データ」が技術的に担保されることを確認できます。
