### PR TITLE
RSS取得処理の堅牢化：ネットワークエラーおよびパース失敗時のハンドリング追加

### DIFF
--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -324,11 +324,12 @@ class OpenAIRagChatService(BaseChatService):
             / "lib/llm/pdf_sample/令和4年版少子化社会対策白書全体版（PDF版）.pdf"
         )
         dataloader = PdfDataloader(str(file_path))
-        response_dict = OpenAILlmRagService(
+        rag_service = OpenAILlmRagService(
             model=self.config.model,
             api_key=self.config.api_key,
-            documents=dataloader.data,
-        ).retrieve_answer(user_message.to_message())
+        )
+        rag_service.upsert_documents(dataloader.data)
+        response_dict = rag_service.retrieve_answer(user_message.to_message())
 
         user_message.role = RoleType.ASSISTANT
         user_message.content = response_dict["answer"]


### PR DESCRIPTION
### 概要
外部サービス（RSS、LLM API）への依存箇所において、エラーハンドリングの不足や不適切な設定によりシステムがクラッシュする問題が発生していました。本改修により、これらの処理の堅牢性を向上させ、安定した動作を確保しました。

### 変更内容

#### 1. RSS取得処理の堅牢化（ベトナム株情報ページ）
- **エラーハンドリング強化**: `requests.exceptions.RequestException` を個別にキャッチし、ネットワークエラーの詳細をログに記録するように修正しました。
- **データ妥当性チェック**: `feedparser` の `bozo` ビットを確認し、不完全なXMLデータを受信した際の警告ログ出力を追加しました。
- **フォールバック処理**: 取得失敗時にページ全体がクラッシュ（500エラー）しないよう、空データと現在時刻を返却する安全なフォールバック処理を導入しました。

#### 2. LLMチャット機能の500エラー修正
- **RAGサービス呼び出しの修正**: `OpenAIRagChatService` において `OpenAILlmRagService` をインスタンス化する際の引数エラー（`documents` 引数の誤用）を修正しました。正しい手順（インスタンス化 -> `upsert_documents` -> `retrieve_answer`）に変更しています。

#### 3. その他
- `get_rss_feed` の docstring に `bozo` ビットに関する技術的な注釈を追記しました。

### 確認事項
- [x] RSS取得失敗時（オフライン等）にベトナム株ページが正常に表示されること
- [x] LLMチャット（OpenAIGpt, Gemini, OpenAIRag等）で500エラーが出ずに回答が返ってくること
- [x] エラー発生時に適切なログが出力されていること