### PR TITLE
本番環境（パス・権限）の最適化

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,13 @@ python manage.py migrate
 # 5. 書き込みディレクトリの権限設定
 sudo chmod -R 775 /var/www/html/portfolio/media /var/www/html/portfolio/static
 
-# 6. サービスの再起動
+# 6. LLM/RAG 関連の権限設定 (ChromaDB)
+# ※ 暫定的にプロジェクトルート配下で運用しますが、将来的に適切な永続化パスを検討してください
+sudo mkdir -p /var/www/html/portfolio/chroma_db
+sudo chown -R www-data:www-data /var/www/html/portfolio/chroma_db
+sudo chmod -R 775 /var/www/html/portfolio/chroma_db
+
+# 7. サービスの再起動
 sudo systemctl restart apache2
 sudo tail -n 200 /var/log/apache2/error.log
 ```

--- a/lib/llm/service/completion.py
+++ b/lib/llm/service/completion.py
@@ -419,6 +419,12 @@ class OpenAILlmRagService(LlmService):
 
         # Chroma DB の設定
         persist_path = persist_directory or os.getenv("CHROMA_DB_PATH", "./chroma_db")
+        # 相対パスの場合は BASE_DIR からの絶対パスに変換
+        if not os.path.isabs(persist_path):
+            from config.settings import BASE_DIR
+
+            persist_path = str(Path(BASE_DIR) / persist_path)
+
         try:
             # パスが有効か（書き込み可能か）を事前にチェック
             test_path = Path(persist_path).resolve()


### PR DESCRIPTION
#### 3. 本番環境（WSGI/Apache）向けの最適化
- **Chroma DB パス解決**: 相対パス指定時にルートディレクトリを参照して権限エラーになる問題を防ぐため、プロジェクトルート（`BASE_DIR`）を基点とした絶対パスに自動変換するロジックを追加。
- **README.md の更新**:
    - 書き込み権限設定を「Django標準」と「LLM/RAG（ChromaDB）用」に分割。
    - 暫定的な相対パス運用に関する注釈（将来的なパス検討の必要性）を追記。