### PR TITLE
 usa: Bootstrap 5 への完全移行 & リデザイン

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls C:/Users/yoshi/OneDrive/dev/portfolio/*.md)"
+    ]
+  }
+}

--- a/usa_research/templates/usa_research/base.html
+++ b/usa_research/templates/usa_research/base.html
@@ -33,8 +33,6 @@
     <!-- favicon -->
     <link rel="shortcut icon" href="{% static 'usa_research/s_u.ico' %}">
 
-    <!-- for ajax -->
-    <script>let myUrl = {"base": "{% url 'vnm:index' %}", "login": "{% url 'login' %}"};</script>
 </head>
 <body>
 <h1></h1>
@@ -42,7 +40,7 @@
     <nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid px-3">
             <a class="navbar-brand" href="{% url 'home:index' %}">Henojiya</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                     aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -104,7 +102,7 @@
                         </select>
                     </li>
                     {% if user.is_authenticated %}
-                        <li class="nav-item small mr-3">
+                        <li class="nav-item small me-3">
 
                             <span class="nav-link"><i class="fas fa-user"></i> {{ user.username }}さん</span>
                         </li>

--- a/usa_research/templates/usa_research/index.html
+++ b/usa_research/templates/usa_research/index.html
@@ -8,14 +8,14 @@
         <nav class="mb-4 p-3 bg-light border rounded shadow-sm">
             <h6 class="text-secondary mb-2"><i class="fas fa-list"></i> クイックリンク</h6>
             <div class="d-flex flex-wrap">
-                <a href="#macro" class="btn btn-sm btn-outline-primary mr-2 mb-2">0. 主要マクロ指標</a>
-                <a href="#assets" class="btn btn-sm btn-outline-primary mr-2 mb-2">1. 資産リターン推移</a>
-                <a href="#msci" class="btn btn-sm btn-outline-primary mr-2 mb-2">2. MSCIレポート</a>
-                <a href="#almanac" class="btn btn-sm btn-outline-primary mr-2 mb-2">3. アルマナック</a>
-                <a href="#sectors" class="btn btn-sm btn-outline-primary mr-2 mb-2">4. セクターローテーション</a>
-                <a href="#nasdaq100" class="btn btn-sm btn-outline-primary mr-2 mb-2">5. NASDAQ100銘柄</a>
-                <a href="#rss" class="btn btn-sm btn-outline-primary mr-2 mb-2">6. RSSニュース</a>
-                <a href="{% url 'usa:financial_results' %}" class="btn btn-sm btn-outline-success mr-2 mb-2"><i
+                <a href="#macro" class="btn btn-sm btn-outline-primary me-2 mb-2">0. 主要マクロ指標</a>
+                <a href="#assets" class="btn btn-sm btn-outline-primary me-2 mb-2">1. 資産リターン推移</a>
+                <a href="#msci" class="btn btn-sm btn-outline-primary me-2 mb-2">2. MSCIレポート</a>
+                <a href="#almanac" class="btn btn-sm btn-outline-primary me-2 mb-2">3. アルマナック</a>
+                <a href="#sectors" class="btn btn-sm btn-outline-primary me-2 mb-2">4. セクターローテーション</a>
+                <a href="#nasdaq100" class="btn btn-sm btn-outline-primary me-2 mb-2">5. NASDAQ100銘柄</a>
+                <a href="#rss" class="btn btn-sm btn-outline-primary me-2 mb-2">6. RSSニュース</a>
+                <a href="{% url 'usa:financial_results' %}" class="btn btn-sm btn-outline-success me-2 mb-2"><i
                         class="fas fa-check-circle"></i> 7. 決算ウォッチ</a>
             </div>
         </nav>
@@ -77,7 +77,7 @@
                             </li>
                         </ul>
                     </div>
-                    <div class="col-md-6 border-left">
+                    <div class="col-md-6 border-start">
                         <ul class="mb-0">
                             <li>
                                 <a href="https://finance.yahoo.com/quote/%5EVIX" target="_blank"
@@ -110,7 +110,7 @@
                     </div>
                 </div>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
@@ -178,7 +178,7 @@
                     </div>
                 </div>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
@@ -375,7 +375,7 @@
                         を実行してください。</p>
                 {% endif %}
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
@@ -408,7 +408,7 @@
                             </thead>
                             <tbody>
                             {% for item in monthly_anomalies %}
-                                <tr {% if item.month == current_month %}class="table-warning font-weight-bold"{% endif %}>
+                                <tr {% if item.month == current_month %}class="table-warning fw-bold"{% endif %}>
                                     <td>{{ item.month }}月</td>
                                     <td>{{ item.title }}</td>
                                     <td>{{ item.description }}</td>
@@ -445,7 +445,7 @@
             <div class="mt-4 text-muted small">
                 <p>※ ストックトレーダーズ・アルマナックに基づくアノマリー。投資判断の思考補助としてご利用ください。</p>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
@@ -473,7 +473,7 @@
                             <thead class="table-dark">
                             <tr>
                                 <th>Signal</th>
-                                <th class="text-left">Sector</th>
+                                <th class="text-start">Sector</th>
                                 <th>Symbol</th>
                                 <th>Rank</th>
                                 <th>ΔRank(5d)</th>
@@ -486,41 +486,41 @@
                                 <tr>
                                     <td>
                                         {% if snapshot.signal == 'Green' %}
-                                            <span class="badge badge-success"
+                                            <span class="badge bg-success text-white"
                                                   style="background-color: #28a745; color: white;">Green</span>
                                         {% elif snapshot.signal == 'Yellow' %}
-                                            <span class="badge badge-warning"
+                                            <span class="badge bg-warning text-dark"
                                                   style="background-color: #ffc107; color: black;">Yellow</span>
                                         {% elif snapshot.signal == 'Red' %}
-                                            <span class="badge badge-danger"
+                                            <span class="badge bg-danger text-white"
                                                   style="background-color: #dc3545; color: white;">Red</span>
                                         {% else %}
                                             <span class="text-muted">-</span>
                                         {% endif %}
                                     </td>
-                                    <td class="text-left">
+                                    <td class="text-start">
                                         {% if snapshot.sector.name == 'Information Technology' %}
-                                            <i class="fas fa-laptop-code fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-laptop-code fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Financials' %}
-                                            <i class="fas fa-university fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-university fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Health Care' %}
-                                            <i class="fas fa-stethoscope fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-stethoscope fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Consumer Discretionary' %}
-                                            <i class="fas fa-shopping-cart fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-shopping-cart fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Consumer Staples' %}
-                                            <i class="fas fa-apple-alt fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-apple-alt fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Energy' %}
-                                            <i class="fas fa-fire fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-fire fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Industrials' %}
-                                            <i class="fas fa-industry fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-industry fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Materials' %}
-                                            <i class="fas fa-mountain fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-mountain fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Utilities' %}
-                                            <i class="fas fa-bolt fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-bolt fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Real Estate' %}
-                                            <i class="fas fa-building fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-building fa-fw text-muted me-1"></i>
                                         {% elif snapshot.sector.name == 'Communication Services' %}
-                                            <i class="fas fa-broadcast-tower fa-fw text-muted mr-1"></i>
+                                            <i class="fas fa-broadcast-tower fa-fw text-muted me-1"></i>
                                         {% endif %}
                                         {{ snapshot.sector.name }}
                                     </td>
@@ -576,17 +576,17 @@
                             </li>
                         </ul>
                     </div>
-                    <div class="col-md-6 border-left">
+                    <div class="col-md-6 border-start">
                         <p class="mb-1"><strong>信号機ルール:</strong></p>
                         <ul class="mb-0">
-                            <li><span class="badge badge-success"
+                            <li><span class="badge bg-success text-white"
                                       style="background-color: #28a745; color: white;">Green</span>:
                                 <strong>出遅れからの反発</strong> (RS_20d < 0 かつ ΔRS_5d > 0 かつ ΔRank_5d ≤ -2)
                             </li>
-                            <li><span class="badge badge-warning" style="background-color: #ffc107; color: black;">Yellow</span>:
+                            <li><span class="badge bg-warning text-dark" style="background-color: #ffc107; color: black;">Yellow</span>:
                                 <strong>勢い改善中</strong> (ΔRS_5d > 0)
                             </li>
-                            <li><span class="badge badge-danger"
+                            <li><span class="badge bg-danger text-white"
                                       style="background-color: #dc3545; color: white;">Red</span>:
                                 <strong>過熱からの失速</strong> (RS_20d > 0 かつ ΔRS_5d < 0 かつ ΔRank_5d ≥ 2)
                             </li>
@@ -602,27 +602,27 @@
                             </small>
                         </div>
                         <div class="row">
-                            <div class="col-md-3 border-right">
-                                <small class="font-weight-bold text-success">【拡大期】景気＋ / 金利ー</small><br>
+                            <div class="col-md-3 border-end">
+                                <small class="fw-bold text-success">【拡大期】景気＋ / 金利ー</small><br>
                                 <small>Information Technology, Financials</small>
                             </div>
-                            <div class="col-md-3 border-right">
-                                <small class="font-weight-bold text-primary">【成熟期】景気＋ / 金利＋</small><br>
+                            <div class="col-md-3 border-end">
+                                <small class="fw-bold text-primary">【成熟期】景気＋ / 金利＋</small><br>
                                 <small>Industrials, Materials, Consumer Discretionary</small>
                             </div>
-                            <div class="col-md-3 border-right">
-                                <small class="font-weight-bold text-danger">【後退期】景気ー / 金利＋</small><br>
+                            <div class="col-md-3 border-end">
+                                <small class="fw-bold text-danger">【後退期】景気ー / 金利＋</small><br>
                                 <small>Energy</small>
                             </div>
                             <div class="col-md-3">
-                                <small class="font-weight-bold text-secondary">【停滞期】景気ー / 金利ー</small><br>
+                                <small class="fw-bold text-secondary">【停滞期】景気ー / 金利ー</small><br>
                                 <small>Communication Services, Health Care, Consumer Staples, Utilities</small>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
@@ -634,7 +634,7 @@
                     <h4 class="text-primary mb-1"><i class="fas fa-bug"></i> 5. NASDAQ100 構成銘柄 (虫の目)</h4>
                     <p class="text-muted mb-0">NASDAQ100 指数の正体を業種分布から理解する</p>
                 </div>
-                <div class="text-right">
+                <div class="text-end">
                     <a href="https://jp.tradingview.com/symbols/NASDAQ-NDX/components/" target="_blank"
                        class="btn btn-sm btn-outline-info">
                         TradingView <i class="fas fa-external-link-alt"></i>
@@ -701,7 +701,7 @@
                     SPY (S&P500) と比較して景気敏感な金融セクターが含まれず、技術革新や高い成長性を期待される企業が集まっているため、強気相場では市場を牽引する役割を果たします。
                 </p>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
@@ -738,7 +738,7 @@
                     </div>
                 </div>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-end mt-3">
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>


### PR DESCRIPTION
  Closes #642 (parent: #636)                                                                                                                                                                                                       
                                                            
  usa_research テンプレートを Bootstrap 5 に完全移行する。

  - base.html
    - ナビバートグラーの data-toggle / data-target を data-bs-toggle / data-bs-target に修正（BS5でモバイルメニューが動作しないバグ修正）
    - mr-3 → me-3
    - myUrl スクリプト削除（vnm:index を誤参照しており、usa_research では AJAX 未使用のため不要）
  - index.html
    - スペーシング: mr-* → me-*
    - テキスト配置: text-right → text-end、text-left → text-start
    - ボーダー: border-left / border-right → border-start / border-end
    - フォント: font-weight-bold → fw-bold
    - バッジ: badge-success/warning/danger → bg-success/warning/danger（テキスト色クラスも付与）
  - financial_results/ 3ファイル（index.html, create.html, detail.html）は確認済みで BS5 対応済みのため変更なし

  Test plan

  - ナビバーのハンバーガーメニューがモバイル幅で開閉できる
  - /usa_research/ の各セクション表示（マクロ指標・資産リターン・MSCIレポート・アルマナック・セクターローテーション・NASDAQ100・RSS）が崩れていない
  - セクターローテーションの信号機バッジ（Green/Yellow/Red）の色が正常に表示される
  - /usa_research/financial_results/ 一覧・登録・詳細が正常に表示される
