### PR TITLE
 robots.txt（任意で sitemap も）を追加してクローラ由来の404ノイズを削減し、クロール品質を改善する

### DIFF
--- a/config/sitemap.py
+++ b/config/sitemap.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+from django.http import HttpResponse
+from django.urls import URLPattern, URLResolver, get_resolver
+
+
+def _normalize_path(path: str) -> str:
+    if not path:
+        return "/"
+    if not path.startswith("/"):
+        return f"/{path}"
+    return path
+
+
+def _iter_static_paths(urlpatterns, prefix=""):
+    for entry in urlpatterns:
+        if isinstance(entry, URLPattern):
+            route = getattr(entry.pattern, "_route", None)
+            if route is None:
+                continue
+            if "<" in route or ">" in route:
+                continue
+            full_route = f"{prefix}{route}"
+            yield _normalize_path(full_route)
+            continue
+        if isinstance(entry, URLResolver):
+            route = getattr(entry.pattern, "_route", "")
+            if route is None:
+                continue
+            next_prefix = f"{prefix}{route}"
+            yield from _iter_static_paths(entry.url_patterns, next_prefix)
+
+
+def _collect_public_paths():
+    resolver = get_resolver()
+    paths = []
+    for path in _iter_static_paths(resolver.url_patterns):
+        if path.startswith("/admin/"):
+            continue
+        if path.startswith("/accounts/"):
+            continue
+        paths.append(path)
+    unique_paths = sorted(set(paths))
+    return unique_paths
+
+
+def sitemap_xml(_request):
+    base_url = settings.SITE_URL.rstrip("/")
+    urls = _collect_public_paths()
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ]
+    for path in urls:
+        lines.append(f"  <url><loc>{base_url}{path}</loc></url>")
+    lines.append("</urlset>")
+    content = "\n".join(lines) + "\n"
+    return HttpResponse(content, content_type="application/xml")

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,11 +18,25 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
+from django.http import HttpResponse
 from django.urls import include, path
 
+from config.sitemap import sitemap_xml
 from vietnam_research.views import CustomLoginView
 
+
+def robots_txt(_request):
+    content = (
+        "User-agent: *\n"
+        "Disallow:\n"
+        f"Sitemap: {settings.SITE_URL.rstrip('/')}/sitemap.xml\n"
+    )
+    return HttpResponse(content, content_type="text/plain")
+
+
 urlpatterns = [
+    path("robots.txt", robots_txt, name="robots_txt"),
+    path("sitemap.xml", sitemap_xml, name="sitemap_xml"),
     path("", include("home.urls")),
     path("vietnam_research/", include("vietnam_research.urls")),
     path("usa_research/", include("usa_research.urls")),


### PR DESCRIPTION
## 目的
- `/robots.txt` と `/sitemap.xml` を 200 で返し、クローラ由来の 404 を減らす。
- 正規クローラがサイト構造を取得できるようにする。

## 変更内容
- Django で `/robots.txt` と `/sitemap.xml` を配信するルートを追加。
- `sitemap.xml` は URLconf の静的パスから生成（動的パラメータ付きは除外）。
- `/admin/` と `/accounts/` を sitemap から除外。
- `robots.txt` に `Sitemap: https://www.henojiya.net/sitemap.xml` を追記。

## 動作確認
- 既存ページの表示は変更なし（URLconfの追加のみ）。
- 受け入れ基準確認:
  - `curl -I https://www.henojiya.net/robots.txt` が 200
  - `curl -I https://www.henojiya.net/sitemap.xml` が 200

## 留意点
- `settings.SITE_URL` に依存。現在 `https://www.henojiya.net` 設定済み。
- 動的ページを sitemap に含めたい場合は別途追加実装が必要。