### PR TITLE
refactor: taxonomy: Bootstrap 5 への完全移行 & リデザイン

### DIFF
--- a/rental_shop/templates/rental_shop/invoice/detail.html
+++ b/rental_shop/templates/rental_shop/invoice/detail.html
@@ -57,8 +57,7 @@
                                     <tr>
                                         <th class="text-muted">合計金額</th>
                                         <td class="fs-5 fw-bold text-danger">
-                                            {# 金額計算が必要な場合はモデルにメソッドがあるか確認すべきだが、ここでは表示のみ #}
-                                            <i class="fas fa-coins me-2 text-secondary"></i>--- 円
+                                            <i class="fas fa-coins me-2 text-secondary"></i>{{ total|intcomma }}円
                                         </td>
                                     </tr>
                                 </table>

--- a/rental_shop/views.py
+++ b/rental_shop/views.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 from django.contrib import messages
 from django.http import JsonResponse
 from django.shortcuts import redirect
@@ -142,6 +144,8 @@ class InvoiceCreateView(CreateView):
         )
         if staff:
             initial["staff"] = staff
+        initial["rental_start_date"] = date.today()
+        initial["rental_end_date"] = date.today() + timedelta(days=7)
         return initial
 
     def form_invalid(self, form):
@@ -170,7 +174,9 @@ class InvoiceDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["items"] = Item.objects.filter(invoice=self.object)
+        items = Item.objects.filter(invoice=self.object)
+        context["items"] = items
+        context["total"] = sum(item.price for item in items)
         return context
 
 

--- a/taxonomy/templates/taxonomy/base.html
+++ b/taxonomy/templates/taxonomy/base.html
@@ -42,12 +42,11 @@
     <link rel="shortcut icon" href="{% static 'taxonomy/s_t.ico' %}">
 </head>
 <body>
-<h1></h1>
 <header>
     <nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid px-3">
             <a class="navbar-brand" href="{% url 'home:index' %}">Henojiya</a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                     aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -120,6 +119,19 @@
 
 <div id="main" style="margin-top: 70px;"> {# ナビバーの高さ #}
     {% block content %}{% endblock %}
+</div>
+
+<!-- Global Toast Container -->
+<div class="toast-container position-fixed bottom-0 end-0 p-3">
+    <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="toast-header bg-warning text-dark">
+            <strong class="me-auto">お知らせ</strong>
+            <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+        <div class="toast-body" id="toastMessage">
+            ここにメッセージが表示されます。
+        </div>
+    </div>
 </div>
 <footer>
     <p>© 2019 henojiya. / <a href="https://github.com/duri0214" target="_blank">GitHub portfolio</a></p>

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -1,49 +1,138 @@
 {% extends "taxonomy/base.html" %}
 {% load static %}
 {% block content %}
-    <div class="custom-section bg-light p-5 rounded">
-        <h1 class="display-4">Let's analyze Taxonomy!</h1>
-        <p class="lead">it's interesting Taxonomy</p>
-        <hr class="my-4">
-        <p>You can understand taxonomies</p>
-        <ul class="list-items">
-            <li><a class="btn btn-secondary btn-sm disabled" href="#" role="button">界(kingdom)のメンテナンス</a>
-            </li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#"
-                   role="button">門(phylum)のメンテナンス</a></li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#" role="button">綱(classification)のメンテナンス</a>
-            </li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#"
-                   role="button">科(family)のメンテナンス</a></li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#"
-                   role="button">属(genus)のメンテナンス</a></li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#" role="button">種(species)のメンテナンス</a>
-            </li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#"
-                   role="button">品種(breed)のメンテナンス</a></li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#"
-                   role="button">タグ(tag)のメンテナンス</a></li>
-            <li><a class="btn btn-secondary btn-sm disabled" href="#"
-                   role="button">品種とタグの紐づけ</a></li>
-        </ul>
-        <ul class="list-items">
-            <li><a class="btn btn-outline-primary" href="{% url 'txo:observation' %}"
-                   role="button">鶏の観察グラフ</a>
-            </li>
-        </ul>
-    </div>
-    <section class="container">
-        <h3>分類グラフ</h3>
-        <div id="chicken-classification-chart">
-            <div class="text">See one-liners for each transition</div>
-            <script>
-                const dataSpec = {
-                    source: JSON.parse('{{ data|safe }}'),
-                    key: "name",
-                };
-                const myChart = d3.indentedTree(dataSpec);
-                d3.select("#chicken-classification-chart").append("div").attr("class", "chart").call(myChart);
-            </script>
+    <div class="container mt-4">
+        <!-- Breadcrumb -->
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item active" aria-current="page">分類学</li>
+            </ol>
+        </nav>
+
+        <div class="row g-4">
+            <!-- Hero Section -->
+            <div class="col-12">
+                <div class="bg-light p-5 rounded shadow-sm">
+                    <h1 class="display-4">Let's analyze Taxonomy!</h1>
+                    <p class="lead">生き物の分類体系を探究します。</p>
+                    <hr class="my-4">
+                    <div class="d-flex flex-wrap gap-2">
+                        <a class="btn btn-outline-primary" href="{% url 'txo:observation' %}">鶏の観察グラフ</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Maintenance Menu -->
+            <div class="col-12">
+                <h2 class="h4 mb-3">メンテナンスメニュー</h2>
+                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+                    {% for item in menu_items %}
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">{{ item.label }}</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">界(kingdom)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">門(phylum)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">綱(classification)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">科(family)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">属(genus)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">種(species)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">品種(breed)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">タグ(tag)のメンテナンス</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="card h-100 shadow-sm border-0">
+                                <div class="card-body d-flex align-items-center justify-content-between">
+                                    <span class="small text-muted">品種とタグの紐づけ</span>
+                                    <a class="btn btn-outline-secondary btn-sm disabled" href="#" role="button">開く</a>
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+
+            <!-- Classification Chart -->
+            <div class="col-12">
+                <div class="card shadow-sm border-0">
+                    <div class="card-header bg-white border-bottom-0 pt-3">
+                        <h2 class="h5 mb-0">分類グラフ</h2>
+                    </div>
+                    <div class="card-body">
+                        <div id="chicken-classification-chart">
+                            <div class="text">See one-liners for each transition</div>
+                            <script>
+                                const dataSpec = {
+                                    source: JSON.parse('{{ data|safe }}'),
+                                    key: "name",
+                                };
+                                const myChart = d3.indentedTree(dataSpec);
+                                d3.select("#chicken-classification-chart").append("div").attr("class", "chart").call(myChart);
+                            </script>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-    </section>
+    </div>
 {% endblock %}

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -1,40 +1,92 @@
 {% extends "taxonomy/base.html" %}
 {% load static %}
 {% block content %}
-    <section class="container">
-        <h3>長野県で鶏を飼っていたころの観察データ</h3>
-        <p>餌を半分にしても生産量は変わらないことがわかる</p>
-        <h4>餌の量と卵生産量の推移</h4>
-        <div id="feed-vs-egg-chart" data-feed-data='{{ feed_vs_egg }}'></div>
-        <h4>フィードグループ別の産卵率推移</h4>
-        {% for group in feed_group_laying_rate %}
-            <h5>フィードグループ: {{ group.feed_group }}</h5>
-            <table class="table table-striped">
-                <thead>
-                <tr>
-                    <th scope="col">日付</th>
-                    <th scope="col">天気</th>
-                    <th scope="col">産卵率</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for item in group.data %}
-                    <tr>
-                        <td>{{ item.date }}</td>
-                        <td>
-                            {% if item.weather_code %}
-                                {% with 'soil_analysis/images/weather/svg/'|add:item.weather_code|add:'.svg' as weather_svg_path %}
-                                    <img src="{% static weather_svg_path %}" width="30" alt="{{ item.weather_code }}">
-                                {% endwith %}
-                            {% else %}
-                                -
-                            {% endif %}
-                        </td>
-                        <td>{{ item.laying_rate }}</td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        {% endfor %}
-    </section>
+    <div class="container mt-4">
+        <!-- Breadcrumb -->
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'txo:index' %}">分類学</a></li>
+                <li class="breadcrumb-item active" aria-current="page">鶏の観察グラフ</li>
+            </ol>
+        </nav>
+
+        <div class="row g-4">
+            <!-- Hero -->
+            <div class="col-12">
+                <div class="bg-light p-5 rounded shadow-sm">
+                    <h1 class="display-5"><i class="fas fa-egg me-2 text-warning"></i>鶏の観察データ</h1>
+                    <p class="lead mb-0">長野県で鶏を飼っていたころの記録</p>
+                </div>
+            </div>
+
+            <!-- Key Insight -->
+            <div class="col-12">
+                <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
+                    <i class="fas fa-lightbulb me-2"></i>
+                    <span>餌の量を半分にしても卵の生産量はほとんど変わらないことがデータから確認できます。</span>
+                </div>
+            </div>
+
+            <!-- Feed vs Egg Chart -->
+            <div class="col-12">
+                <div class="card shadow-sm border-0">
+                    <div class="card-header bg-white pt-3 pb-2">
+                        <h2 class="h6 mb-0 text-muted text-uppercase fw-semibold">
+                            <i class="fas fa-chart-line me-1"></i>餌の量と卵生産量の推移
+                        </h2>
+                    </div>
+                    <div class="card-body">
+                        <div id="feed-vs-egg-chart" data-feed-data='{{ feed_vs_egg }}'></div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Feed Group Laying Rate -->
+            <div class="col-12">
+                <h2 class="h5 mb-3">
+                    <i class="fas fa-table me-1 text-secondary"></i>フィードグループ別の産卵率推移
+                </h2>
+                <div class="row row-cols-1 row-cols-lg-2 g-3">
+                    {% for group in feed_group_laying_rate %}
+                        <div class="col">
+                            <div class="card shadow-sm border-0 h-100">
+                                <div class="card-header bg-white pt-3 pb-2 d-flex align-items-center gap-2">
+                                    <i class="fas fa-layer-group text-secondary"></i>
+                                    <h3 class="h6 mb-0">{{ group.feed_group }}</h3>
+                                </div>
+                                <div class="card-body p-0">
+                                    <table class="table table-striped table-hover table-sm mb-0">
+                                        <thead class="table-light">
+                                        <tr>
+                                            <th scope="col" class="ps-3">日付</th>
+                                            <th scope="col">天気</th>
+                                            <th scope="col">産卵率</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        {% for item in group.data %}
+                                            <tr>
+                                                <td class="ps-3 text-muted small">{{ item.date }}</td>
+                                                <td>
+                                                    {% if item.weather_code %}
+                                                        {% with 'soil_analysis/images/weather/svg/'|add:item.weather_code|add:'.svg' as weather_svg_path %}
+                                                            <img src="{% static weather_svg_path %}" width="24" alt="{{ item.weather_code }}">
+                                                        {% endwith %}
+                                                    {% else %}
+                                                        <span class="text-muted">-</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td class="fw-semibold">{{ item.laying_rate }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/usa_research/templates/usa_research/base.html
+++ b/usa_research/templates/usa_research/base.html
@@ -101,22 +101,6 @@
                             <option value="{% url 'bank:index' %}" {% if request.path == '/bank/' %}selected{% endif %}>BANK</option>
                         </select>
                     </li>
-                    {% if user.is_authenticated %}
-                        <li class="nav-item small me-3">
-
-                            <span class="nav-link"><i class="fas fa-user"></i> {{ user.username }}さん</span>
-                        </li>
-                        <li class="nav-item">
-                            <form method="post" action="{% url 'logout' %}">
-                                {% csrf_token %}
-                                <button type="submit" class="btn btn-outline-danger">LOGOUT</button>
-                            </form>
-                        </li>
-                    {% else %}
-                        <li class="nav-item">
-                            <a href="{% url 'login' %}" class="btn btn-outline-primary">LOGIN</a>
-                        </li>
-                    {% endif %}
                 </ul>
                 <form class="d-flex my-2">
                     <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                       
  taxonomy アプリの Bootstrap 5 完全移行とリデザイン、および usa_research の不要なログイン UI 削除。                                                                                                                               
                                                                                                                                                                                                                                   
  - `taxonomy/base.html`: 空の `<h1>` 削除、navbar toggler を BS5 属性（`data-bs-toggle` / `data-bs-target`）に修正、Global Toast コンテナ追加                                                                                     
  - `taxonomy/index.html`: breadcrumb・ヒーローセクション・カードグリッド形式のメンテナンスメニュー・分類グラフカードに刷新                                                                                                        
  - `taxonomy/observation.html`: breadcrumb・ヒーローセクション・インサイトバナー追加、フィードグループテーブルを2カラムカードグリッドに変更                                                                                       
  - `usa_research/base.html`: 誤って存在していたログイン/ログアウト UI ブロックを削除

  ## 目検による動作確認手順
  - [x] http://127.0.0.1:8000/taxonomy/ を開き、ヒーローセクション・メンテナンスカード・分類グラフが正しく表示される
  - [x] http://127.0.0.1:8000/taxonomy/observation/ を開き、breadcrumb・インサイトバナー・チャート・フィードグループカードが正しく表示される
  - [x] ブラウザ幅を狭めてナビバーのハンバーガーメニューが開閉できる（BS5 属性修正の確認）
  - [x] http://127.0.0.1:8000/usa_research/ を開き、ナビバーにログイン/ログアウトボタンが表示されていない
  - [x] taxonomy・usa_research ともにナビバーにログインボタンが表示されていない

  ## 自動テストでカバーできた範囲
  なし（テンプレートのみの変更）

  ## 関連Issue
  https://github.com/duri0214/portfolio/issues/645
