### PR TITLE
soil_analysis アプリにおける UserAttribute 導入とモデル整理

### DIFF
--- a/soil_analysis/domain/repository/land_ledger.py
+++ b/soil_analysis/domain/repository/land_ledger.py
@@ -9,6 +9,7 @@ from soil_analysis.models import (
     Company,
     SoilHardnessMeasurement,
     SoilHardnessMeasurementImportErrors,
+    UserAttribute,
 )
 from soil_analysis.domain.repository.hardness_measurement import (
     SoilHardnessMeasurementRepository,
@@ -95,7 +96,9 @@ class LandLedgerRepository:
             ],
             "sampling_staff": [
                 {"id": user.id, "name": user.get_username()}
-                for user in get_user_model().objects.all()
+                for user in get_user_model()
+                .objects.filter(soil_profile__role=UserAttribute.Role.STAFF)
+                .order_by("username")
             ],
             "suggested_land_id": suggested_land.id if suggested_land else None,
             "suggested_sampling_date": (

--- a/soil_analysis/fixtures/land.json
+++ b/soil_analysis/fixtures/land.json
@@ -9,7 +9,7 @@
       "area": 100,
       "cultivation_type": 1,
       "company": 1,
-      "owner": 20,
+      "owner": 21,
       "created_at": "2022-08-13T00:00:00+09:00",
       "remark": "備考"
     }
@@ -23,7 +23,7 @@
       "jma_city": 600,
       "cultivation_type": 2,
       "company": 1,
-      "owner": 20,
+      "owner": 21,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   },
@@ -36,7 +36,7 @@
       "jma_city": 600,
       "cultivation_type": 2,
       "company": 1,
-      "owner": 21,
+      "owner": 22,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   },
@@ -50,7 +50,7 @@
       "area": 100,
       "cultivation_type": 1,
       "company": 2,
-      "owner": 20,
+      "owner": 21,
       "created_at": "2022-08-13T00:00:00+09:00",
       "remark": "備考"
     }
@@ -64,7 +64,7 @@
       "jma_city": 971,
       "cultivation_type": 2,
       "company": 2,
-      "owner": 20,
+      "owner": 21,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   },
@@ -77,7 +77,7 @@
       "jma_city": 971,
       "cultivation_type": 2,
       "company": 2,
-      "owner": 21,
+      "owner": 22,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   },
@@ -90,7 +90,7 @@
       "jma_city": 971,
       "cultivation_type": 2,
       "company": 2,
-      "owner": 21,
+      "owner": 22,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   },
@@ -104,7 +104,7 @@
       "area": 100,
       "cultivation_type": 1,
       "company": 3,
-      "owner": 20,
+      "owner": 21,
       "created_at": "2022-08-13T00:00:00+09:00",
       "remark": "備考"
     }
@@ -118,7 +118,7 @@
       "jma_city": 1422,
       "cultivation_type": 2,
       "company": 3,
-      "owner": 20,
+      "owner": 21,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   },
@@ -131,7 +131,7 @@
       "jma_city": 1422,
       "cultivation_type": 2,
       "company": 3,
-      "owner": 21,
+      "owner": 22,
       "created_at": "2022-08-13T00:00:00+09:00"
     }
   }

--- a/soil_analysis/fixtures/land_ledger.json
+++ b/soil_analysis/fixtures/land_ledger.json
@@ -64,7 +64,7 @@
       "land_id": 2,
       "land_period_id": 4,
       "sampling_method_id": 1,
-      "sampling_staff_id": 1
+      "sampling_staff_id": 20
     }
   },
   {
@@ -81,7 +81,7 @@
       "land_id": 2,
       "land_period_id": 5,
       "sampling_method_id": 1,
-      "sampling_staff_id": 1
+      "sampling_staff_id": 20
     }
   }
 ]

--- a/soil_analysis/fixtures/userattribute.json
+++ b/soil_analysis/fixtures/userattribute.json
@@ -1,0 +1,58 @@
+[
+  {
+    "model": "soil_analysis.userattribute",
+    "pk": 1,
+    "fields": {
+      "user": 19,
+      "role": "staff",
+      "address": null,
+      "organization": "土掘りチーム",
+      "area": "成田",
+      "remark": null,
+      "created_at": "2022-06-30T15:00:00+09:00",
+      "updated_at": "2022-06-30T15:00:00+09:00"
+    }
+  },
+  {
+    "model": "soil_analysis.userattribute",
+    "pk": 2,
+    "fields": {
+      "user": 20,
+      "role": "staff",
+      "address": null,
+      "organization": "採土班",
+      "area": "静岡",
+      "remark": null,
+      "created_at": "2022-06-30T15:00:00+09:00",
+      "updated_at": "2022-06-30T15:00:00+09:00"
+    }
+  },
+  {
+    "model": "soil_analysis.userattribute",
+    "pk": 3,
+    "fields": {
+      "user": 21,
+      "role": "owner",
+      "address": "千葉県成田市",
+      "organization": "アグリファクトリー",
+      "area": "成田",
+      "remark": null,
+      "created_at": "2022-08-13T00:00:00+09:00",
+      "updated_at": "2022-08-13T00:00:00+09:00"
+    }
+  },
+  {
+    "model": "soil_analysis.userattribute",
+    "pk": 4,
+    "fields": {
+      "user": 22,
+      "role": "owner",
+      "address": "徳島県徳島市",
+      "organization": "農業法人三徳",
+      "area": "徳島",
+      "remark": null,
+      "created_at": "2022-08-13T00:00:00+09:00",
+      "updated_at": "2022-08-13T00:00:00+09:00"
+    }
+  }
+]

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -9,6 +9,7 @@ from .models import (
     JmaCity,
     LandLedger,
     SamplingMethod,
+    UserAttribute,
 )
 
 User = get_user_model()
@@ -119,6 +120,14 @@ class LandCreateForm(forms.ModelForm):
             "owner": "所有者",
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        owner_field = self.fields.get("owner")
+        if isinstance(owner_field, forms.ModelChoiceField):
+            owner_field.queryset = User.objects.filter(
+                soil_profile__role=UserAttribute.Role.OWNER
+            )
+
     def clean_name(self):
         name = self.cleaned_data.get("name")
         company_id = self.data.get("company-id")
@@ -213,6 +222,12 @@ class LandLedgerCreateForm(forms.ModelForm):
             field = self.fields[field_name]
             if field.required:
                 field.widget.attrs["required"] = True
+
+        sampling_staff_field = self.fields.get("sampling_staff")
+        if isinstance(sampling_staff_field, forms.ModelChoiceField):
+            sampling_staff_field.queryset = User.objects.filter(
+                soil_profile__role=UserAttribute.Role.STAFF
+            )
 
         # デフォルトで5点法を選択状態にする
         try:

--- a/soil_analysis/migrations/0002_userattribute.py
+++ b/soil_analysis/migrations/0002_userattribute.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("soil_analysis", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserAttribute",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "role",
+                    models.CharField(choices=[("owner", "圃場オーナー"), ("staff", "採土スタッフ")], max_length=20, verbose_name="ロール"),
+                ),
+                ("address", models.TextField(blank=True, null=True, verbose_name="住所")),
+                (
+                    "organization",
+                    models.CharField(
+                        blank=True, max_length=255, null=True, verbose_name="所属"
+                    ),
+                ),
+                (
+                    "area",
+                    models.CharField(
+                        blank=True, max_length=255, null=True, verbose_name="担当エリア"
+                    ),
+                ),
+                ("remark", models.TextField(blank=True, null=True, verbose_name="備考")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="soil_profile",
+                        to=settings.AUTH_USER_MODEL,
+                        verbose_name="ユーザ",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/soil_analysis/models.py
+++ b/soil_analysis/models.py
@@ -157,6 +157,58 @@ class JmaWarning(models.Model):
         unique_together = ("jma_region",)
 
 
+class UserAttribute(models.Model):
+    """
+    土壌分析アプリ特有のユーザー属性。
+
+    - Django 標準の auth.User と 1:1 で紐づく（認証や氏名・メール等は auth.User を参照）
+    - 土壌分析ドメイン固有の情報を保持
+
+    Attributes:
+        - user (OneToOneField): ユーザ
+        - role (CharField): ロール (OWNER/STAFF)
+        - address (TextField): 住所
+        - organization (CharField): 所属
+        - area (CharField): 担当エリア
+        - remark (TextField): 備考
+        - created_at (DateTimeField): 作成日時
+        - updated_at (DateTimeField): 更新日時
+    """
+
+    class Role(models.TextChoices):
+        """
+        ロール定義:
+        - OWNER: 圃場オーナー
+        - STAFF: 採土スタッフ
+        """
+
+        OWNER = "owner", "圃場オーナー"
+        STAFF = "staff", "採土スタッフ"
+
+    user = models.OneToOneField(
+        get_user_model(),
+        on_delete=models.CASCADE,
+        related_name="soil_profile",
+        verbose_name="ユーザ",
+    )
+    role = models.CharField(
+        max_length=20,
+        choices=Role,
+        verbose_name="ロール",
+    )
+    address = models.TextField(verbose_name="住所", null=True, blank=True)
+    organization = models.CharField(
+        verbose_name="所属", max_length=255, null=True, blank=True
+    )
+    area = models.CharField(verbose_name="担当エリア", max_length=255, null=True, blank=True)
+    remark = models.TextField(verbose_name="備考", null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True, null=True)
+
+    def __str__(self):
+        return self.user.get_full_name() or self.user.username
+
+
 class CompanyCategory(models.Model):
     """
     顧客カテゴリマスタ


### PR DESCRIPTION
**Summary**
soil_analysis に UserAttribute モデルを追加し、OWNER/STAFF ロールでユーザー選択を絞り込むようにしました。既存 fixture を新しいユーザー体系に合わせて調整し、UserAttribute 用の fixture を追加しました。

**Changes**
- `UserAttribute` モデル（OWNER/STAFF、住所/所属/担当エリア/備考）を追加
- `LandCreateForm.owner` と `LandLedgerCreateForm.sampling_staff` をロールで絞り込み
- `LandLedgerRepository` の `sampling_staff` 取得も STAFF のみに限定
- `soil_analysis` fixtures を更新し、`userattribute.json` を追加
- マイグレーション `0002_userattribute` を追加

**Tests**
- 未実施（DBに対する `migrate` と `loaddata` は実行済み）

**動作確認観点（目検）**
- [x] 管理画面 or 該当画面で `Land` 作成時の `owner` 一覧に OWNER ロールのみが出る
- [x] LandLedger 作成時（画面と Ajax 取得の両方）で sampling_staff が STAFF のみになる
- [x] `loaddata` 実行後、`soil_analysis_userattribute` が作成され、`user` と 1:1 で紐づいている
- [x] `land.json` の `owner` が OWNER ロールのユーザーを参照している
- [x] `land_ledger.json` の `sampling_staff_id` が STAFF ロールを参照している