### PR TITLE
docs(qiita): HSTS を追記して HTTPS 運用を補強（ネットde診断の指摘に基づく）

### DIFF
--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -585,28 +585,11 @@ $ sudo systemctl restart apache2
 - 適用前: ユーザーが http:// でアクセスしたり、中間者攻撃で HTTP にダウングレードされると、平文通信が成立しうる。初回 HTTP アクセス時はブラウザ側に「今後もHTTPSを使う」記憶は残らない。
 - 適用後: 一度でも HTTPS 応答で HSTS を受け取ったブラウザは、以後そのドメイン（`includeSubDomains` 指定時はサブドメインも）へのアクセスを強制的に HTTPS 化。HTTP ダウングレード攻撃やクッキー漏洩のリスクを大幅に低減できる。
 
-HTTPS 応答時にブラウザへ「今後は常に HTTPS を使う」ことを指示します。まずは Apache の `headers` モジュールを有効化し、`default-ssl.conf` の `<VirtualHost *:443>` ブロック内にヘッダを追加します。
+HTTPS 応答時にブラウザへ「今後は常に HTTPS を使う」ことを指示します。まずは Apache の `headers` モジュールを有効化します。
 
 ```bash:console
 $ sudo a2enmod headers
 $ sudo systemctl reload apache2
-
-# HSTS ヘッダを 443 側の vhost に追加
-$ sudo vi /etc/apache2/sites-available/default-ssl.conf
-```
-
-```diff:/etc/apache2/sites-available/default-ssl.conf
- <VirtualHost *:443>
-   ...
-   SSLEngine on
-   SSLCertificateFile      /etc/letsencrypt/live/www.henojiya.net/cert.pem
-   SSLCertificateKeyFile   /etc/letsencrypt/live/www.henojiya.net/privkey.pem
-   SSLCertificateChainFile /etc/letsencrypt/live/www.henojiya.net/chain.pem
-
-   # HSTS: 1年 + サブドメイン含む + preload（運用に応じて検討）
- + Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-   ...
- </VirtualHost>
 ```
 
 ```bash:console
@@ -672,7 +655,7 @@ $ curl -I --resolve www.henojiya.net:443:127.0.0.1 https://www.henojiya.net/ | g
 ```
 
 > メモ
-> - すでに `X-Frame-Options` など他のセキュリティヘッダが出ているのに HSTS だけ出ない場合、実応答している vhost が `000-default-le-ssl.conf` で、`default-ssl.conf` の設定が使われていない可能性が高いです。
+> - すでに `X-Frame-Options` など他のセキュリティヘッダが出ているのに HSTS だけ出ない場合、実応答している vhost が `000-default-le-ssl.conf` で、他のSSL設定ファイル（例: default-ssl.conf）は使われていない可能性が高いです。
 > - preload を当面外す場合は `; preload` を省いてください（`max-age=31536000; includeSubDomains` まで）。
 
 ### 確認

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -576,7 +576,6 @@ $ sudo vi /etc/apache2/sites-available/default-ssl.conf
 $ sudo systemctl restart apache2
 ```
 
-
 ### 確認
 
 ```bash:console

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -690,12 +690,9 @@ $ sudo chmod 755 /root/certbot.sh
 
 前提: Let’s Encrypt を `--apache` で導入済み。HTTPS 応答は `/etc/apache2/sites-available/000-default-le-ssl.conf` の vhost が担う想定。
 
-\0) `headers` モジュールを有効化（`Header` ディレクティブでHTTPヘッダを注入・変更するためのApache拡張）
+#### 0. `headers` モジュールを有効化（`Header` ディレクティブでHTTPヘッダを注入・変更するためのApache拡張）
 
 `mod_headers` は、Apache がやり取りする HTTP ヘッダをサーバ側で「注入（injection）/書き換え」できる仕組みです。たとえば、ブラウザにセキュリティ方針を伝える各種ヘッダ（HSTS/Content-Security-Policy/Referrer-Policy など）をサーバが付け足すのに使います。本手順では HSTS ヘッダ（`Strict-Transport-Security`）をレスポンスに付与するために必要です。無効のままだと `Header ...` 行が効きません。
-
-補足（“ヘッダに注入する”イメージ）
-- Webページの本文にトラッキングタグ（例: `<!-- Global site tag (gtag.js) - Google Analytics -->`）を埋め込むのと似た発想ですが、こちらは「本文（HTML）」ではなく「HTTPレスポンスのヘッダ」にポリシー情報をサーバ側で差し込むイメージです。ブラウザはヘッダを先に解釈するため、セキュリティ制御（HTTPS強制や参照ポリシーなど）を確実に適用できます。
 
 ```bash:console
 $ sudo a2enmod headers

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -576,87 +576,6 @@ $ sudo vi /etc/apache2/sites-available/default-ssl.conf
 $ sudo systemctl restart apache2
 ```
 
-### HSTS（HTTP Strict Transport Security）の有効化（推奨）
-
-なぜ必要か（背景）
-- 外部診断サービス「ネットde診断」の指摘により、HTTPS 運用をより強固にする必要が判明。本手順でサーバを補強する（初回アクセスやダウングレード攻撃に対し、ブラウザ側で恒久的に HTTPS を強制させる HSTS を導入）。
-
-目的（適用前/適用後の違い）
-- 適用前: ユーザーが http:// でアクセスしたり、中間者攻撃で HTTP にダウングレードされると、平文通信が成立しうる。初回 HTTP アクセス時はブラウザ側に「今後もHTTPSを使う」記憶は残らない。
-- 適用後: 一度でも HTTPS 応答で HSTS を受け取ったブラウザは、以後そのドメイン（`includeSubDomains` 指定時はサブドメインも）へのアクセスを強制的に HTTPS 化。HTTP ダウングレード攻撃やクッキー漏洩のリスクを大幅に低減できる。
-
-HTTPS 応答時にブラウザへ「今後は常に HTTPS を使う」ことを指示します。まずは Apache の `headers` モジュールを有効化します。
-
-```bash:console
-$ sudo a2enmod headers
-$ sudo systemctl reload apache2
-```
-
-```bash:console
-$ sudo apachectl -t               # 構文チェック（Syntax OK）
-$ sudo systemctl reload apache2   # 反映
-```
-
-> Note（preload について）
-> - `preload` を付けると、Chrome 系の HSTS Preload List 登録前提の強い宣言になります。全サブドメインで常時 HTTPS を維持できることが要件です。
-> - 迷う場合はまず `max-age=31536000; includeSubDomains` までで開始し、体制が整ってから `preload` を追加しても構いません。
-
-確認（サーバ上）:
-
-```bash:console
-$ curl -I https://www.henojiya.net/ | grep -i strict-transport-security || echo NG
-```
-
-#### Let’s Encrypt 前提環境での vhost 確認と HSTS 追記（000-default-le-ssl.conf 版）
-
-Let’s Encrypt を `--apache` で導入している環境では、`/etc/apache2/sites-available/000-default-le-ssl.conf` が作成・有効化され、実際の HTTPS 応答はこの vhost が担う構成になっていることが多いです。`default-ssl.conf` に追記しても効かない場合は、こちらに HSTS を追加します。
-
-1) まず、対象ファイルが存在し有効化されているか確認
-
-```bash:console
-$ ls -l /etc/apache2/sites-enabled/
-$ sudo test -f /etc/apache2/sites-available/000-default-le-ssl.conf && echo OK || echo NG
-```
-
-2) 000-default-le-ssl.conf を開き、`<VirtualHost *:443>` ブロック内に HSTS を追加
-
-```bash:console
-$ sudo vi /etc/apache2/sites-available/000-default-le-ssl.conf
-```
-
-追記位置の例（Let’s Encrypt の推奨設定 `Include /etc/letsencrypt/options-ssl-apache.conf` の直後に入れると分かりやすい）:
-
-```diff:/etc/apache2/sites-available/000-default-le-ssl.conf
- <IfModule mod_ssl.c>
- <VirtualHost *:443>
-   ServerName www.henojiya.net
-   DocumentRoot /var/www/html
-   ...
-   SSLCertificateFile /etc/letsencrypt/live/www.henojiya.net/fullchain.pem
-   SSLCertificateKeyFile /etc/letsencrypt/live/www.henojiya.net/privkey.pem
-   Include /etc/letsencrypt/options-ssl-apache.conf
-
- + Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
- </VirtualHost>
- </IfModule>
-```
-
-3) 構文チェックと反映
-
-```bash:console
-$ sudo apachectl -t
-$ sudo systemctl reload apache2
-```
-
-4) 動作確認（SNI を固定してローカルの 443 を直接叩く）
-
-```bash:console
-$ curl -I --resolve www.henojiya.net:443:127.0.0.1 https://www.henojiya.net/ | grep -i strict-transport-security || echo NG
-```
-
-> メモ
-> - すでに `X-Frame-Options` など他のセキュリティヘッダが出ているのに HSTS だけ出ない場合、実応答している vhost が `000-default-le-ssl.conf` で、他のSSL設定ファイル（例: default-ssl.conf）は使われていない可能性が高いです。
-> - preload を当面外す場合は `; preload` を省いてください（`max-age=31536000; includeSubDomains` まで）。
 
 ### 確認
 
@@ -759,6 +678,82 @@ $ sudo chmod 755 /root/certbot.sh
 
 > Note:
 > 定期実行（cron への登録）は、下記の「Cron（タスクスケジューラ）」セクションで設定します。
+
+### HSTS の設定（必ず HTTPS でアクセスさせる）
+
+なぜ必要か（背景）
+- 外部診断サービス「ネットde診断」の指摘により、HTTPS 運用をより強固にする必要が判明。本手順でサーバを補強する（初回アクセスやダウングレード攻撃に対し、ブラウザ側で恒久的に HTTPS を強制させる HSTS を導入）。
+
+目的（適用前/適用後の違い）
+- 適用前: ユーザーが http:// でアクセスしたり、中間者攻撃で HTTP にダウングレードされると、平文通信が成立しうる。初回 HTTP アクセス時はブラウザ側に「今後もHTTPSを使う」記憶は残らない。
+- 適用後: 一度でも HTTPS 応答で HSTS を受け取ったブラウザは、以後そのドメイン（`includeSubDomains` 指定時はサブドメインも）へのアクセスを強制的に HTTPS 化。HTTP ダウングレード攻撃やクッキー漏洩のリスクを大幅に低減できる。
+
+前提: Let’s Encrypt を `--apache` で導入済み。HTTPS 応答は `/etc/apache2/sites-available/000-default-le-ssl.conf` の vhost が担う想定。
+
+\0) `headers` モジュールを有効化（`Header` ディレクティブでHTTPヘッダを注入・変更するためのApache拡張）
+
+`mod_headers` は、Apache がやり取りする HTTP ヘッダをサーバ側で「注入（injection）/書き換え」できる仕組みです。たとえば、ブラウザにセキュリティ方針を伝える各種ヘッダ（HSTS/Content-Security-Policy/Referrer-Policy など）をサーバが付け足すのに使います。本手順では HSTS ヘッダ（`Strict-Transport-Security`）をレスポンスに付与するために必要です。無効のままだと `Header ...` 行が効きません。
+
+補足（“ヘッダに注入する”イメージ）
+- Webページの本文にトラッキングタグ（例: `<!-- Global site tag (gtag.js) - Google Analytics -->`）を埋め込むのと似た発想ですが、こちらは「本文（HTML）」ではなく「HTTPレスポンスのヘッダ」にポリシー情報をサーバ側で差し込むイメージです。ブラウザはヘッダを先に解釈するため、セキュリティ制御（HTTPS強制や参照ポリシーなど）を確実に適用できます。
+
+```bash:console
+$ sudo a2enmod headers
+$ sudo systemctl reload apache2
+```
+
+Let’s Encrypt を `--apache` で導入している環境では、`/etc/apache2/sites-available/000-default-le-ssl.conf` が作成・有効化され、実際の HTTPS 応答はこの vhost が担う構成になっていることが多いです。`default-ssl.conf` に追記しても効かない場合は、こちらに HSTS を追加します。
+
+#### 1. まず、対象ファイルが存在し有効化されているか確認
+
+```bash:console
+$ ls -l /etc/apache2/sites-enabled/
+$ sudo test -f /etc/apache2/sites-available/000-default-le-ssl.conf && echo OK || echo NG
+```
+
+#### 2. 000-default-le-ssl.conf を開き、`<VirtualHost *:443>` ブロック内に HSTS を追加
+
+```bash:console
+$ sudo vi /etc/apache2/sites-available/000-default-le-ssl.conf
+```
+
+追記位置の例（Let’s Encrypt の推奨設定 `Include /etc/letsencrypt/options-ssl-apache.conf` の直後に入れると分かりやすい）:
+
+```diff:/etc/apache2/sites-available/000-default-le-ssl.conf
+ <IfModule mod_ssl.c>
+ <VirtualHost *:443>
+   ServerName www.henojiya.net
+   DocumentRoot /var/www/html
+   ...
+   SSLCertificateFile /etc/letsencrypt/live/www.henojiya.net/fullchain.pem
+   SSLCertificateKeyFile /etc/letsencrypt/live/www.henojiya.net/privkey.pem
+   Include /etc/letsencrypt/options-ssl-apache.conf
+
+ + Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+ </VirtualHost>
+ </IfModule>
+```
+
+#### 3. 構文チェックと反映
+
+```bash:console
+$ sudo apachectl -t
+$ sudo systemctl reload apache2
+```
+
+#### 4. 動作確認（SNI を固定してローカルの 443 を直接叩く）
+
+```bash:console
+$ curl -I --resolve www.henojiya.net:443:127.0.0.1 https://www.henojiya.net/ \
+  | GREP_COLORS='ms=01;31' grep -i --color=always strict-transport-security || echo NG
+```
+
+- “Strict-Transport-Security” の文字列が赤字でハイライト表示されたらOK（ヘッダ付与を検出）。
+- 文字色は環境により異なる場合がありますが、色付きでハイライトされれば検出されています。
+
+> メモ
+> - すでに `X-Frame-Options` など他のセキュリティヘッダが出ているのに HSTS だけ出ない場合、実応答している vhost が `000-default-le-ssl.conf` で、他のSSL設定ファイル（例: default-ssl.conf）は使われていない可能性が高いです。
+> - preload を当面外す場合は `; preload` を省いてください（`max-age=31536000; includeSubDomains` まで）。
 
 ## MySQL8
 


### PR DESCRIPTION
### 概要
- ネットde診断の指摘を受け、HSTS（HTTP Strict Transport Security）を記事に追記し、HTTPS 運用を補強します。
- 本PRは Qiita 記事に対応するリポジトリ内ドキュメント（docs/qiita/centos_to_ubuntu_setup.md）の更新です。

### 変更点（What）
- HSTS 追加手順を「HTTPS 化（Let’s Encrypt 証明書の適用と Apache の設定）」セクション直下に追記。
  - headers モジュールの有効化（a2enmod headers → reload）
  - /etc/apache2/sites-available/default-ssl.conf の <VirtualHost *:443> に Strict-Transport-Security を追加する差分例
  - 構文チェック（apachectl -t）と反映（systemctl reload apache2）
  - 動作確認コマンド（curl -I https://… | grep -i strict-transport-security）
- 背景/目的の明記
  - なぜ: 「ネットde診断」の指摘により、初回アクセスやダウングレード攻撃に対する強化が必要 → 本手順でサーバを補強
  - 目的: 適用前/適用後の違い（HTTPダウングレード時に平文通信が成立しうる → HSTS配布後はブラウザが強制HTTPS）
- preload の注意事項をNoteとして追記（全サブドメイン常時HTTPSが前提。迷う場合は preload なしで開始も可）。

### 理由（Why）
- ブラウザ側に“今後は必ずHTTPSを使う”というフットプリントを残し、HTTPダウングレード攻撃やクッキー漏洩のリスクを低減するため。
- 外部診断の指摘事項を解消し、セキュリティベースラインを底上げするため。

### 影響範囲（Impact）
- ドキュメントのみの変更。アプリケーションコード・挙動への影響はありません。
- 実運用では、Apache の headers モジュールが無効な環境では有効化が必要です。

### 動作確認（How to Test）
1) 既にHTTPS応答が出せる状態で、443 vhost に HSTS を追加。
2) apachectl -t で Syntax OK を確認 → systemctl reload apache2。
3) サーバで `curl -I https://<domain>/ | grep -i strict-transport-security` を実行し、ヘッダが付与されていることを確認。
4) ブラウザのDevToolsでもResponse Headersに表示されることを確認。

### 備考 / Follow-ups
- preload を本番で採用するかは運用ポリシーに依存します。現状は例として記載。必要に応じて記事側の文言を“preload なし”に変更可能です。
- 80→443 の恒久リダイレクト手順は記事の別章に既に記載。必要なら同セクション内にも再掲可能です。
```

### 差分ファイル
- docs/qiita/centos_to_ubuntu_setup.md

### ブランチ
- feature/qiita-hsts-update

PR作成URL
- https://github.com/duri0214/portfolio/pull/new/feature/qiita-hsts-update