### PR TITLE
 soil: Bootstrap 5 への完全移行 & リデザイン

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(ls C:/Users/yoshi/OneDrive/dev/portfolio/*.md)"
+      "Bash(ls C:/Users/yoshi/OneDrive/dev/portfolio/*.md)",
+      "WebFetch(domain:github.com)"
     ]
   }
 }

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -49,9 +49,13 @@ class LandCreateForm(forms.ModelForm):
         queryset=JmaPrefecture.objects.all(),
         empty_label="選択してください",
         label="都道府県",
+        widget=forms.Select(attrs={"class": "form-select", "tabindex": "2"}),
     )
     jma_city = forms.ModelChoiceField(
-        queryset=JmaCity.objects.all(), empty_label="選択してください", label="市区町村"
+        queryset=JmaCity.objects.all(),
+        empty_label="選択してください",
+        label="市区町村",
+        widget=forms.Select(attrs={"class": "form-select", "tabindex": "3"}),
     )
 
     class Meta:
@@ -69,20 +73,6 @@ class LandCreateForm(forms.ModelForm):
         )
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control", "tabindex": "1"}),
-            "jma_prefecture": forms.Select(
-                attrs={
-                    "class": "form-select",
-                    "tabindex": "2",
-                    "placeholder": "都道府県を選択してください",
-                }
-            ),
-            "jma_city": forms.Select(
-                attrs={
-                    "class": "form-select",
-                    "tabindex": "3",
-                    "placeholder": "市区町村を選択してください",
-                }
-            ),
             "center": forms.TextInput(
                 attrs={
                     "class": "form-control",

--- a/soil_analysis/templates/soil_analysis/base.html
+++ b/soil_analysis/templates/soil_analysis/base.html
@@ -43,7 +43,7 @@
     <nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid px-3">
             <a class="navbar-brand" href="{% url 'home:index' %}">Henojiya</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                     aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/soil_analysis/templates/soil_analysis/company/create.html
+++ b/soil_analysis/templates/soil_analysis/company/create.html
@@ -32,35 +32,33 @@
                         <div class="row">
                             {% for field in form %}
                                 <div class="col-12 mb-4">
-                                    <div class="form-group">
-                                        {% if field.label %}
-                                            <label for="{{ field.id_for_label }}"
-                                                   class="form-label text-muted fw-semibold mb-2">
-                                                {{ field.label }}
-                                                {% if field.field.required %}
-                                                    <span class="text-danger ms-1">*</span>
-                                                {% endif %}
-                                            </label>
-                                        {% endif %}
+                                    {% if field.label %}
+                                        <label for="{{ field.id_for_label }}"
+                                               class="form-label text-muted fw-semibold mb-2">
+                                            {{ field.label }}
+                                            {% if field.field.required %}
+                                                <span class="text-danger ms-1">*</span>
+                                            {% endif %}
+                                        </label>
+                                    {% endif %}
 
-                                        <div class="input-wrapper">
-                                            {{ field }}
-                                        </div>
-
-                                        {% if field.help_text %}
-                                            <div class="form-text text-muted small mt-1">
-                                                <i class="fas fa-info-circle me-1"></i>{{ field.help_text }}
-                                            </div>
-                                        {% endif %}
-
-                                        {% if field.errors %}
-                                            {% for error in field.errors %}
-                                                <div class="invalid-feedback d-block mt-1">
-                                                    <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
-                                                </div>
-                                            {% endfor %}
-                                        {% endif %}
+                                    <div class="input-wrapper">
+                                        {{ field }}
                                     </div>
+
+                                    {% if field.help_text %}
+                                        <div class="form-text text-muted small mt-1">
+                                            <i class="fas fa-info-circle me-1"></i>{{ field.help_text }}
+                                        </div>
+                                    {% endif %}
+
+                                    {% if field.errors %}
+                                        {% for error in field.errors %}
+                                            <div class="invalid-feedback d-block mt-1">
+                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                            </div>
+                                        {% endfor %}
+                                    {% endif %}
                                 </div>
                             {% endfor %}
                         </div>

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -2,70 +2,108 @@
 {% load static %}
 
 {% block content %}
-    <div class="container">
-        <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item active" aria-current="page">Home</li>
+    <div class="container mt-4">
+        <!-- Breadcrumb -->
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item active" aria-current="page">土壌分析CRM</li>
             </ol>
         </nav>
 
-        <h3 class="mb-3">企業別圃場一覧</h3>
-        <div class="mb-4">
-            <a class="btn btn-primary me-2" href="{% url 'soil:company_create' %}" role="button">企業の追加</a>
-            <a class="btn btn-outline-primary me-2" href="{% url 'soil:hardness_upload' %}" role="button">土壌硬度データ取り込み</a>
-            <a class="btn btn-outline-primary me-2" href="{% url 'soil:route_suggest_upload' %}" role="button">圃場ルートサジェスト</a>
-            <a class="btn btn-outline-primary" href="{% url 'soil:associate_picture_and_land' %}" role="button">写真と圃場の自動紐づけ</a>
-        </div>
+        <div class="row g-4">
+            <!-- Hero Section -->
+            <div class="col-12">
+                <div class="bg-light p-5 rounded shadow-sm">
+                    <h1 class="display-5">土壌分析CRM</h1>
+                    <p class="lead">農業法人の圃場情報・土壌データを一元管理します。</p>
+                    <hr class="my-4">
+                    <div class="d-flex flex-wrap gap-2">
+                        <a class="btn btn-primary" href="{% url 'soil:company_create' %}">
+                            <i class="fas fa-building me-1"></i>企業の追加
+                        </a>
+                        <a class="btn btn-outline-primary" href="{% url 'soil:hardness_upload' %}">
+                            <i class="fas fa-upload me-1"></i>土壌硬度データ取り込み
+                        </a>
+                        <a class="btn btn-outline-primary" href="{% url 'soil:route_suggest_upload' %}">
+                            <i class="fas fa-route me-1"></i>圃場ルートサジェスト
+                        </a>
+                        <a class="btn btn-outline-primary" href="{% url 'soil:associate_picture_and_land' %}">
+                            <i class="fas fa-camera me-1"></i>写真と圃場の自動紐づけ
+                        </a>
+                    </div>
+                </div>
+            </div>
 
-        {% if companies %}
-            <div class="table-responsive">
-                <table class="table table-striped table-hover">
-                    <thead>
-                        <tr>
-                            <th>企業名</th>
-                            <th>圃場名</th>
-                            <th>操作</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for company in companies %}
-                            {% if company.land_set.all %}
-                                {% for land in company.land_set.all %}
+            <!-- 企業別圃場一覧 -->
+            <div class="col-12">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h2 class="h3 mb-0"><i class="fas fa-list me-2 text-muted"></i>企業別圃場一覧</h2>
+                </div>
+
+                {% if companies %}
+                    <div class="card border-0 shadow-sm">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead class="table-light">
                                     <tr>
-                                        {% if forloop.first %}
-                                            <td rowspan="{{ company.land_set.all|length }}">
-                                                <a href="{% url 'soil:company_detail' company.pk %}">{{ company.name }}</a>
-                                            </td>
-                                        {% endif %}
-                                        <td>
-                                            <a href="{% url 'soil:land_detail' company.pk land.pk %}">{{ land.name }}</a>
-                                        </td>
-                                        {% if forloop.first %}
-                                            <td rowspan="{{ company.land_set.all|length }}">
-                                                <a class="btn btn-sm btn-outline-primary" href="{% url 'soil:land_create' company.pk %}" role="button">圃場の追加</a>
-                                            </td>
-                                        {% endif %}
+                                        <th>企業名</th>
+                                        <th>圃場名</th>
+                                        <th class="text-end">操作</th>
                                     </tr>
-                                {% endfor %}
-                            {% else %}
-                                <tr>
-                                    <td>
-                                        <a href="{% url 'soil:company_detail' company.pk %}">{{ company.name }}</a>
-                                    </td>
-                                    <td class="text-muted">（圃場なし）</td>
-                                    <td>
-                                        <a class="btn btn-sm btn-outline-primary" href="{% url 'soil:land_create' company.pk %}" role="button">圃場の追加</a>
-                                    </td>
-                                </tr>
-                            {% endif %}
-                        {% endfor %}
-                    </tbody>
-                </table>
+                                </thead>
+                                <tbody>
+                                    {% for company in companies %}
+                                        {% if company.land_set.all %}
+                                            {% for land in company.land_set.all %}
+                                                <tr>
+                                                    {% if forloop.first %}
+                                                        <td rowspan="{{ company.land_set.all|length }}" class="align-middle">
+                                                            <a href="{% url 'soil:company_detail' company.pk %}" class="fw-semibold text-decoration-none">{{ company.name }}</a>
+                                                        </td>
+                                                    {% endif %}
+                                                    <td class="align-middle">
+                                                        <a href="{% url 'soil:land_detail' company.pk land.pk %}" class="text-decoration-none">{{ land.name }}</a>
+                                                    </td>
+                                                    {% if forloop.first %}
+                                                        <td rowspan="{{ company.land_set.all|length }}" class="align-middle text-end">
+                                                            <a class="btn btn-sm btn-outline-primary" href="{% url 'soil:land_create' company.pk %}">
+                                                                <i class="fas fa-plus me-1"></i>圃場の追加
+                                                            </a>
+                                                        </td>
+                                                    {% endif %}
+                                                </tr>
+                                            {% endfor %}
+                                        {% else %}
+                                            <tr>
+                                                <td class="align-middle">
+                                                    <a href="{% url 'soil:company_detail' company.pk %}" class="fw-semibold text-decoration-none">{{ company.name }}</a>
+                                                </td>
+                                                <td class="text-muted align-middle">（圃場なし）</td>
+                                                <td class="text-end align-middle">
+                                                    <a class="btn btn-sm btn-outline-primary" href="{% url 'soil:land_create' company.pk %}">
+                                                        <i class="fas fa-plus me-1"></i>圃場の追加
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        {% endif %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="card bg-light border-0 py-5 text-center">
+                        <div class="card-body">
+                            <i class="fas fa-building fa-3x text-muted mb-3 opacity-25"></i>
+                            <h4 class="text-muted mb-3">まだ企業が登録されていません</h4>
+                            <p class="text-secondary small mb-4">上のボタンから農業法人を追加してください。</p>
+                            <a href="{% url 'soil:company_create' %}" class="btn btn-primary">
+                                <i class="fas fa-plus me-1"></i>企業を追加する
+                            </a>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
-        {% else %}
-            <div class="alert alert-info" role="alert">
-                まだ企業が登録されていません。上のボタンから農業法人を追加してください。
-            </div>
-        {% endif %}
+        </div>
     </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -32,84 +32,78 @@
                         <!-- 圃場名（1行全体） -->
                         <div class="row">
                             <div class="col-12 mb-4">
-                                <div class="form-group">
-                                    {% if form.name.label %}
-                                        <label for="{{ form.name.id_for_label }}"
-                                               class="form-label text-muted fw-semibold mb-2">
-                                            {{ form.name.label }}
-                                            {% if form.name.field.required %}
-                                                <span class="text-danger ms-1">*</span>
-                                            {% endif %}
-                                        </label>
-                                    {% endif %}
+                                {% if form.name.label %}
+                                    <label for="{{ form.name.id_for_label }}"
+                                           class="form-label text-muted fw-semibold mb-2">
+                                        {{ form.name.label }}
+                                        {% if form.name.field.required %}
+                                            <span class="text-danger ms-1">*</span>
+                                        {% endif %}
+                                    </label>
+                                {% endif %}
 
-                                    <div class="input-wrapper">
-                                        {{ form.name }}
-                                    </div>
-
-                                    {% if form.name.errors %}
-                                        {% for error in form.name.errors %}
-                                            <div class="invalid-feedback d-block mt-1">
-                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
-                                            </div>
-                                        {% endfor %}
-                                    {% endif %}
+                                <div class="input-wrapper">
+                                    {{ form.name }}
                                 </div>
+
+                                {% if form.name.errors %}
+                                    {% for error in form.name.errors %}
+                                        <div class="invalid-feedback d-block mt-1">
+                                            <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
                             </div>
                         </div>
 
                         <!-- 都道府県・市区町村（横並び） -->
                         <div class="row">
                             <div class="col-md-6 mb-4">
-                                <div class="form-group">
-                                    {% if form.jma_prefecture.label %}
-                                        <label for="{{ form.jma_prefecture.id_for_label }}"
-                                               class="form-label text-muted fw-semibold mb-2">
-                                            {{ form.jma_prefecture.label }}
-                                            {% if form.jma_prefecture.field.required %}
-                                                <span class="text-danger ms-1">*</span>
-                                            {% endif %}
-                                        </label>
-                                    {% endif %}
+                                {% if form.jma_prefecture.label %}
+                                    <label for="{{ form.jma_prefecture.id_for_label }}"
+                                           class="form-label text-muted fw-semibold mb-2">
+                                        {{ form.jma_prefecture.label }}
+                                        {% if form.jma_prefecture.field.required %}
+                                            <span class="text-danger ms-1">*</span>
+                                        {% endif %}
+                                    </label>
+                                {% endif %}
 
-                                    <div class="input-wrapper">
-                                        {{ form.jma_prefecture }}
-                                    </div>
-
-                                    {% if form.jma_prefecture.errors %}
-                                        {% for error in form.jma_prefecture.errors %}
-                                            <div class="invalid-feedback d-block mt-1">
-                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
-                                            </div>
-                                        {% endfor %}
-                                    {% endif %}
+                                <div class="input-wrapper">
+                                    {{ form.jma_prefecture }}
                                 </div>
+
+                                {% if form.jma_prefecture.errors %}
+                                    {% for error in form.jma_prefecture.errors %}
+                                        <div class="invalid-feedback d-block mt-1">
+                                            <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
                             </div>
 
                             <div class="col-md-6 mb-4">
-                                <div class="form-group">
-                                    {% if form.jma_city.label %}
-                                        <label for="{{ form.jma_city.id_for_label }}"
-                                               class="form-label text-muted fw-semibold mb-2">
-                                            {{ form.jma_city.label }}
-                                            {% if form.jma_city.field.required %}
-                                                <span class="text-danger ms-1">*</span>
-                                            {% endif %}
-                                        </label>
-                                    {% endif %}
+                                {% if form.jma_city.label %}
+                                    <label for="{{ form.jma_city.id_for_label }}"
+                                           class="form-label text-muted fw-semibold mb-2">
+                                        {{ form.jma_city.label }}
+                                        {% if form.jma_city.field.required %}
+                                            <span class="text-danger ms-1">*</span>
+                                        {% endif %}
+                                    </label>
+                                {% endif %}
 
-                                    <div class="input-wrapper">
-                                        {{ form.jma_city }}
-                                    </div>
-
-                                    {% if form.jma_city.errors %}
-                                        {% for error in form.jma_city.errors %}
-                                            <div class="invalid-feedback d-block mt-1">
-                                                <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
-                                            </div>
-                                        {% endfor %}
-                                    {% endif %}
+                                <div class="input-wrapper">
+                                    {{ form.jma_city }}
                                 </div>
+
+                                {% if form.jma_city.errors %}
+                                    {% for error in form.jma_city.errors %}
+                                        <div class="invalid-feedback d-block mt-1">
+                                            <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
                             </div>
                         </div>
 
@@ -118,35 +112,33 @@
                             {% for field in form %}
                                 {% if field.name != 'name' and field.name != 'jma_prefecture' and field.name != 'jma_city' %}
                                     <div class="col-md-6 mb-4">
-                                        <div class="form-group">
-                                            {% if field.label %}
-                                                <label for="{{ field.id_for_label }}"
-                                                       class="form-label text-muted fw-semibold mb-2">
-                                                    {{ field.label }}
-                                                    {% if field.field.required %}
-                                                        <span class="text-danger ms-1">*</span>
-                                                    {% endif %}
-                                                </label>
-                                            {% endif %}
+                                        {% if field.label %}
+                                            <label for="{{ field.id_for_label }}"
+                                                   class="form-label text-muted fw-semibold mb-2">
+                                                {{ field.label }}
+                                                {% if field.field.required %}
+                                                    <span class="text-danger ms-1">*</span>
+                                                {% endif %}
+                                            </label>
+                                        {% endif %}
 
-                                            <div class="input-wrapper">
-                                                {{ field }}
-                                            </div>
-
-                                            {% if field.help_text %}
-                                                <div class="form-text text-muted small mt-1">
-                                                    <i class="fas fa-info-circle me-1"></i>{{ field.help_text }}
-                                                </div>
-                                            {% endif %}
-
-                                            {% if field.errors %}
-                                                {% for error in field.errors %}
-                                                    <div class="invalid-feedback d-block mt-1">
-                                                        <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
-                                                    </div>
-                                                {% endfor %}
-                                            {% endif %}
+                                        <div class="input-wrapper">
+                                            {{ field }}
                                         </div>
+
+                                        {% if field.help_text %}
+                                            <div class="form-text text-muted small mt-1">
+                                                <i class="fas fa-info-circle me-1"></i>{{ field.help_text }}
+                                            </div>
+                                        {% endif %}
+
+                                        {% if field.errors %}
+                                            {% for error in field.errors %}
+                                                <div class="invalid-feedback d-block mt-1">
+                                                    <i class="fas fa-exclamation-triangle me-1"></i>{{ error }}
+                                                </div>
+                                            {% endfor %}
+                                        {% endif %}
                                     </div>
                                 {% endif %}
                             {% endfor %}

--- a/soil_analysis/templates/soil_analysis/land/create.html
+++ b/soil_analysis/templates/soil_analysis/land/create.html
@@ -272,15 +272,17 @@
 
         // ページ読み込み時の初期化
         document.addEventListener('DOMContentLoaded', function () {
-            // 初期状態では都市選択を無効化
-            disableCitySelect()
-
-            // 都道府県選択の変更イベント
             const prefectureSelect = document.getElementById("id_jma_prefecture")
             if (prefectureSelect) {
+                // バリデーションエラー後の再表示など、都道府県に値が入っている場合はそのまま市区町村を取得
+                if (prefectureSelect.value) {
+                    fetchCities(prefectureSelect.value)
+                } else {
+                    disableCitySelect()
+                }
+
                 prefectureSelect.addEventListener("change", function () {
-                    const prefectureId = this.value
-                    fetchCities(prefectureId)
+                    fetchCities(this.value)
                 })
             }
         })


### PR DESCRIPTION
● ## Summary                                                
                                                                                                                                                                                                                                   
  soil_analysis アプリの Bootstrap 5 完全移行とリデザインを実施しました。    
                                                                                                                                                                                                                                   
  - `base.html`: Bootstrap 4 のナビバートグラー属性（`data-toggle` / `data-target`）を BS5 の `data-bs-toggle` / `data-bs-target` に修正（モバイル表示でナビバーが開かない不具合を解消）                                           
  - `company/create.html`: BS5 で廃止された `form-group` ラッパー `div` を除去                                                                                                                                                     
  - `land/create.html`: 全フィールドの `form-group` ラッパー `div` を除去                                                                                                                                                          
  - `home.html`: vietnam_research のトンマナに準拠したリデザインを実施（ヒーローセクション追加・テーブルカード化・空状態UI改善）

  ## 目検による動作確認手順

  - [x] `/soil_analysis/` にアクセスし、ヒーローセクション（タイトル・説明文・アクションボタン群）が表示されること
  - [x] 企業が登録済みの場合、企業別圃場一覧テーブルがカード内に表示されること
  - [x] 企業が未登録の場合、空状態カード（アイコン・メッセージ・追加ボタン）が表示されること
  - [x] モバイル幅（〜768px）でナビバーのトグルボタンを押すと、メニューが正しく開閉されること
  - [x] `/soil_analysis/company/create/` で企業作成フォームが正常に表示・送信できること
  - [x] `/soil_analysis/land/create/<company_pk>/` で圃場作成フォームが正常に表示・送信できること（都道府県→市区町村の連動ドロップダウンも含む）

  ## 自動テストでカバーできた範囲

  なし（テンプレート変更のみのため）

  ## 関連Issue

  https://github.com/duri0214/portfolio/issues/643
