### PR TITLE
[feature] なぞなぞの性別指定を必須化 (#598)

### DIFF
--- a/llm_chat/domain/service/completion/chat.py
+++ b/llm_chat/domain/service/completion/chat.py
@@ -61,7 +61,7 @@ class ChatService(BaseChatService):
             raise Exception("content is None")
 
         if use_case_type == UseCaseType.RIDDLE and gender is None:
-            gender = Gender(GenderType.MAN)  # デフォルト
+            raise ValueError("gender is required for RiddleUseCase")
 
         # DBから履歴を取得（roleがstrで返ってくることを想定してRoleTypeで変換）
         chat_history = ChatLogRepository.find_chat_history(user_message.user)

--- a/llm_chat/domain/usecase/completion/riddle.py
+++ b/llm_chat/domain/usecase/completion/riddle.py
@@ -17,9 +17,14 @@ class RiddleUseCase(UseCase):
         super().__init__()
         self.config = config
 
-    def execute(self, user: User, content: str | None) -> MessageDTO:
+    def execute(
+        self, user: User, content: str | None, gender: Gender | None = None
+    ) -> MessageDTO:
         if content is None:
             raise ValueError("content cannot be None for RiddleUseCase")
+
+        if gender is None:
+            raise ValueError("gender is required for RiddleUseCase")
 
         chat_service = ChatService(self.config)
 
@@ -33,7 +38,7 @@ class RiddleUseCase(UseCase):
 
         # なぞなぞは明示的に use_case_type="Riddle" を指定
         assistant_message = chat_service.generate(
-            user_message, use_case_type="Riddle", gender=Gender(GenderType.MAN)
+            user_message, use_case_type="Riddle", gender=gender
         )
 
         # なぞなぞの終端処理

--- a/llm_chat/forms.py
+++ b/llm_chat/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+from llm_chat.domain.valueobject.completion.riddle import GenderType
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
@@ -30,6 +31,18 @@ class UserTextForm(forms.Form):
         widget=forms.ClearableFileInput(
             attrs={"class": "form-control", "accept": "audio/*"}
         ),
+    )
+
+    GENDER_CHOICES = [
+        (GenderType.MAN.value, "男性"),
+        (GenderType.WOMAN.value, "女性"),
+    ]
+
+    gender = forms.ChoiceField(
+        choices=GENDER_CHOICES,
+        label="Gender",
+        initial=GenderType.MAN.value,
+        widget=forms.Select(attrs={"class": "form-control"}),
     )
 
     def __init__(self, *args, **kwargs):

--- a/llm_chat/templates/llm_chat/index.html
+++ b/llm_chat/templates/llm_chat/index.html
@@ -51,6 +51,10 @@
                 <label for="audio_file">{{ form.audio_file.label }}</label>
                 {{ form.audio_file }}
             </div>
+            <div id="gender-container" style="display: none;">
+                <label for="gender">{{ form.gender.label }}</label>
+                {{ form.gender }}
+            </div>
             <br>
             <div id="loading-indicator" class="align-items-center mt-2 d-none">
                 <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>
@@ -81,6 +85,8 @@
             const useCaseType = document.querySelector('select[name="use_case_type"]');
             const audioFileInput = document.querySelector('input[name="audio_file"]');
             const audioFileContainer = document.getElementById("audio-file-container");
+            const genderInput = document.querySelector('select[name="gender"]');
+            const genderContainer = document.getElementById("gender-container");
             const sendButton = document.getElementById("sendButton");
             const riddleButton = document.getElementById("riddleButton");
             const userInput = document.getElementById("id_question");
@@ -243,6 +249,9 @@
                 const requestData = new FormData();
                 requestData.append("use_case_type", selectedUseCaseType);
                 requestData.append("user_input", userMessage);
+                if (genderInput) {
+                    requestData.append("gender", genderInput.value);
+                }
 
                 // ユースケースごとのエンドポイントを指定
                 let endpointUrl;
@@ -306,6 +315,12 @@
                 } else {
                     audioFileContainer.style.display = "none"; // フォームを非表示
                 }
+
+                if (useCaseType.value === "Riddle") {
+                    genderContainer.style.display = "block";
+                } else {
+                    genderContainer.style.display = "none";
+                }
             });
 
             // ページロード時にも選択状態に応じてフィールドを表示／非表示
@@ -313,6 +328,12 @@
                 audioFileContainer.style.display = "block";
             } else {
                 audioFileContainer.style.display = "none";
+            }
+
+            if (useCaseType.value === "Riddle") {
+                genderContainer.style.display = "block";
+            } else {
+                genderContainer.style.display = "none";
             }
 
             // Server-Sent Events を開始（ストリームデータを受信）

--- a/llm_chat/tests.py
+++ b/llm_chat/tests.py
@@ -1,5 +1,6 @@
 import time
 from django.test import TestCase, RequestFactory
+from django.contrib.sessions.backends.db import SessionStore
 from django.contrib.auth.models import User
 from lib.llm.valueobject.completion import RoleType
 from lib.llm.valueobject.config import OpenAIGptConfig, ModelName
@@ -13,10 +14,7 @@ from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
 from llm_chat.domain.service.completion.chat import ChatService
 from llm_chat.domain.service.completion.riddle import RiddleChatService
-from llm_chat.domain.usecase.completion.chat import (
-    LlmChatUseCase,
-    OpenAIGptStreamingUseCase,
-)
+from llm_chat.domain.usecase.completion.chat import LlmChatUseCase
 from llm_chat.domain.usecase.completion.multimedia import (
     OpenAIDalleUseCase,
     OpenAITextToSpeechUseCase,
@@ -245,6 +243,16 @@ class OpenAiUseCaseTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="openaiuser", password="password")
 
+    def _assert_chat_log_saved(self, model_name: ModelName, use_case_type: UseCaseType):
+        """ChatLogs にファイルパスとモデル名、ユースケースタイプが正しく保存されていることを検証する共通ヘルパー"""
+        last_log = ChatLogs.objects.filter(
+            user=self.user, role=RoleType.ASSISTANT.value
+        ).last()
+        self.assertIsNotNone(last_log)
+        self.assertIsNotNone(last_log.file.name)
+        self.assertEqual(last_log.model_name, model_name)
+        self.assertEqual(last_log.use_case_type, use_case_type)
+
     @patch("llm_chat.domain.service.completion.multimedia.OpenAILlmDalleService")
     @patch("llm_chat.domain.service.completion.multimedia.requests.get")
     @patch("llm_chat.domain.service.completion.multimedia.Image.open")
@@ -279,13 +287,7 @@ class OpenAiUseCaseTest(TestCase):
         self.assertEqual(result.model_name, ModelName.DALLE_3)
 
         # DB への保存を検証
-        last_log = ChatLogs.objects.filter(
-            user=self.user, role=RoleType.ASSISTANT.value
-        ).last()
-        self.assertIsNotNone(last_log)
-        self.assertIsNotNone(last_log.file.name)
-        self.assertEqual(last_log.model_name, ModelName.DALLE_3)
-        self.assertEqual(last_log.use_case_type, UseCaseType.OPENAI_DALLE)
+        self._assert_chat_log_saved(ModelName.DALLE_3, UseCaseType.OPENAI_DALLE)
 
     @patch("llm_chat.domain.service.completion.multimedia.OpenAILlmTextToSpeech")
     def test_tts_usecase_saves_file_path(self, mock_tts_service):
@@ -309,13 +311,7 @@ class OpenAiUseCaseTest(TestCase):
         self.assertEqual(result.model_name, ModelName.TTS_1)
 
         # DB への保存を検証
-        last_log = ChatLogs.objects.filter(
-            user=self.user, role=RoleType.ASSISTANT.value
-        ).last()
-        self.assertIsNotNone(last_log)
-        self.assertIsNotNone(last_log.file.name)
-        self.assertEqual(last_log.model_name, ModelName.TTS_1)
-        self.assertEqual(last_log.use_case_type, UseCaseType.OPENAI_TEXT_TO_SPEECH)
+        self._assert_chat_log_saved(ModelName.TTS_1, UseCaseType.OPENAI_TEXT_TO_SPEECH)
 
     @patch("llm_chat.domain.service.completion.multimedia.OpenAILlmSpeechToText")
     @patch("llm_chat.domain.service.completion.multimedia.Path.exists")
@@ -374,6 +370,7 @@ class ViewLogicTest(TestCase):
         factory = RequestFactory()
         request = factory.get("/")
         request.user = self.user
+        request.session = SessionStore()
 
         # 1. 履歴なし -> Riddle 非アクティブ
         view = IndexView()
@@ -414,6 +411,7 @@ class ViewLogicTest(TestCase):
         factory = RequestFactory()
         request = factory.get("/")
         request.user = self.user
+        request.session = SessionStore()
 
         view = IndexView()
         view.request = request

--- a/llm_chat/tests.py
+++ b/llm_chat/tests.py
@@ -532,3 +532,20 @@ class ViewLogicTest(TestCase):
         )
         initial = view.get_initial()
         self.assertEqual(initial.get("use_case_type"), UseCaseType.OPENAI_RAG)
+
+        # 9. セッションからの use_case_type 復元 (DB 履歴より優先)
+        request.session["use_case_type"] = UseCaseType.GEMINI
+        initial = view.get_initial()
+        self.assertEqual(initial.get("use_case_type"), UseCaseType.GEMINI)
+
+        # 10. なぞなぞ進行中が最優先 (セッションより優先)
+        ChatLogs.objects.create(
+            user=self.user,
+            role=RoleType.ASSISTANT.value,
+            content="なぞなぞです",
+            model_name=ModelName.GPT_5_MINI,
+            use_case_type=UseCaseType.RIDDLE,
+            created_at=timezone.now() + timezone.timedelta(seconds=1),
+        )
+        initial = view.get_initial()
+        self.assertEqual(initial.get("use_case_type"), UseCaseType.RIDDLE)

--- a/llm_chat/tests.py
+++ b/llm_chat/tests.py
@@ -26,7 +26,7 @@ from unittest.mock import patch, MagicMock
 
 class ChatModelAndRepositoryTest(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="testuser")
+        self.user = User.objects.create_user(username="test_user")
 
     def test_chat_logs_to_message_dto(self):
         """
@@ -71,7 +71,7 @@ class ChatModelAndRepositoryTest(TestCase):
 
 class ChatLogicTest(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="logicuser")
+        self.user = User.objects.create_user(username="logic_user")
 
     def test_get_chat_history_normal(self):
         """
@@ -241,7 +241,9 @@ class ChatLogicTest(TestCase):
 
 class OpenAiUseCaseTest(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="openaiuser", password="password")
+        self.user = User.objects.create_user(
+            username="openai_user", password="password"
+        )
 
     def _assert_chat_log_saved(self, model_name: ModelName, use_case_type: UseCaseType):
         """ChatLogs にファイルパスとモデル名、ユースケースタイプが正しく保存されていることを検証する共通ヘルパー"""

--- a/llm_chat/tests.py
+++ b/llm_chat/tests.py
@@ -157,7 +157,9 @@ class ChatLogicTest(TestCase):
         ) as mock_eval:
             mock_eval.return_value = "\n【評価結果】\n- 論理的思考力: 100点 (合格)"
 
-            result = use_case.execute(self.user, "答えは人間です")
+            result = use_case.execute(
+                self.user, "答えは人間です", gender=Gender(GenderType.MAN)
+            )
 
             self.assertIn(RiddleChatService.RIDDLE_END_MESSAGE, result.content)
             self.assertIn("評価結果", result.content)
@@ -202,12 +204,41 @@ class ChatLogicTest(TestCase):
             api_key="fake", max_tokens=100, model=ModelName.GPT_5_MINI
         )
         use_case = RiddleUseCase(config)
-        result = use_case.execute(self.user, "スタート")
+        result = use_case.execute(self.user, "スタート", gender=Gender(GenderType.MAN))
 
         self.assertEqual(result.content, "それは人間ですか？")
         self.assertEqual(result.use_case_type, UseCaseType.RIDDLE)
         # 初回なぞなぞ：System(非保存), User, Assistant の計2通がDBへ
         self.assertEqual(ChatLogs.objects.filter(user=self.user).count(), 2)
+
+    def test_get_chat_history_riddle_no_gender_raises_error(self):
+        """
+        [シナリオ] なぞなぞモードで性別を指定せずに get_chat_history を呼び出す
+        [期待値] ValueError が発生すること
+        """
+        user_message = MessageDTO(
+            user=self.user,
+            role=RoleType.USER,
+            content="なぞなぞスタート",
+            model_name=ModelName.GPT_5_MINI,
+            use_case_type=UseCaseType.RIDDLE,
+        )
+        with self.assertRaisesRegex(ValueError, "gender is required for RiddleUseCase"):
+            ChatService.get_chat_history(
+                user_message, use_case_type=UseCaseType.RIDDLE, gender=None
+            )
+
+    def test_riddle_usecase_no_gender_raises_error(self):
+        """
+        [シナリオ] RiddleUseCase.execute を性別指定なしで呼び出す
+        [期待値] ValueError が発生すること
+        """
+        config = OpenAIGptConfig(
+            api_key="fake", max_tokens=100, model=ModelName.GPT_5_MINI
+        )
+        use_case = RiddleUseCase(config)
+        with self.assertRaisesRegex(ValueError, "gender is required for RiddleUseCase"):
+            use_case.execute(user=self.user, content="なぞなぞスタート", gender=None)
 
 
 class OpenAiUseCaseTest(TestCase):

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -55,6 +55,10 @@ class IndexView(FormView):
         # 1. なぞなぞが進行中の場合は、Riddleモードを優先
         if self._is_riddle_active(chat_history):
             initial["use_case_type"] = UseCaseType.RIDDLE
+            # なぞなぞ進行中もセッションから性別を復元
+            riddle_gender = self.request.session.get("riddle_gender")
+            if riddle_gender:
+                initial["gender"] = riddle_gender
             return initial
 
         last_log = chat_history[-1] if chat_history else None
@@ -65,6 +69,13 @@ class IndexView(FormView):
             initial["use_case_type"] = last_log.use_case_type
         else:
             initial["use_case_type"] = UseCaseType.OPENAI_GPT
+
+        # 3. セッションから性別の初期値を取得
+        riddle_gender = self.request.session.get("riddle_gender")
+        if riddle_gender:
+            initial["gender"] = riddle_gender
+        else:
+            initial["gender"] = GenderType.MAN.value
 
         return initial
 
@@ -118,6 +129,8 @@ class SyncResponseView(View):
             if gender_val:
                 try:
                     gender = Gender(GenderType(gender_val))
+                    # セッションに性別を保存（モデル変更なしで記憶するため）
+                    request.session["riddle_gender"] = gender_val
                 except ValueError:
                     pass
 

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -45,8 +45,9 @@ class IndexView(FormView):
 
         以下の優先順位で `use_case_type` を決定します：
         1. なぞなぞが進行中の場合（最新のなぞなぞ履歴が未終了）："Riddle"
-        2. 過去のチャット履歴がある場合：最新のメッセージで使用されたモデルから推定
-        3. 履歴がない場合：デフォルトの "OpenAIGpt"
+        2. セッションに保存された use_case_type がある場合：それを優先
+        3. 過去のチャット履歴がある場合：最新のメッセージで使用されたモデルから推定
+        4. 履歴がない場合：デフォルトの "OpenAIGpt"
         """
         initial = super().get_initial()
         login_user = self._get_login_user()
@@ -61,16 +62,21 @@ class IndexView(FormView):
                 initial["gender"] = riddle_gender
             return initial
 
-        last_log = chat_history[-1] if chat_history else None
-
-        if last_log:
-            # 2. 直近の use_case_type を優先的に使用
-            # データベースに保存されている use_case_type を直接初期値として設定する
-            initial["use_case_type"] = last_log.use_case_type
+        # 2. セッションから use_case_type を復元
+        session_use_case_type = self.request.session.get("use_case_type")
+        if session_use_case_type:
+            initial["use_case_type"] = session_use_case_type
         else:
-            initial["use_case_type"] = UseCaseType.OPENAI_GPT
+            last_log = chat_history[-1] if chat_history else None
 
-        # 3. セッションから性別の初期値を取得
+            if last_log:
+                # 3. 直近の use_case_type を優先的に使用
+                # データベースに保存されている use_case_type を直接初期値として設定する
+                initial["use_case_type"] = last_log.use_case_type
+            else:
+                initial["use_case_type"] = UseCaseType.OPENAI_GPT
+
+        # 4. セッションから性別の初期値を取得
         riddle_gender = self.request.session.get("riddle_gender")
         if riddle_gender:
             initial["gender"] = riddle_gender
@@ -123,6 +129,9 @@ class SyncResponseView(View):
 
             if not use_case_type:
                 return JsonResponse({"error": "No use case type provided"}, status=400)
+
+            # セッションに use_case_type を保存（モデル変更なしで記憶するため）
+            request.session["use_case_type"] = use_case_type
 
             # 性別のパース
             gender = None
@@ -215,6 +224,9 @@ class StreamingResponseView(View):
 
         if use_case_type != UseCaseType.OPENAI_GPT_STREAMING:
             return JsonResponse({"error": "Invalid use case for streaming"}, status=400)
+
+        # セッションに use_case_type を保存
+        request.session["use_case_type"] = use_case_type
 
         if not user_input:
             return JsonResponse({"error": "No input provided"}, status=400)

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 from lib.llm.valueobject.completion import StreamResponse
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
 from llm_chat.domain.service.completion.riddle import RiddleChatService
+from llm_chat.domain.valueobject.completion.riddle import GenderType, Gender
 from llm_chat.domain.usecase.completion.base import UseCase
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 from llm_chat.domain.usecase.completion.chat import (
@@ -107,9 +108,18 @@ class SyncResponseView(View):
             use_case_type = request.POST.get("use_case_type")
             user_input = request.POST.get("user_input")
             audio_file = request.FILES.get("audio_file")
+            gender_val = request.POST.get("gender")
 
             if not use_case_type:
                 return JsonResponse({"error": "No use case type provided"}, status=400)
+
+            # 性別のパース
+            gender = None
+            if gender_val:
+                try:
+                    gender = Gender(GenderType(gender_val))
+                except ValueError:
+                    pass
 
             # 使用するユースケースを切り替え TODO: Use-caseのFactoryにしたらよさそう issue229
             use_case: UseCase | None = None
@@ -154,7 +164,12 @@ class SyncResponseView(View):
                 )
 
             # ユースケースの実行
-            message = use_case.execute(user=request.user, content=user_input)
+            if isinstance(use_case, RiddleUseCase):
+                message = use_case.execute(
+                    user=request.user, content=user_input, gender=gender
+                )
+            else:
+                message = use_case.execute(user=request.user, content=user_input)
 
             # 成功レスポンスを返す
             return JsonResponse(


### PR DESCRIPTION
## 概要
なぞなぞモード（RiddleUseCase/RiddleChatService）において、ユーザーの性別（gender）指定を必須化しました。
これまでは指定がない場合にデフォルト値（男性）が設定されていましたが、口調に影響する重要な要素であるため、明示的な指定を求めるように変更しました。

## 変更内容
- **ChatService.get_chat_history**: なぞなぞモードで `gender` が `None` の場合に `ValueError` をスローするように変更。
- **RiddleUseCase.execute**: 引数に `gender` を追加し、必須チェックを実装。
- **UserTextForm**: 画面から性別を選択できるよう `gender` フィールドを追加。
- **SyncResponseView**: リクエストから `gender` を取得し、`RiddleUseCase` に渡すように修正。
- **tests.py**: 既存のテストケースを新仕様に合わせて更新し、バリデーションエラーのテストを追加。

## テスト観点 (オペレーション視点)
- なぞなぞモード開始時に性別（男性/女性）を選択し、それぞれの口調で開始されるか確認
- 通常のチャット（OpenAI GPT等）がこれまで通り動作するか確認

### 自動テストでカバーできた範囲
- `llm_chat/tests.py`: 性別未指定時の `ValueError` 発生を検証するテストを追加
- 既存の全テスト（14件）がパスすることを確認済み

## 関連Issue
- Closes #598