### PR TITLE
[feature] llmから型返し｜LLM Typed Response（ChatResult）対応 (#465)

### DIFF
--- a/lib/llm/service/completion.py
+++ b/lib/llm/service/completion.py
@@ -21,6 +21,7 @@ from lib.llm.valueobject.completion import (
     StreamResponse,
     RagDocument,
     RagResponse,
+    ChatResult,
 )
 from lib.llm.valueobject.config import OpenAIGptConfig, GeminiConfig
 
@@ -73,6 +74,20 @@ class LlmService(ABC):
 
         Returns:
             LLMからの応答
+        """
+        pass
+
+
+class BaseLLMTask(ABC):
+    """
+    全てのLLMタスクが守るべきインターフェース。
+    特定の入力に対して構造化された ChatResult を返すことを強制します。
+    """
+
+    @abstractmethod
+    def execute(self, *args, **kwargs) -> ChatResult:
+        """
+        タスクを実行し、構造化されたレスポンスを返します。
         """
         pass
 

--- a/lib/llm/service/completion.py
+++ b/lib/llm/service/completion.py
@@ -125,20 +125,16 @@ class LlmCompletionService(LlmService):
 
     def retrieve_answer(
         self, chat_history: list[Message], max_messages: int = 5
-    ) -> ChatCompletion:
+    ) -> ChatResult:
         """
-        チャット履歴から回答を取得します。
-
-        注意: この機能はトークン数ベースの制限から単純なメッセージ件数ベースの制限に移行したため、
-        内部処理が形骸化されました。現在はmax_messagesパラメータを使用して直近の指定件数のみを
-        保持する方式に置き換えられています。
+        チャット履歴から回答を取得し、構造化された ChatResult として返します。
 
         Args:
             chat_history (list[Message]): チャット履歴メッセージのリスト
             max_messages (int, optional): 保持する最大メッセージ件数。デフォルト値は5。
 
         Returns:
-            ChatCompletion: OpenAI形式のチャット完了レスポンス
+            ChatResult: 構造化されたチャット完了レスポンス
         """
         cut_down_history = cut_down_chat_history(chat_history, max_messages)
 
@@ -146,9 +142,20 @@ class LlmCompletionService(LlmService):
         if not cut_down_history:
             raise ValueError("Chat history cannot be empty")
 
-        return self.client.chat.completions.create(
+        response = self.client.chat.completions.create(
             model=self.config.model,
             messages=[x.to_dict() for x in cut_down_history],
+        )
+
+        content = response.choices[0].message.content or ""
+
+        return ChatResult(
+            answer=content,
+            metadata={
+                "model": response.model,
+                "usage": response.usage.to_dict() if response.usage else {},
+                "finish_reason": response.choices[0].finish_reason,
+            },
         )
 
 

--- a/lib/llm/service/completion.py
+++ b/lib/llm/service/completion.py
@@ -10,7 +10,6 @@ from dotenv import load_dotenv
 from openai import OpenAI
 from openai.types import ImagesResponse
 from openai.types.chat import (
-    ChatCompletion,
     ChatCompletionSystemMessageParam,
     ChatCompletionUserMessageParam,
 )
@@ -151,6 +150,7 @@ class LlmCompletionService(LlmService):
 
         return ChatResult(
             answer=content,
+            explanation=None,
             metadata={
                 "model": response.model,
                 "usage": response.usage.to_dict() if response.usage else {},
@@ -525,6 +525,7 @@ class OpenAILlmRagService(LlmService):
         if not selected:
             return RagResponse(
                 answer="該当する資料が見つかりませんでした。",
+                explanation=None,
                 sources="",
                 source_documents=[],
                 warning=None,
@@ -566,6 +567,7 @@ class OpenAILlmRagService(LlmService):
 
         return RagResponse(
             answer=answer,
+            explanation=None,
             sources=sources,
             source_documents=selected,
             warning=warning,

--- a/lib/llm/valueobject/completion.py
+++ b/lib/llm/valueobject/completion.py
@@ -19,7 +19,7 @@ class Message:
 
     Attributes:
         role (RoleType): メッセージを送信した役割（ユーザ、アシスタント、システム）。
-        content (str): メッセージ内容。
+        content (str): メッセージの内容。
     """
 
     role: RoleType
@@ -29,10 +29,13 @@ class Message:
         return {"role": self.role.value, "content": self.content}
 
 
-@dataclass
-class RagDocument:
+class RagDocument(BaseModel):
     """
     RAGの検索結果ドキュメントを保持するVO。
+
+    Attributes:
+        page_content (str): 抽出されたドキュメントの本文。
+        metadata (dict[str, Any]): ドキュメントの出典情報（source, fileなど）。
     """
 
     page_content: str
@@ -42,6 +45,11 @@ class RagDocument:
 class ChatResult(BaseModel):
     """
     LLMからの構造化されたレスポンスを格納する共通のデータ構造。
+
+    Attributes:
+        answer (str): LLMの回答メインコンテンツ。
+        explanation (str | None): 回答の根拠や補足説明。
+        metadata (dict[str, Any]): トークン数、モデル名、ステータスなどの付随情報。
     """
 
     answer: str = Field(..., description="LLMの回答メインコンテンツ")
@@ -54,6 +62,12 @@ class ChatResult(BaseModel):
 class RagResponse(ChatResult):
     """
     RAGの回答結果を保持するVO。
+
+    Attributes:
+        answer (str): 生成された回答。
+        sources (str): 出典情報（人間可読な形式）。
+        source_documents (list[RagDocument]): 検索によって取得されたソースドキュメントのリスト。
+        warning (str | None): 文字数超過などの警告メッセージ。
     """
 
     sources: str = Field(..., description="回答のソース情報")
@@ -81,7 +95,13 @@ FinishReason = Literal[
 
 @dataclass
 class StreamResponse:
-    """ストリームで返すレスポンスをラップするVO"""
+    """
+    ストリームで返すレスポンスをラップするVO。
+
+    Attributes:
+        content (str | None): 逐次生成される回答の一部（delta.content）。
+        finish_reason (FinishReason | None): 終了理由（stop, lengthなど）。
+    """
 
     content: str | None  # delta.content
     finish_reason: FinishReason | None  # 終了理由 (e.g., stop, length, etc.)

--- a/lib/llm/valueobject/completion.py
+++ b/lib/llm/valueobject/completion.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Literal, Any
 
+from pydantic import BaseModel, Field
+
 
 class RoleType(Enum):
     USER = "user"
@@ -78,3 +80,15 @@ class StreamResponse:
             "finish_reason": self.finish_reason,
         }
         return json.dumps(serialized_data)
+
+
+class ChatResult(BaseModel):
+    """
+    LLMからの構造化されたレスポンスを格納する共通のデータ構造。
+    """
+
+    answer: str = Field(..., description="LLMの回答メインコンテンツ")
+    explanation: str | None = Field(None, description="回答の根拠・解説")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="トークン数やステータスなどの付随情報"
+    )

--- a/lib/llm/valueobject/completion.py
+++ b/lib/llm/valueobject/completion.py
@@ -39,16 +39,28 @@ class RagDocument:
     metadata: dict[str, Any]
 
 
-@dataclass
-class RagResponse:
+class ChatResult(BaseModel):
+    """
+    LLMからの構造化されたレスポンスを格納する共通のデータ構造。
+    """
+
+    answer: str = Field(..., description="LLMの回答メインコンテンツ")
+    explanation: str | None = Field(None, description="回答の根拠・解説")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="トークン数やステータスなどの付随情報"
+    )
+
+
+class RagResponse(ChatResult):
     """
     RAGの回答結果を保持するVO。
     """
 
-    answer: str
-    sources: str
-    source_documents: list[RagDocument]
-    warning: str | None = None
+    sources: str = Field(..., description="回答のソース情報")
+    source_documents: list[RagDocument] = Field(
+        ..., description="参照したドキュメントのリスト"
+    )
+    warning: str | None = Field(None, description="警告メッセージ")
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -80,15 +92,3 @@ class StreamResponse:
             "finish_reason": self.finish_reason,
         }
         return json.dumps(serialized_data)
-
-
-class ChatResult(BaseModel):
-    """
-    LLMからの構造化されたレスポンスを格納する共通のデータ構造。
-    """
-
-    answer: str = Field(..., description="LLMの回答メインコンテンツ")
-    explanation: str | None = Field(None, description="回答の根拠・解説")
-    metadata: dict[str, Any] = Field(
-        default_factory=dict, description="トークン数やステータスなどの付随情報"
-    )

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -52,7 +52,7 @@ def get_prompt(gender: Gender) -> str:
         - 私は黒い服を着て、赤い手袋を持っている。夜には立っているが、朝になると寝る。何でしょう？
 
         #判定結果例
-        [{{"skill": "論理的思考力", "score": 50, "judge": "不合格"}},{{"skill": "洞察力", "score": 96, "judge": "合格"}}]
+        [{"viewpoint": "論理的思考力", "score": 50, "judge": "不合格"},{"viewpoint": "洞察力", "score": 96, "judge": "合格"}]
     """
 
 

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -57,22 +57,27 @@ def get_prompt(gender: Gender) -> str:
 
 
 def create_initial_prompt(user_message: MessageDTO, gender: Gender) -> list[MessageDTO]:
-    chat_history = [
-        MessageDTO(
-            user=user_message.user,
-            role=RoleType.SYSTEM,
-            content=get_prompt(gender),
-            invisible=True,
-        ),
-        MessageDTO(
-            user=user_message.user,
-            role=RoleType.USER,
-            content=f"なぞなぞスタート（{user_message.content}）",
-            invisible=False,
-        ),
-    ]
-    ChatLogRepository.bulk_insert(chat_history)
-    return chat_history
+    """
+    初期プロンプト（システムメッセージと初回のユーザーメッセージ）を生成します。
+    システムメッセージはDBに保存せず、初回ユーザーメッセージのみ保存します。
+    """
+    system_message = MessageDTO(
+        user=user_message.user,
+        role=RoleType.SYSTEM,
+        content=get_prompt(gender),
+        invisible=True,
+    )
+    first_user_message = MessageDTO(
+        user=user_message.user,
+        role=RoleType.USER,
+        content=f"なぞなぞスタート（{user_message.content}）",
+        invisible=False,
+    )
+    # ユーザーメッセージのみDBに保存
+    ChatLogRepository.insert(first_user_message)
+
+    # システムメッセージを先頭に含めて返す
+    return [system_message, first_user_message]
 
 
 def get_chat_history(
@@ -87,10 +92,12 @@ def get_chat_history(
     2. チャット履歴が存在する場合、それを取得します。
     3. チャット履歴が空であり、`gender` が指定されている場合は、
        なぞなぞモード用の初期プロンプトを生成し挿入します。
-    4. 最新のユーザーメッセージを履歴に追加します。
+    4. 既存の履歴がある場合は、システムメッセージを先頭に動的に追加します。
+    5. 最新のユーザーメッセージを履歴に追加します。
 
     **特記事項**:
     初期プロンプト挿入は、なぞなぞモードの特別仕様です。このプロンプトには挨拶や、なぞなぞの開始案内が含まれます。
+    システムメッセージはDBには保存せず、LLMへのリクエスト時にのみ動的に追加されます。
 
     :param user_message: 現在処理対象のユーザーからの入力メッセージ (MessageDTO)
     :param gender: なぞなぞモード用初期プロンプト生成のためのユーザーの性別（オプション）
@@ -101,6 +108,7 @@ def get_chat_history(
     if user_message.content is None:
         raise Exception("content is None")
 
+    # DBから履歴を取得（roleがstrで返ってくることを想定してRoleTypeで変換）
     chat_history = [
         MessageDTO(
             user=x.user, role=RoleType(x.role), content=x.content, invisible=False
@@ -109,8 +117,22 @@ def get_chat_history(
     ]
 
     if not chat_history and gender is not None:
+        # 初回：システムメッセージ（非保存）と初回ユーザーメッセージ（保存）を生成
         chat_history = create_initial_prompt(user_message=user_message, gender=gender)
     else:
+        # 2回目以降：既存の履歴にシステムメッセージが含まれていない場合は動的に追加
+        if gender is not None:
+            has_system = any(m.role == RoleType.SYSTEM for m in chat_history)
+            if not has_system:
+                system_message = MessageDTO(
+                    user=user_message.user,
+                    role=RoleType.SYSTEM,
+                    content=get_prompt(gender),
+                    invisible=True,
+                )
+                chat_history.insert(0, system_message)
+
+        # 最新のユーザーメッセージをDBに保存し、履歴に追加
         ChatLogRepository.insert(user_message)
         chat_history.append(user_message)
 

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -137,14 +137,14 @@ class ChatService(BaseChatService):
         # なぞなぞモードはgenderが与えられた場合に初期プロンプトを入れる
         self.chat_history = get_chat_history(user_message, gender)
 
-        response = LlmCompletionService(self.config).retrieve_answer(
+        chat_result = LlmCompletionService(self.config).retrieve_answer(
             [x.to_message() for x in self.chat_history]
         )
 
         return MessageDTO(
             user=user_message.user,
             role=RoleType.ASSISTANT,
-            content=response.choices[0].message.content,
+            content=chat_result.answer,
             invisible=False,
         )
 
@@ -193,8 +193,8 @@ class RiddleTask(BaseLLMTask):
         messages.append(eval_message)
 
         # LLM実行
-        response = LlmCompletionService(self.config).retrieve_answer(messages)
-        raw_content = response.choices[0].message.content
+        chat_result = LlmCompletionService(self.config).retrieve_answer(messages)
+        raw_content = chat_result.answer
 
         # 念のため、DBには非表示のユーザーメッセージを記録（履歴の整合性のため）
         invisible_user_message = MessageDTO(

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -148,20 +148,17 @@ class ChatService(BaseChatService):
             invisible=False,
         )
 
-    def evaluate(self, login_user: User):
-        """評価機能（Gemini/OpenAI共通）"""
+    def evaluate(self, login_user: User) -> str:
+        """
+        評価機能（Gemini/OpenAI共通）。
+        評価結果を RiddleResponse として取得し、箇条書きテキストを返します。
+        """
         # なぞなぞタスクを使用して構造化された評価結果を取得
         task = RiddleTask(self.config, self.chat_history)
         riddle_response = task.execute(login_user)
 
-        # 評価結果を保存
-        invisible_assistant_message = MessageDTO(
-            user=login_user,
-            role=RoleType.ASSISTANT,
-            content=riddle_response.model_dump_json(),
-            invisible=True,
-        )
-        ChatLogRepository.insert(invisible_assistant_message)
+        # 箇条書きテキストを生成して返す
+        return riddle_response.to_bullet_points()
 
 
 class RiddleTask(BaseLLMTask):
@@ -195,15 +192,6 @@ class RiddleTask(BaseLLMTask):
         # LLM実行
         chat_result = LlmCompletionService(self.config).retrieve_answer(messages)
         raw_content = chat_result.answer
-
-        # 念のため、DBには非表示のユーザーメッセージを記録（履歴の整合性のため）
-        invisible_user_message = MessageDTO(
-            user=login_user,
-            role=RoleType.USER,
-            content=eval_message.content,
-            invisible=True,
-        )
-        ChatLogRepository.insert(invisible_user_message)
 
         # パース処理
         try:

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -52,7 +52,7 @@ def get_prompt(gender: Gender) -> str:
         - 私は黒い服を着て、赤い手袋を持っている。夜には立っているが、朝になると寝る。何でしょう？
 
         #判定結果例
-        [{"viewpoint": "論理的思考力", "score": 50, "judge": "不合格"},{"viewpoint": "洞察力", "score": 96, "judge": "合格"}]
+        [{{"viewpoint": "論理的思考力", "score": 50, "judge": "不合格"}},{{"viewpoint": "洞察力", "score": 96, "judge": "合格"}}]
     """
 
 

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -1,4 +1,5 @@
 import os
+import json
 import secrets
 from abc import ABC, abstractmethod
 from io import BytesIO
@@ -17,12 +18,18 @@ from lib.llm.service.completion import (
     OpenAILlmTextToSpeech,
     OpenAILlmSpeechToText,
     OpenAILlmRagService,
+    BaseLLMTask,
 )
-from lib.llm.valueobject.completion import RoleType, StreamResponse
+from lib.llm.valueobject.completion import RoleType, StreamResponse, Message
 from lib.llm.valueobject.config import OpenAIGptConfig, GeminiConfig
 from lib.llm.valueobject.rag import PdfDataloader
 from llm_chat.domain.repository.chat import ChatLogRepository
-from llm_chat.domain.valueobject.chat import MessageDTO, Gender
+from llm_chat.domain.valueobject.chat import (
+    MessageDTO,
+    Gender,
+    RiddleResponse,
+    RiddleEvaluation,
+)
 
 
 def get_prompt(gender: Gender) -> str:
@@ -143,26 +150,90 @@ class ChatService(BaseChatService):
 
     def evaluate(self, login_user: User):
         """評価機能（Gemini/OpenAI共通）"""
-        invisible_user_message = MessageDTO(
-            user=login_user,
-            role=RoleType.USER,
-            content="評価結果をjsonで出力してください。フォーマットは判定結果例に従うこと",
-            invisible=True,
-        )
-        ChatLogRepository.insert(invisible_user_message)
-        self.chat_history.append(invisible_user_message)
+        # なぞなぞタスクを使用して構造化された評価結果を取得
+        task = RiddleTask(self.config, self.chat_history)
+        riddle_response = task.execute(login_user)
 
-        response = LlmCompletionService(self.config).retrieve_answer(
-            [x.to_message() for x in self.chat_history]
-        )
+        # 評価結果を保存
         invisible_assistant_message = MessageDTO(
             user=login_user,
             role=RoleType.ASSISTANT,
-            content=response.choices[0].message.content,
+            content=riddle_response.model_dump_json(),
             invisible=True,
         )
         ChatLogRepository.insert(invisible_assistant_message)
-        self.chat_history.append(invisible_user_message)
+
+
+class RiddleTask(BaseLLMTask):
+    """
+    なぞなぞの評価タスク。
+    LLMからの評価結果（JSON）をパースし、RiddleResponse型で返します。
+    """
+
+    def __init__(
+        self,
+        config: OpenAIGptConfig | GeminiConfig,
+        chat_history: list[MessageDTO],
+    ):
+        self.config = config
+        self.chat_history = chat_history
+
+    def execute(self, login_user: User) -> RiddleResponse:
+        """
+        評価プロンプトを送信し、結果を RiddleResponse に変換します。
+        """
+        # 評価用のユーザーメッセージ（非表示）
+        eval_message = Message(
+            role=RoleType.USER,
+            content="評価結果をjsonで出力してください。フォーマットは判定結果例に従うこと",
+        )
+
+        # メッセージ履歴を準備
+        messages = [x.to_message() for x in self.chat_history]
+        messages.append(eval_message)
+
+        # LLM実行
+        response = LlmCompletionService(self.config).retrieve_answer(messages)
+        raw_content = response.choices[0].message.content
+
+        # 念のため、DBには非表示のユーザーメッセージを記録（履歴の整合性のため）
+        invisible_user_message = MessageDTO(
+            user=login_user,
+            role=RoleType.USER,
+            content=eval_message.content,
+            invisible=True,
+        )
+        ChatLogRepository.insert(invisible_user_message)
+
+        # パース処理
+        try:
+            # LLMが ```json ... ``` で囲んでくる場合を考慮
+            cleaned_content = raw_content.strip()
+            if cleaned_content.startswith("```"):
+                lines = cleaned_content.splitlines()
+                if lines[0].startswith("```"):
+                    lines = lines[1:]
+                if lines[-1].startswith("```"):
+                    lines = lines[:-1]
+                cleaned_content = "\n".join(lines).strip()
+
+            eval_data = json.loads(cleaned_content)
+            # eval_data はリスト形式 [{...}, {...}] と想定
+            evaluations = [RiddleEvaluation(**item) for item in eval_data]
+
+            return RiddleResponse(
+                answer=raw_content,
+                evaluations=evaluations,
+                explanation="なぞなぞの評価結果です。",
+            )
+        except (json.JSONDecodeError, ValueError) as e:
+            # パース失敗時のフォールバックまたはエラーハンドリング
+            # ここで「残心」を持ってエラーを処理
+            return RiddleResponse(
+                answer=raw_content,
+                evaluations=[],
+                explanation=f"評価結果のパースに失敗しました: {str(e)}",
+            )
 
 
 class OpenAIChatStreamingService(BaseChatService):

--- a/llm_chat/domain/usecase/chat.py
+++ b/llm_chat/domain/usecase/chat.py
@@ -56,15 +56,14 @@ class LlmChatUseCase(UseCase):
         # なぞなぞはOpenAI/Gemini共通機能として扱う
         assistant_message = chat_service.generate(user_message, Gender(GenderType.MAN))
 
-        self.repository.insert(assistant_message)
-
         # なぞなぞの終端処理（共通機能）
         if "本日はなぞなぞにご参加いただき" in assistant_message.content:
-            chat_service.evaluate(login_user=user_message.user)
+            evaluation_text = chat_service.evaluate(login_user=user_message.user)
+            assistant_message.content += evaluation_text
+
+        self.repository.insert(assistant_message)
 
         return assistant_message
-
-
 
 
 class OpenAIGptStreamingUseCase(UseCase):

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -82,7 +82,9 @@ class Gender:
 
 class RiddleEvaluation(BaseModel):
     """
-    なぞなぞの各スキルに対する評価結果。
+    なぞなぞの各スキル（論理的思考力、洞察力など）に対する個別の評価結果を表す。
+
+    RiddleResponse の evaluations リストの要素として使用される、最小単位の評価データ。
     """
 
     skill: str = Field(..., description="評価スキル名（例: 論理的思考力、洞察力）")
@@ -92,7 +94,11 @@ class RiddleEvaluation(BaseModel):
 
 class RiddleResponse(ChatResult):
     """
-    なぞなぞタスクの最終的な構造化レスポンス。
+    なぞなぞタスクの最終的な構造化レスポンス（集約ルート）。
+
+    BaseModelである ChatResult を継承し、複数の RiddleEvaluation をリスト形式で保持する。
+    処理の流れとして、LLMから返されたJSONをパースしてこのクラスにマッピングすることで、
+    型安全な評価結果の提供を保証する。
     """
 
     evaluations: list[RiddleEvaluation] = Field(

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -82,7 +82,7 @@ class Gender:
 
 class RiddleEvaluation(BaseModel):
     """
-    なぞなぞの各スキル（論理的思考力、洞察力など）に対する個別の評価結果を表す「観点別評価」。
+    なぞなぞの各スキル（論理的思考力、洞察力など）に対する個別の評価結果を表す。
 
     RiddleResponse の evaluations リストの要素として使用される、最小単位の評価データ。
     """

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -84,7 +84,12 @@ class RiddleEvaluation(BaseModel):
     """
     なぞなぞの各評価観点（論理的思考力、洞察力など）に対する個別の評価結果を表す。
 
-    RiddleResponse の evaluations リストの要素として使用される、最小単位の評価データ。
+    RiddleResponse の evaluations リストの要素として使用される、最小単位の評価データ（観点別評価）。
+
+    Attributes:
+        viewpoint (str): 評価観点名（例: 論理的思考力、洞察力）。
+        score (int): 評価スコア（0-100）。
+        judge (str): 判定結果（例: 合格、不合格）。
     """
 
     viewpoint: str = Field(..., description="評価観点名（例: 論理的思考力、洞察力）")
@@ -99,6 +104,12 @@ class RiddleResponse(ChatResult):
     BaseModelである ChatResult を継承し、複数の RiddleEvaluation をリスト形式で保持する。
     処理の流れとして、LLMから返されたJSONをパースしてこのクラスにマッピングすることで、
     型安全な評価結果の提供を保証する。
+
+    Attributes:
+        answer (str): LLMから返された生の回答テキスト。
+        explanation (str | None): 評価に関する補足説明。
+        metadata (dict[str, Any]): トークン数やモデル名などの付随情報。
+        evaluations (list[RiddleEvaluation]): 各評価観点（viewpoint）ごとの評価詳細リスト。
     """
 
     evaluations: list[RiddleEvaluation] = Field(

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -82,12 +82,12 @@ class Gender:
 
 class RiddleEvaluation(BaseModel):
     """
-    なぞなぞの各スキル（論理的思考力、洞察力など）に対する個別の評価結果を表す。
+    なぞなぞの各評価観点（論理的思考力、洞察力など）に対する個別の評価結果を表す。
 
     RiddleResponse の evaluations リストの要素として使用される、最小単位の評価データ。
     """
 
-    skill: str = Field(..., description="評価スキル名（例: 論理的思考力、洞察力）")
+    viewpoint: str = Field(..., description="評価観点名（例: 論理的思考力、洞察力）")
     score: int = Field(..., description="評価スコア（0-100）")
     judge: str = Field(..., description="判定結果（例: 合格、不合格）")
 
@@ -102,5 +102,5 @@ class RiddleResponse(ChatResult):
     """
 
     evaluations: list[RiddleEvaluation] = Field(
-        ..., description="各スキルごとの評価リスト"
+        ..., description="各評価観点ごとの評価リスト"
     )

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -3,8 +3,9 @@ from dataclasses import dataclass
 from enum import Enum
 
 from django.contrib.auth.models import User
+from pydantic import BaseModel, Field
 
-from lib.llm.valueobject.completion import RoleType, Message
+from lib.llm.valueobject.completion import RoleType, Message, ChatResult
 from llm_chat.models import ChatLogs
 
 
@@ -77,3 +78,23 @@ class Gender:
     @property
     def name(self) -> str:
         return "男性" if self.gender == GenderType.MAN else "女性"
+
+
+class RiddleEvaluation(BaseModel):
+    """
+    なぞなぞの各スキルに対する評価結果。
+    """
+
+    skill: str = Field(..., description="評価スキル名（例: 論理的思考力、洞察力）")
+    score: int = Field(..., description="評価スコア（0-100）")
+    judge: str = Field(..., description="判定結果（例: 合格、不合格）")
+
+
+class RiddleResponse(ChatResult):
+    """
+    なぞなぞタスクの最終的な構造化レスポンス。
+    """
+
+    evaluations: list[RiddleEvaluation] = Field(
+        ..., description="各スキルごとの評価リスト"
+    )

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -82,7 +82,7 @@ class Gender:
 
 class RiddleEvaluation(BaseModel):
     """
-    なぞなぞの各スキル（論理的思考力、洞察力など）に対する個別の評価結果を表す。
+    なぞなぞの各スキル（論理的思考力、洞察力など）に対する個別の評価結果を表す「観点別評価」。
 
     RiddleResponse の evaluations リストの要素として使用される、最小単位の評価データ。
     """

--- a/llm_chat/domain/valueobject/chat.py
+++ b/llm_chat/domain/valueobject/chat.py
@@ -115,3 +115,14 @@ class RiddleResponse(ChatResult):
     evaluations: list[RiddleEvaluation] = Field(
         ..., description="各評価観点ごとの評価リスト"
     )
+
+    def to_bullet_points(self) -> str:
+        """
+        評価結果を箇条書き形式のテキストに変換します。
+        """
+        lines = ["\n【評価結果】"]
+        for eval_item in self.evaluations:
+            lines.append(
+                f"- {eval_item.viewpoint}: {eval_item.score}点 ({eval_item.judge})"
+            )
+        return "\n".join(lines)


### PR DESCRIPTION
### Summary
- LLMの実行結果を Pydantic を用いた構造化データ（型定義）で管理するようにリファクタリングし、不要なDB保存を削減してチャット履歴をクリーンにしました。

### Changes
- **構造化データの導入**:
    - `lib/llm/valueobject/completion.py`: Pydantic の `ChatResult` (基底クラス) を追加。
    - `lib/llm/service/completion.py`: `BaseLLMTask` (抽象基底クラス) を追加し、戻り値を `ChatResult` に統一。
    - `llm_chat/domain/valueobject/chat.py`: `RiddleResponse` と `RiddleEvaluation` (観点別評価) を定義。
- **なぞなぞ評価フローの改善**:
    - `llm_chat/domain/service/chat.py`: `RiddleTask` を実装し、JSONパースとバリデーションをカプセル化。
    - 評価結果を最終回答に箇条書きとして自動付与するように変更。
- **DB保存のクリーンアップ**:
    - **システムプロンプト (1レコード目) の削減**: DBへの保存を廃止し、LLM実行時に履歴の先頭へ動的に挿入するように変更。
    - **評価用メッセージ (4, 5レコード目) の削減**: 評価依頼メッセージとJSONレスポンスのDB保存を廃止。
- **ドキュメント強化**:
    - 主要なVOクラスに `Attributes` セクションを追加し、IDEでのマウスオーバーによる情報表示をサポート。

### Verification
- `RiddleResponse.to_bullet_points()` により、評価結果が期待通りの形式で生成されることを確認。
- システムメッセージがDBに保存されず、かつLLMへのコンテキストには正しく含まれていることを検証スクリプトで確認。
- 不正なJSONレスポンスに対するバリデーションが機能することを確認。
