### PR TITLE
DALL·E 3 → gpt-image-1-mini 移行対応

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -24,12 +24,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/hospital.png' %}" alt="不在者投票転記ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/hospital.png' %}" alt="不在者投票転記ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-primary text-white px-2 py-1">病院</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">不在者投票事務用の転記</h5>
-                        <p class="card-text small text-secondary">2015年当時、友人の残業時間を減らすために転記ツールを作成。病棟別の不在者投票データを事務処理簿等に自動転記し、大きく残業時間を削減。成果物は6時間ほどで完成し、横展開できそうだと病院の注目を集めた。</p>
+                        <p class="card-text small text-secondary">
+                            2015年当時、友人の残業時間を減らすために転記ツールを作成。病棟別の不在者投票データを事務処理簿等に自動転記し、大きく残業時間を削減。成果物は6時間ほどで完成し、横展開できそうだと病院の注目を集めた。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_hospital' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -40,12 +42,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/soil_analysis.png' %}" alt="土壌分析レポートツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/soil_analysis.png' %}" alt="土壌分析レポートツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-success text-white px-2 py-1">農業</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">圃場計測のレポーティング</h5>
-                        <p class="card-text small text-secondary">2023年当時、農業の調査をするため、一時的に静岡に移住し土壌分析のIT課題に取り組んだ。普段ITで扱うデータは誰かが集めたもので、実際にデータを収集するのは地道で大変な作業だと実感。雨の日も風の日も計測した</p>
+                        <p class="card-text small text-secondary">
+                            2023年当時、農業の調査をするため、一時的に静岡に移住し土壌分析のIT課題に取り組んだ。普段ITで扱うデータは誰かが集めたもので、実際にデータを収集するのは地道で大変な作業だと実感。雨の日も風の日も計測した</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_soil_analysis' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -56,12 +60,15 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/vietnam_research.png' %}" alt="ベトナム株価分析ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/vietnam_research.png' %}" alt="ベトナム株価分析ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-warning text-white px-2 py-1">経済</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">ベトナムの株価を分析する</h5>
-                        <p class="card-text small text-secondary">2019年当時、チャイナリスクを見据えてつぎの投資対象となりそうなベトナムについて調査し、名古屋市主催の「ベトナム ホーチミン 経済交流ミッション」に参加。訪問する直前、プレゼンテーションに作成した</p>
+                        <p class="card-text small text-secondary">
+                            2019年当時、チャイナリスクを見据えてつぎの投資対象となりそうなベトナムについて調査し、名古屋市主催の「ベトナム
+                            ホーチミン 経済交流ミッション」に参加。訪問する直前、プレゼンテーションに作成した</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_vietnam_research' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -72,12 +79,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/gmarker.png' %}" alt="GoogleMapsピン配置ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/gmarker.png' %}" alt="GoogleMapsピン配置ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-primary text-white px-2 py-1">地図</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">GoogleMapsにピンをさす</h5>
-                        <p class="card-text small text-secondary">2015年当時、ラーメン屋とか洋食などのワードでGoogleMapsにまとめてピンを打ち、さらに任意のピンだけに絞れるようなものを作れたら便利そうだなとおもったことからトライ。外部APIを初めて使ったツールとなった</p>
+                        <p class="card-text small text-secondary">
+                            2015年当時、ラーメン屋とか洋食などのワードでGoogleMapsにまとめてピンを打ち、さらに任意のピンだけに絞れるようなものを作れたら便利そうだなとおもったことからトライ。外部APIを初めて使ったツールとなった</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_gmarker' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -88,12 +97,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/shopping.png' %}" alt="ECサイト管理ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/shopping.png' %}" alt="ECサイト管理ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-success text-white px-2 py-1">ＥＣ</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">通販サイトの基礎機能</h5>
-                        <p class="card-text small text-secondary">2022年当時、ECサイトってやっぱり作れるようになっておいたほうがいいなと思ってトライしたもの。店員管理、商品管理、CSV登録機能、写真アップロード機能、カード決済など基本的なＥＣサイトの機能を実装した</p>
+                        <p class="card-text small text-secondary">
+                            2022年当時、ECサイトってやっぱり作れるようになっておいたほうがいいなと思ってトライしたもの。店員管理、商品管理、CSV登録機能、写真アップロード機能、カード決済など基本的なＥＣサイトの機能を実装した</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_shopping' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -104,12 +115,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/rental_shop.png' %}" alt="倉庫在庫管理ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/rental_shop.png' %}" alt="倉庫在庫管理ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-warning text-white px-2 py-1">倉庫</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">倉庫のどこにいくつあるの？</h5>
-                        <p class="card-text small text-secondary">2016年当時、物流のオープンデータ活用コンテストがあった。そのころはまだAPIをまともに扱うWeb開発スキルがなくて、話を振ってもらったものの断念した。2023年ごろWebアプリを作る力もついてきてアプリとして結実させた</p>
+                        <p class="card-text small text-secondary">
+                            2016年当時、物流のオープンデータ活用コンテストがあった。そのころはまだAPIをまともに扱うWeb開発スキルがなくて、話を振ってもらったものの断念した。2023年ごろWebアプリを作る力もついてきてアプリとして結実させた</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_rental_shop' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -120,12 +133,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/taxonomy.png' %}" alt="生物分類樹形図ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/taxonomy.png' %}" alt="生物分類樹形図ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-primary text-white px-2 py-1">分類学</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">ニワトリとミミズの種を分類</h5>
-                        <p class="card-text small text-secondary">2017年に地方に移住して畑作業をするなかで、土壌の生物性に興味をもった。鶏とミミズの種類を調べ上げて登録すると分類の樹形図ができあがるようなアプリがあったらいいなと思って2023年につくることにした。応用すれば家系図も作れるだろう</p>
+                        <p class="card-text small text-secondary">
+                            2017年に地方に移住して畑作業をするなかで、土壌の生物性に興味をもった。鶏とミミズの種類を調べ上げて登録すると分類の樹形図ができあがるようなアプリがあったらいいなと思って2023年につくることにした。応用すれば家系図も作れるだろう</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_taxonomy' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -136,12 +151,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/securities.png' %}" alt="有価証券報告書分析ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/securities.png' %}" alt="有価証券報告書分析ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-success text-white px-2 py-1">金融</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">金融庁の有価証券報告書を分析</h5>
-                        <p class="card-text small text-secondary">2019年当時、金融の業務知識を総動員して "有価証券報告書" をpythonで取得するプログラムを作った（当初は単にダウンロード済みの有価証券報告書ファイルを処理するもの）。2023年頃にWebアプリ（API版）として移植したついでに、分析する機能をつけた</p>
+                        <p class="card-text small text-secondary">2019年当時、金融の業務知識を総動員して "有価証券報告書"
+                            をpythonで取得するプログラムを作った（当初は単にダウンロード済みの有価証券報告書ファイルを処理するもの）。2023年頃にWebアプリ（API版）として移植したついでに、分析する機能をつけた</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_securities' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -152,12 +169,15 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/llm_chat.png' %}" alt="LLM統合チャットツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/llm_chat.png' %}" alt="LLM統合チャットツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-warning text-white px-2 py-1">LLM</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">GPTチャット</h5>
-                        <p class="card-text small text-secondary">2024年当時、Gemini, ChatGPT4, Dall-e-3, TextToSpeech, SpeechToText and RAG　といった一通りのLLMを実行する仕組みを作成した。さらにライブラリとして共通化したことによってどのアプリからでもgptに絡めることができるようになった</p>
+                        <p class="card-text small text-secondary">2024年当時、Gemini, ChatGPT4, gpt-image-1-mini,
+                            TextToSpeech, SpeechToText and
+                            RAG　といった一通りのLLMを実行する仕組みを作成した。さらにライブラリとして共通化したことによってどのアプリからでもgptに絡めることができるようになった</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_llm_chat' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -168,12 +188,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/ai_agent.png' %}" alt="会話型AIエージェントシステム" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/ai_agent.png' %}" alt="会話型AIエージェントシステム"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-primary text-white px-2 py-1">LLM</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">AI-AGENTの試作</h5>
-                        <p class="card-text small text-secondary">2025年当時、会話型AIエージェントシステムを構築。複数のAIエージェントによる対話を実現し、ターン制管理で自然な会話を実現。ガードレール機能でユーザー入力の安全性を確保しながら、各エージェントが専門分野に基づいた応答を生成する。</p>
+                        <p class="card-text small text-secondary">
+                            2025年当時、会話型AIエージェントシステムを構築。複数のAIエージェントによる対話を実現し、ターン制管理で自然な会話を実現。ガードレール機能でユーザー入力の安全性を確保しながら、各エージェントが専門分野に基づいた応答を生成する。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_ai_agent' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -184,12 +206,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/jp_stocks.png' %}" alt="日本株分析ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/jp_stocks.png' %}" alt="日本株分析ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-success text-white px-2 py-1">経済</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">日本の株価を分析する</h5>
-                        <p class="card-text small text-secondary">2025年当時、日本の株価を分析するための機能があればオモシロイと思った。現在は板シミュレーションしかおいていないが、そのうちrssでニュースを取得したりできるとよい仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章</p>
+                        <p class="card-text small text-secondary">
+                            2025年当時、日本の株価を分析するための機能があればオモシロイと思った。現在は板シミュレーションしかおいていないが、そのうちrssでニュースを取得したりできるとよい仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_jp_stocks' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -200,12 +224,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/welfare_services.png' %}" alt="東京都福祉事務所情報ポータル" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/welfare_services.png' %}" alt="東京都福祉事務所情報ポータル"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-info text-white px-2 py-1">ハッカソン</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">東京都福祉事務所情報ポータル</h5>
-                        <p class="card-text small text-secondary">2025年当時、東京都内の福祉事務所の情報を一元管理し、利用者に提供するポータルサイト。空き状況を信号機表示で直感的に把握できます。都知事杯オープンデータ・ハッカソン2025で「障がい福祉サービス空き情報の見える化」をテーマに開発。</p>
+                        <p class="card-text small text-secondary">
+                            2025年当時、東京都内の福祉事務所の情報を一元管理し、利用者に提供するポータルサイト。空き状況を信号機表示で直感的に把握できます。都知事杯オープンデータ・ハッカソン2025で「障がい福祉サービス空き情報の見える化」をテーマに開発。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_welfare_services' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -216,12 +242,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/no-image.png' %}" alt="USAニュース自動取得ツール" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/no-image.png' %}" alt="USAニュース自動取得ツール"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-primary text-white px-2 py-1">経済</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">USAニュースを分析する</h5>
-                        <p class="card-text small text-secondary">2025年当時、米国株や政治動向のトレンドを素早く把握したいと感じ、主要ニュースサイトの記事タイトル・概要・公開日時などを自動取得する仕組みを構築。カテゴリ別に閲覧でき、経済・政策・テックの動きを短時間で追えるようにした。</p>
+                        <p class="card-text small text-secondary">
+                            2025年当時、米国株や政治動向のトレンドを素早く把握したいと感じ、主要ニュースサイトの記事タイトル・概要・公開日時などを自動取得する仕組みを構築。カテゴリ別に閲覧でき、経済・政策・テックの動きを短時間で追えるようにした。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_usa_research' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -232,12 +260,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/no-image.png' %}" alt="国会議事録検索・分析システム" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/no-image.png' %}" alt="国会議事録検索・分析システム"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-info text-white px-2 py-1">政治</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">国会議事録を分析する</h5>
-                        <p class="card-text small text-secondary">2026年当時、国会の膨大な議事録から必要な情報を効率的に検索し、AI（LLM）を用いて内容を要約・分析するシステム。RAG技術を活用し、正確な根拠に基づいた回答生成を目指す。</p>
+                        <p class="card-text small text-secondary">
+                            2026年当時、国会の膨大な議事録から必要な情報を効率的に検索し、AI（LLM）を用いて内容を要約・分析するシステム。RAG技術を活用し、正確な根拠に基づいた回答生成を目指す。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_kokkai' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -248,12 +278,14 @@
             <div class="col">
                 <div class="card h-100 shadow-sm border-0">
                     <figure class="card-img-top mb-0">
-                        <img src="{% static 'home/images/no-image.png' %}" alt="銀行CSV分析基盤" class="img-fluid rounded-top">
+                        <img src="{% static 'home/images/no-image.png' %}" alt="銀行CSV分析基盤"
+                             class="img-fluid rounded-top">
                         <figcaption class="cat-name bg-info text-white px-2 py-1">金融</figcaption>
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">銀行CSVを分析</h5>
-                        <p class="card-text small text-secondary">2026年当時、銀行ごとに異なるCSVフォーマットの取引明細を取り込み、資金分析を行う基盤。銀行別のRawデータをそのまま保持し、長期的に拡張可能な設計で横断的なレポート生成を目指す。</p>
+                        <p class="card-text small text-secondary">
+                            2026年当時、銀行ごとに異なるCSVフォーマットの取引明細を取り込み、資金分析を行う基盤。銀行別のRawデータをそのまま保持し、長期的に拡張可能な設計で横断的なレポート生成を目指す。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_bank' %}" class="btn btn-primary btn-sm">詳細を見る</a>

--- a/lib/llm/prototype/llm_health_check.py
+++ b/lib/llm/prototype/llm_health_check.py
@@ -1,9 +1,10 @@
-import re
-import os
 import json
+import os
+import re
 from dataclasses import dataclass, field
-from typing import Any
 from enum import Enum
+from typing import Any
+
 from openai import OpenAI, AzureOpenAI, APIError
 
 
@@ -309,7 +310,7 @@ class AvailabilityValidator(BaseValidator):
         self._validate(
             "OpenAI",
             self.get_client("OpenAI", os.getenv("OPENAI_API_KEY")),
-            ["gpt-4o", "gpt-4o-mini", "dall-e-3"],
+            ["gpt-4o", "gpt-4o-mini", "gpt-image-1-mini"],
         )
 
         # Gemini

--- a/lib/llm/service/completion.py
+++ b/lib/llm/service/completion.py
@@ -29,7 +29,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")
 
 
-ImageSize = Literal["256x256", "512x512", "1024x1024", "1024x1792", "1792x1024"]
+ImageSize = Literal["1024x1024", "1024x1536", "1536x1024", "auto"]
 
 
 def cut_down_chat_history(
@@ -310,14 +310,14 @@ class OpenAILlmImageService(LlmService):
         self.client = OpenAI(api_key=self.config.api_key)
 
     def retrieve_answer(
-        self, message: Message, size: ImageSize = "256x256"
+        self, message: Message, size: ImageSize = "auto"
     ) -> ImagesResponse:
         """
         メッセージの内容に基づいて画像を生成します。
 
         Args:
             message (Message): 画像生成プロンプトを含むメッセージ
-            size (ImageSize): 画像のサイズ (例: "256x256", "512x512", "1024x1024", "1024x1792", "1792x1024")
+            size (ImageSize): 画像のサイズ (例: "1024x1024", "1024x1536", "1536x1024", "auto")
 
         Returns:
             ImagesResponse: 生成された画像のレスポンス
@@ -329,7 +329,6 @@ class OpenAILlmImageService(LlmService):
             model=self.config.model,
             prompt=message.content,
             size=size,
-            quality="standard",
             n=1,
         )
 

--- a/lib/llm/service/completion.py
+++ b/lib/llm/service/completion.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Generator, Iterable, Sequence
+from typing import Any, Generator, Iterable, Sequence, Literal
 
 import chromadb
 from chromadb.config import Settings
@@ -27,6 +27,9 @@ from lib.llm.valueobject.config import OpenAIGptConfig, GeminiConfig
 # .env ファイルを読み込む
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")
+
+
+ImageSize = Literal["256x256", "512x512", "1024x1024", "1024x1792", "1792x1024"]
 
 
 def cut_down_chat_history(
@@ -296,9 +299,9 @@ class LlmCompletionStreamingService(LlmService):
             yield f"data: {chunk.to_json()}\n\n"
 
 
-class OpenAILlmDalleService(LlmService):
+class OpenAILlmImageService(LlmService):
     """
-    OpenAIのDALL-Eモデルを使用して画像生成を行うサービス。
+    OpenAIの画像生成モデルを使用して画像生成を行うサービス。
     """
 
     def __init__(self, config: OpenAIGptConfig):
@@ -306,12 +309,15 @@ class OpenAILlmDalleService(LlmService):
         self.config = config
         self.client = OpenAI(api_key=self.config.api_key)
 
-    def retrieve_answer(self, message: Message) -> ImagesResponse:
+    def retrieve_answer(
+        self, message: Message, size: ImageSize = "256x256"
+    ) -> ImagesResponse:
         """
         メッセージの内容に基づいて画像を生成します。
 
         Args:
             message (Message): 画像生成プロンプトを含むメッセージ
+            size (ImageSize): 画像のサイズ (例: "256x256", "512x512", "1024x1024", "1024x1792", "1792x1024")
 
         Returns:
             ImagesResponse: 生成された画像のレスポンス
@@ -322,7 +328,7 @@ class OpenAILlmDalleService(LlmService):
         return self.client.images.generate(
             model=self.config.model,
             prompt=message.content,
-            size="1024x1024",
+            size=size,
             quality="standard",
             n=1,
         )

--- a/lib/llm/valueobject/config.py
+++ b/lib/llm/valueobject/config.py
@@ -9,7 +9,9 @@ class ApiConfig(ABC):
     max_tokens: int
 
 
-OpenAiModel = Literal["gpt-4o", "gpt-5", "gpt-5-mini", "dall-e-3", "tts-1", "whisper-1"]
+OpenAiModel = Literal[
+    "gpt-4o", "gpt-5", "gpt-5-mini", "gpt-image-1-mini", "tts-1", "whisper-1"
+]
 GeminiModel = Literal["gemini-2.0-flash", "gemini-2.5-flash"]
 
 
@@ -18,7 +20,7 @@ class ModelName:
     GPT_4O: OpenAiModel = "gpt-4o"
     GPT_5: OpenAiModel = "gpt-5"
     GPT_5_MINI: OpenAiModel = "gpt-5-mini"
-    DALLE_3: OpenAiModel = "dall-e-3"
+    GPT_IMAGE_1_MINI: OpenAiModel = "gpt-image-1-mini"
     TTS_1: OpenAiModel = "tts-1"
     WHISPER_1: OpenAiModel = "whisper-1"
     GEMINI_2_0_FLASH: GeminiModel = "gemini-2.0-flash"

--- a/llm_chat/domain/factory/completion/use_case.py
+++ b/llm_chat/domain/factory/completion/use_case.py
@@ -1,17 +1,18 @@
 import os
+
 from lib.llm.valueobject.config import OpenAIGptConfig, GeminiConfig, ModelName
-from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 from llm_chat.domain.use_case.completion.chat import (
     LlmChatUseCase,
     OpenAIGptStreamingUseCase,
 )
 from llm_chat.domain.use_case.completion.multimedia import (
-    OpenAIDalleUseCase,
+    OpenAIImageUseCase,
     OpenAITextToSpeechUseCase,
     OpenAISpeechToTextUseCase,
 )
 from llm_chat.domain.use_case.completion.rag import OpenAIRagUseCase
 from llm_chat.domain.use_case.completion.riddle import RiddleUseCase
+from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
 class UseCaseFactory:
@@ -51,8 +52,8 @@ class UseCaseFactory:
         if use_case_type == UseCaseType.OPENAI_GPT_STREAMING:
             return OpenAIGptStreamingUseCase()
 
-        if use_case_type == UseCaseType.OPENAI_DALLE:
-            return OpenAIDalleUseCase()
+        if use_case_type == UseCaseType.OPENAI_IMAGE:
+            return OpenAIImageUseCase()
 
         if use_case_type == UseCaseType.OPENAI_TEXT_TO_SPEECH:
             return OpenAITextToSpeechUseCase()

--- a/llm_chat/domain/service/chat.py
+++ b/llm_chat/domain/service/chat.py
@@ -1,9 +1,10 @@
 from typing import Any
+
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
-from llm_chat.domain.service.completion.riddle import RiddleChatService
+from llm_chat.domain.service.completion.riddle import RiddleService
 from llm_chat.domain.valueobject.completion.riddle import GenderType
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
@@ -48,7 +49,6 @@ class ChatDisplayService:
             else:
                 initial["use_case_type"] = UseCaseType.OPENAI_GPT_STREAMING
 
-
         # 4. セッションから性別の初期値を取得
         riddle_gender = request.session.get("riddle_gender")
         if riddle_gender:
@@ -63,7 +63,7 @@ class ChatDisplayService:
         """
         なぞなぞが進行中か判定します。
         最新の履歴がなぞなぞモード（UseCaseType.RIDDLE）であり、 かつ
-        AIからの終了定型文（RiddleChatService.RIDDLE_END_MESSAGE）が含まれていない場合に
+        AIからの終了定型文（RiddleService.RIDDLE_END_MESSAGE）が含まれていない場合に
         「進行中（アクティブ）」とみなされます。
 
         フロントエンドでは、この判定結果に基づきボタンの色（黄色＝進行中、緑色＝開始前）が変化します。
@@ -74,5 +74,5 @@ class ChatDisplayService:
         last_log = chat_history[-1]
         return (
             last_log.use_case_type == UseCaseType.RIDDLE
-            and RiddleChatService.RIDDLE_END_MESSAGE not in (last_log.content or "")
+            and RiddleService.RIDDLE_END_MESSAGE not in (last_log.content or "")
         )

--- a/llm_chat/domain/service/completion/chat.py
+++ b/llm_chat/domain/service/completion/chat.py
@@ -1,6 +1,8 @@
 import os
 from typing import Generator
 
+from django.contrib.auth.models import User
+
 from lib.llm.service.completion import (
     LlmCompletionService,
     LlmCompletionStreamingService,
@@ -13,11 +15,10 @@ from lib.llm.valueobject.config import (
 )
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
 from llm_chat.domain.service.completion.base import BaseChatService
-from llm_chat.domain.valueobject.completion.use_case import UseCaseType
+from llm_chat.domain.service.completion.riddle import RiddleService
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.riddle import Gender, Riddle, SessionState
-from llm_chat.domain.service.completion.riddle import RiddleChatService
-from django.contrib.auth.models import User
+from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
 class ChatService(BaseChatService):
@@ -59,7 +60,7 @@ class ChatService(BaseChatService):
 
         if not chat_history and use_case_type == UseCaseType.RIDDLE:
             # 初回
-            chat_history = RiddleChatService.create_initial_prompt(
+            chat_history = RiddleService.create_initial_prompt(
                 user_message=user_message, gender=gender, riddle_set=riddle_set or []
             )
             # 初回ユーザーメッセージをDBに保存
@@ -79,7 +80,7 @@ class ChatService(BaseChatService):
                     ]
                     current_index = len(assistant_messages)
 
-                    system_content = RiddleChatService.get_prompt(
+                    system_content = RiddleService.get_prompt(
                         gender=gender,
                         riddle_set=riddle_set or [],
                         current_index=current_index,
@@ -130,14 +131,14 @@ class ChatService(BaseChatService):
         評価機能（Gemini/OpenAI共通）。
         評価結果を RiddleResponse として取得し、箇条書きテキストを返します。
         """
-        task = RiddleChatService(self.config, self.chat_history)
+        task = RiddleService(self.config, self.chat_history)
         riddle_response = task.execute(login_user, riddle_set=riddle_set)
 
         # 箇条書きテキストを生成して返す
         return task.to_bullet_points(riddle_response)
 
 
-class OpenAIChatStreamingService(BaseChatService):
+class OpenAIStreamingService(BaseChatService):
     model_name = ModelName.GPT_5_MINI
 
     def __init__(self):

--- a/llm_chat/domain/service/completion/multimedia.py
+++ b/llm_chat/domain/service/completion/multimedia.py
@@ -32,25 +32,26 @@ class OpenAIImageService(BaseChatService):
     def generate(self, user_message: MessageDTO) -> MessageDTO:
         """
         画像urlの有効期限は1時間。それ以上使いたいときは保存する。
-        gpt-image-1-mini: 1024x1024, 512x512, 256x256, 1792x1024, 1024x1792 のいずれかしか生成できない
+        gpt-image-1-mini: 1024x1024, 1024x1536, 1536x1024, auto のいずれかしか生成できない
         """
         if user_message.content is None:
             raise Exception("content is None")
 
-        # API側で小さいサイズ(256x256)を指定して生成
+        # API側で推奨サイズ(auto)を指定して生成
         answer = OpenAILlmImageService(self.config).retrieve_answer(
-            user_message.to_message(), size="256x256"
+            user_message.to_message(), size="auto"
         )
         image_url = answer.data[0].url
         try:
             response = requests.get(image_url)
             response.raise_for_status()
             raw_picture = BytesIO(response.content)
+            resized_picture = Image.open(raw_picture).resize((256, 256))
             return self._create_assistant_message(
                 user=user_message.user,
                 content=user_message.content,
                 use_case_type=UseCaseType.OPENAI_GPT,
-                file_path=self.save(Image.open(raw_picture)),
+                file_path=self.save(resized_picture),
             )
         except requests.exceptions.HTTPError as http_error:
             raise Exception(http_error)

--- a/llm_chat/domain/service/completion/multimedia.py
+++ b/llm_chat/domain/service/completion/multimedia.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import secrets
 from io import BytesIO
@@ -31,8 +32,9 @@ class OpenAIImageService(BaseChatService):
 
     def generate(self, user_message: MessageDTO) -> MessageDTO:
         """
-        画像urlの有効期限は1時間。それ以上使いたいときは保存する。
-        gpt-image-1-mini: 1024x1024, 1024x1536, 1536x1024, auto のいずれかしか生成できない
+        画像生成を行い、結果を保存してMessageDTOを返します。
+        gpt-image-1-mini: 1024x1024, 1024x1536, 1536x1024, auto のいずれかしか生成できない。
+        また、主に b64_json 形式でデータを返します。
         """
         if user_message.content is None:
             raise Exception("content is None")
@@ -41,12 +43,23 @@ class OpenAIImageService(BaseChatService):
         answer = OpenAILlmImageService(self.config).retrieve_answer(
             user_message.to_message(), size="auto"
         )
-        image_url = answer.data[0].url
+
+        image_data = answer.data[0]
         try:
-            response = requests.get(image_url)
-            response.raise_for_status()
-            raw_picture = BytesIO(response.content)
-            resized_picture = Image.open(raw_picture).resize((256, 256))
+            if hasattr(image_data, "b64_json") and image_data.b64_json:
+                # base64形式の場合
+                raw_picture = BytesIO(base64.b64decode(image_data.b64_json))
+            elif hasattr(image_data, "url") and image_data.url:
+                # URL形式の場合
+                response = requests.get(image_data.url)
+                response.raise_for_status()
+                raw_picture = BytesIO(response.content)
+            else:
+                raise Exception(
+                    "画像データの取得に失敗しました（b64_jsonもurlも空です）"
+                )
+
+            resized_picture = Image.open(raw_picture).resize((128, 128))
             return self._create_assistant_message(
                 user=user_message.user,
                 content=user_message.content,

--- a/llm_chat/domain/service/completion/multimedia.py
+++ b/llm_chat/domain/service/completion/multimedia.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from config.settings import MEDIA_ROOT
 from lib.llm.service.completion import (
-    OpenAILlmDalleService,
+    OpenAILlmImageService,
     OpenAILlmTextToSpeech,
     OpenAILlmSpeechToText,
 )
@@ -18,8 +18,8 @@ from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
-class OpenAIDalleChatService(BaseChatService):
-    model_name = ModelName.DALLE_3
+class OpenAIImageService(BaseChatService):
+    model_name = ModelName.GPT_IMAGE_1_MINI
 
     def __init__(self):
         super().__init__(model_name=self.model_name)
@@ -32,26 +32,25 @@ class OpenAIDalleChatService(BaseChatService):
     def generate(self, user_message: MessageDTO) -> MessageDTO:
         """
         画像urlの有効期限は1時間。それ以上使いたいときは保存する。
-        dall-e-3: 1024x1024, 1792x1024, 1024x1792 のいずれかしか生成できない
+        gpt-image-1-mini: 1024x1024, 512x512, 256x256, 1792x1024, 1024x1792 のいずれかしか生成できない
         """
         if user_message.content is None:
             raise Exception("content is None")
 
-        answer = OpenAILlmDalleService(self.config).retrieve_answer(
-            user_message.to_message()
+        # API側で小さいサイズ(256x256)を指定して生成
+        answer = OpenAILlmImageService(self.config).retrieve_answer(
+            user_message.to_message(), size="256x256"
         )
         image_url = answer.data[0].url
         try:
             response = requests.get(image_url)
             response.raise_for_status()
             raw_picture = BytesIO(response.content)
-            resized_picture = Image.open(raw_picture).resize((128, 128))
-            file_path = self.save_picture(resized_picture)
             return self._create_assistant_message(
                 user=user_message.user,
                 content=user_message.content,
                 use_case_type=UseCaseType.OPENAI_GPT,
-                file_path=file_path,
+                file_path=self.save(Image.open(raw_picture)),
             )
         except requests.exceptions.HTTPError as http_error:
             raise Exception(http_error)
@@ -61,7 +60,7 @@ class OpenAIDalleChatService(BaseChatService):
             raise Exception(e)
 
     @staticmethod
-    def save_picture(resized_picture) -> str:
+    def save(image: Image.Image) -> str:
         """
         画像を保存してファイルパスを返すメソッド
         """
@@ -74,13 +73,13 @@ class OpenAIDalleChatService(BaseChatService):
         full_path = folder_path / random_filename
 
         # 画像を保存
-        resized_picture.save(str(full_path))
+        image.save(str(full_path))
 
         # 相対パスを返す
         return f"llm_chat/images/{random_filename}"
 
 
-class OpenAITextToSpeechChatService(BaseChatService):
+class OpenAITextToSpeechService(BaseChatService):
     model_name = ModelName.TTS_1
 
     def __init__(self):
@@ -97,16 +96,15 @@ class OpenAITextToSpeechChatService(BaseChatService):
         response = OpenAILlmTextToSpeech(self.config).retrieve_answer(
             user_message.to_message()
         )
-        file_path = self.save_audio(response)
         return self._create_assistant_message(
             user=user_message.user,
             content=user_message.content,
             use_case_type=UseCaseType.OPENAI_GPT,
-            file_path=file_path,
+            file_path=self.save(response),
         )
 
     @staticmethod
-    def save_audio(response) -> str:
+    def save(response) -> str:
         """
         音声ファイルを保存してファイルパスを返すメソッド
         :param response: 音声データのレスポンス
@@ -127,7 +125,7 @@ class OpenAITextToSpeechChatService(BaseChatService):
         return f"llm_chat/audios/{random_filename}"
 
 
-class OpenAISpeechToTextChatService(BaseChatService):
+class OpenAISpeechToTextService(BaseChatService):
     model_name = ModelName.WHISPER_1
 
     def __init__(self):

--- a/llm_chat/domain/service/completion/rag.py
+++ b/llm_chat/domain/service/completion/rag.py
@@ -5,13 +5,12 @@ from config.settings import BASE_DIR
 from lib.llm.service.completion import OpenAILlmRagService
 from lib.llm.valueobject.config import OpenAIGptConfig, ModelName
 from lib.llm.valueobject.rag import PdfDataloader
-from llm_chat.domain.repository.completion.chat import ChatLogRepository
 from llm_chat.domain.service.completion.base import BaseChatService
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
-class OpenAIRagChatService(BaseChatService):
+class OpenAIRagService(BaseChatService):
     model_name = ModelName.GPT_5_MINI
 
     def __init__(self):

--- a/llm_chat/domain/service/completion/riddle.py
+++ b/llm_chat/domain/service/completion/riddle.py
@@ -19,7 +19,7 @@ from llm_chat.domain.valueobject.completion.riddle import (
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
-class RiddleChatService(BaseLLMTask):
+class RiddleService(BaseLLMTask):
     """
     なぞなぞセッション専用のLLM対話サービス。
 
@@ -75,7 +75,7 @@ class RiddleChatService(BaseLLMTask):
         ]
         return (
             len(answer_turns) >= riddle_count
-            or RiddleChatService.RIDDLE_END_MESSAGE in assistant_message.content
+            or RiddleService.RIDDLE_END_MESSAGE in assistant_message.content
         )
 
     @staticmethod
@@ -114,12 +114,12 @@ class RiddleChatService(BaseLLMTask):
         content = re.sub(r"#####\s*$", "", content).strip()
 
         # 2. 終了メッセージ（定型文）の付与
-        end_msg = RiddleChatService.RIDDLE_END_MESSAGE
+        end_msg = RiddleService.RIDDLE_END_MESSAGE
         if end_msg not in content:
             content = content.rstrip() + "\n\n" + end_msg
 
         # 3. 最終レポートの追記
-        report_text = RiddleChatService.build_profile_report(user=user)
+        report_text = RiddleService.build_profile_report(user=user)
         content += f"\n\n{report_text}"
         return content.strip()
 
@@ -157,7 +157,7 @@ class RiddleChatService(BaseLLMTask):
         1. 【なぞなぞスタート】の合図を受け取ったら、挨拶をし、すぐに【質問1】を出題してください。
         2. 【質問1】から【質問{riddle_count-1}】までの回答を受け取ったら、正誤には触れず、簡単な感想だけを述べてから、すぐに次の質問を出題してください。
         3. 【質問{riddle_count}】（最後の質問）の回答を受け取ったら、簡単な感想を述べ、必ず最後に以下の終了定型文のみを出力して終了してください。これ以上の追加質問や、会話を継続するような提案（「別のなぞなぞを出しましょうか？」など）は絶対にしないでください。
-           - 終了定型文: 「{RiddleChatService.RIDDLE_END_MESSAGE}」
+           - 終了定型文: 「{RiddleService.RIDDLE_END_MESSAGE}」
 
         ### 禁止事項
         - なぞなぞを自作すること。
@@ -182,7 +182,7 @@ class RiddleChatService(BaseLLMTask):
         初期プロンプト（システムメッセージと初回のユーザーメッセージ）を生成します。
         システムメッセージはDBに保存せず、初回ユーザーメッセージを保存します。
         """
-        system_content = RiddleChatService.get_prompt(
+        system_content = RiddleService.get_prompt(
             gender=gender, riddle_set=riddle_set, current_index=0
         )
 
@@ -304,13 +304,13 @@ JSON構造:
 
     @staticmethod
     def _parse_json_dict(raw_content: str) -> dict:
-        cleaned_content = RiddleChatService._clean_json_text(raw_content)
+        cleaned_content = RiddleService._clean_json_text(raw_content)
         try:
             eval_data = json.loads(cleaned_content)
         except json.JSONDecodeError:
-            extracted = RiddleChatService._extract_json_object(cleaned_content)
+            extracted = RiddleService._extract_json_object(cleaned_content)
             if not extracted:
-                extracted = RiddleChatService._extract_json_object(raw_content)
+                extracted = RiddleService._extract_json_object(raw_content)
             if not extracted:
                 raise
             eval_data = json.loads(extracted)
@@ -323,9 +323,11 @@ JSON構造:
         return re.sub(r"\s+", "", (text or "")).lower()
 
     @staticmethod
-    def _fallback_turn_evaluation(answer: str, user_answer: str) -> RiddleTurnEvaluation:
-        answer_norm = RiddleChatService._normalize_answer(answer)
-        user_norm = RiddleChatService._normalize_answer(user_answer)
+    def _fallback_turn_evaluation(
+        answer: str, user_answer: str
+    ) -> RiddleTurnEvaluation:
+        answer_norm = RiddleService._normalize_answer(answer)
+        user_norm = RiddleService._normalize_answer(user_answer)
         is_correct = bool(answer_norm) and (
             answer_norm in user_norm or user_norm in answer_norm
         )
@@ -377,10 +379,10 @@ JSON構造:
         raw_content = chat_result.answer
 
         try:
-            eval_data = RiddleChatService._parse_json_dict(raw_content)
+            eval_data = RiddleService._parse_json_dict(raw_content)
             return RiddleTurnEvaluation(**eval_data)
         except (json.JSONDecodeError, ValueError):
-            return RiddleChatService._fallback_turn_evaluation(answer, user_answer)
+            return RiddleService._fallback_turn_evaluation(answer, user_answer)
 
     @staticmethod
     def format_turn_scores(evaluation: RiddleTurnEvaluation) -> str:
@@ -418,9 +420,7 @@ JSON構造:
         rebuttal_max = total_questions * 5
 
         correctness_rate = (
-            round((correctness_sum / correctness_max) * 100)
-            if correctness_max
-            else 0
+            round((correctness_sum / correctness_max) * 100) if correctness_max else 0
         )
         reasoning_rate = (
             round((reasoning_sum / reasoning_max) * 100) if reasoning_max else 0

--- a/llm_chat/domain/use_case/completion/chat.py
+++ b/llm_chat/domain/use_case/completion/chat.py
@@ -7,7 +7,7 @@ from lib.llm.valueobject.completion import RoleType, StreamResponse
 from lib.llm.valueobject.config import OpenAIGptConfig, GeminiConfig
 from llm_chat.domain.service.completion.chat import (
     ChatService,
-    OpenAIChatStreamingService,
+    OpenAIStreamingService,
 )
 from llm_chat.domain.use_case.completion.base import UseCase
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
@@ -71,7 +71,7 @@ class OpenAIGptStreamingUseCase(UseCase):
         """
         if content is None:
             raise ValueError("content cannot be None for OpenAIGptStreamingUseCase")
-        chat_service = OpenAIChatStreamingService()
+        chat_service = OpenAIStreamingService()
         user_message = self._insert_user_message(
             user=user,
             content=content,
@@ -87,7 +87,7 @@ class OpenAIGptStreamingUseCase(UseCase):
         このメソッドはストリーミング処理終了後に呼び出され、生成されたコンテンツを
         アシスタント役のメッセージとして加工した上でデータベースに保存します。
         メッセージにはユーザー情報と生成コンテンツを付加し、
-        OpenAIChatStreamingService の `save` メソッドを使用します。
+        OpenAIStreamingService の `save` メソッドを使用します。
 
         Args:
             user (User): Django の User モデルのインスタンス
@@ -96,7 +96,7 @@ class OpenAIGptStreamingUseCase(UseCase):
         Returns:
             None
         """
-        chat_service = OpenAIChatStreamingService()
+        chat_service = OpenAIStreamingService()
         self.repository.insert(
             MessageDTO(
                 user=user,

--- a/llm_chat/domain/use_case/completion/multimedia.py
+++ b/llm_chat/domain/use_case/completion/multimedia.py
@@ -4,21 +4,20 @@ from django.contrib.auth.models import User
 from django.core.files.uploadedfile import UploadedFile
 
 from config.settings import MEDIA_ROOT
-from lib.llm.valueobject.completion import RoleType
 from llm_chat.domain.service.completion.multimedia import (
-    OpenAIDalleChatService,
-    OpenAITextToSpeechChatService,
-    OpenAISpeechToTextChatService,
+    OpenAIImageService,
+    OpenAITextToSpeechService,
+    OpenAISpeechToTextService,
 )
 from llm_chat.domain.use_case.completion.base import UseCase
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
-class OpenAIDalleUseCase(UseCase):
+class OpenAIImageUseCase(UseCase):
     def execute(self, user: User, content: str | None) -> MessageDTO:
         """
-        OpenAIDalleServiceを利用し、ユーザーからの入力テキスト（content）を基に画像を生成します。
+        OpenAIImageServiceを利用し、ユーザーからの入力テキスト（content）を基に画像を生成します。
         contentパラメータはNoneではないこと。
 
         Args:
@@ -32,20 +31,20 @@ class OpenAIDalleUseCase(UseCase):
             画像生成の結果
         """
         if content is None:
-            raise ValueError("content cannot be None for OpenAIDalleUseCase")
-        chat_service = OpenAIDalleChatService()
+            raise ValueError("content cannot be None for OpenAIImageUseCase")
+        chat_service = OpenAIImageService()
         user_message = self._insert_user_message(
             user=user,
             content=content,
             model_name=chat_service.model_name,
-            use_case_type=UseCaseType.OPENAI_DALLE,
+            use_case_type=UseCaseType.OPENAI_IMAGE,
         )
         assistant_message = chat_service.generate(user_message)
         return self._insert_assistant_message(
             user=user,
             content=assistant_message.content,
             model_name=chat_service.model_name,
-            use_case_type=UseCaseType.OPENAI_DALLE,
+            use_case_type=UseCaseType.OPENAI_IMAGE,
             file_path=assistant_message.file_path,
         )
 
@@ -68,7 +67,7 @@ class OpenAITextToSpeechUseCase(UseCase):
         """
         if content is None:
             raise ValueError("content cannot be None for OpenAITextToSpeechUseCase")
-        chat_service = OpenAITextToSpeechChatService()
+        chat_service = OpenAITextToSpeechService()
         user_input_message = self._insert_user_message(
             user=user,
             content=content,
@@ -136,7 +135,7 @@ class OpenAISpeechToTextUseCase(UseCase):
         if content != "N/A":
             raise ValueError("content must be 'N/A' for OpenAISpeechToTextUseCase")
 
-        chat_service = OpenAISpeechToTextChatService()
+        chat_service = OpenAISpeechToTextService()
         user_message = self._insert_user_message(
             user=user,
             content=content,

--- a/llm_chat/domain/use_case/completion/rag.py
+++ b/llm_chat/domain/use_case/completion/rag.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 
-from lib.llm.valueobject.completion import RoleType
-from llm_chat.domain.service.completion.rag import OpenAIRagChatService
+from llm_chat.domain.service.completion.rag import OpenAIRagService
 from llm_chat.domain.use_case.completion.base import UseCase
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
@@ -26,7 +25,7 @@ class OpenAIRagUseCase(UseCase):
         if content is None:
             raise ValueError("content cannot be None for OpenAIRagUseCase")
 
-        chat_service = OpenAIRagChatService()
+        chat_service = OpenAIRagService()
         user_message = self._insert_user_message(
             user=user,
             content=content,

--- a/llm_chat/domain/use_case/completion/riddle.py
+++ b/llm_chat/domain/use_case/completion/riddle.py
@@ -7,7 +7,7 @@ from lib.llm.valueobject.completion import RoleType, StreamResponse
 from lib.llm.valueobject.config import OpenAIGptConfig, GeminiConfig
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
 from llm_chat.domain.service.completion.chat import ChatService
-from llm_chat.domain.service.completion.riddle import RiddleChatService
+from llm_chat.domain.service.completion.riddle import RiddleService
 from llm_chat.domain.use_case.completion.base import UseCase
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.riddle import (
@@ -112,16 +112,18 @@ class RiddleUseCase(UseCase):
         answered_count = ChatLogRepository.count_answered_questions(user)
         if answered_count < riddle_count:
             # 問題がまだ残っている場合、次の状態をUSER_INPUTにする
-            first_state = SessionState.START if not current_state else SessionState.EVALUATE
+            first_state = (
+                SessionState.START if not current_state else SessionState.EVALUATE
+            )
             target_states = [first_state, SessionState.USER_INPUT]
             assistant_message.next_riddle_state = SessionState.to_csv(target_states)
 
         # 7. 終了判定と評価
-        if RiddleChatService.is_session_finished(
+        if RiddleService.is_session_finished(
             user, assistant_message, riddle_count, start_signals
         ):
             # 終了処理（定型文付与、最終評価、メッセージクリーニング）
-            assistant_message.content = RiddleChatService.report(
+            assistant_message.content = RiddleService.report(
                 assistant_message.content, riddle_count, user
             )
 
@@ -145,7 +147,9 @@ def _prepare_riddle_turn(
     max_turns: int | None,
     user: User,
     content: str | None,
-) -> tuple[MessageDTO, list[Riddle], int, SessionState | None, SessionState, list[str], bool]:
+) -> tuple[
+    MessageDTO, list[Riddle], int, SessionState | None, SessionState, list[str], bool
+]:
     if content is None:
         raise ValueError("content cannot be None for RiddleUseCase")
 
@@ -153,9 +157,7 @@ def _prepare_riddle_turn(
     last_message = chat_history[-1] if chat_history else None
 
     last_states = (
-        SessionState.from_csv(last_message.next_riddle_state)
-        if last_message
-        else []
+        SessionState.from_csv(last_message.next_riddle_state) if last_message else []
     )
     current_state = last_states[-1] if last_states else None
 
@@ -170,7 +172,7 @@ def _prepare_riddle_turn(
             "セッションが終了しています。画面上の「なぞなぞの開始」を押してやりなおしてください。"
         )
 
-    riddle_set = RiddleChatService.get_riddle_set(max_turns)
+    riddle_set = RiddleService.get_riddle_set(max_turns)
     riddle_count = len(riddle_set)
 
     target_state = current_state if current_state else SessionState.START
@@ -196,14 +198,14 @@ def _prepare_riddle_turn(
         question_index = answered_count - 1
         if 0 <= question_index < riddle_count:
             riddle = riddle_set[question_index]
-            evaluation = RiddleChatService.evaluate_turn(
+            evaluation = RiddleService.evaluate_turn(
                 config=config,
                 question=riddle.question,
                 answer=riddle.answer,
                 user_answer=content,
             )
             if evaluation:
-                score_line = RiddleChatService.format_turn_scores(evaluation)
+                score_line = RiddleService.format_turn_scores(evaluation)
                 ChatLogRepository.update_riddle_scores(
                     message_id=user_message.id,
                     scores=evaluation.model_dump(),
@@ -297,20 +299,22 @@ class RiddleStreamingUseCase(UseCase):
             next_riddle_state=SessionState.to_csv(target_states),
         )
 
-        riddle_set = RiddleChatService.get_riddle_set(self.max_turns)
+        riddle_set = RiddleService.get_riddle_set(self.max_turns)
         riddle_count = len(riddle_set)
 
         answered_count = ChatLogRepository.count_answered_questions(user)
         if answered_count < riddle_count:
-            first_state = SessionState.START if current_state is None else SessionState.EVALUATE
+            first_state = (
+                SessionState.START if current_state is None else SessionState.EVALUATE
+            )
             target_states = [first_state, SessionState.USER_INPUT]
             assistant_message.next_riddle_state = SessionState.to_csv(target_states)
 
         start_signals = ["始めて", "はじめて", "スタート", "開始", "start"]
-        if RiddleChatService.is_session_finished(
+        if RiddleService.is_session_finished(
             user, assistant_message, riddle_count, start_signals
         ):
-            assistant_message.content = RiddleChatService.report(
+            assistant_message.content = RiddleService.report(
                 assistant_message.content, riddle_count, user
             )
             target_states = [SessionState.EVALUATE, SessionState.FINISHED]

--- a/llm_chat/domain/valueobject/completion/use_case.py
+++ b/llm_chat/domain/valueobject/completion/use_case.py
@@ -13,7 +13,7 @@ class UseCaseType:
     OPENAI_GPT = "OpenAIGpt"
     OPENAI_GPT_STREAMING = "OpenAIGptStreaming"
     GEMINI = "Gemini"
-    OPENAI_DALLE = "OpenAIDalle"
+    OPENAI_IMAGE = "OpenAIImage"
     OPENAI_TEXT_TO_SPEECH = "OpenAITextToSpeech"
     OPENAI_SPEECH_TO_TEXT = "OpenAISpeechToText"
     OPENAI_RAG = "OpenAIRag"

--- a/llm_chat/forms.py
+++ b/llm_chat/forms.py
@@ -9,7 +9,7 @@ class UserTextForm(forms.Form):
 
     USE_CASE_TYPE_CHOICES = [
         (UseCaseType.OPENAI_GPT_STREAMING, "OpenAI GPT Streaming"),
-        (UseCaseType.OPENAI_DALLE, "OpenAI Dall-e"),
+        (UseCaseType.OPENAI_IMAGE, "OpenAI Image Generation"),
         (UseCaseType.OPENAI_TEXT_TO_SPEECH, "OpenAI Text to Speech"),
         (UseCaseType.OPENAI_SPEECH_TO_TEXT, "OpenAI Speech to Text"),
         (UseCaseType.OPENAI_RAG, "OpenAI RAG"),

--- a/llm_chat/models.py
+++ b/llm_chat/models.py
@@ -16,8 +16,8 @@ class ChatLogs(models.Model):
         user (ForeignKey): メッセージに関連付けられた Django の User インスタンス。
         role (CharField): メッセージの役割（SYSTEM, USER, ASSISTANT）。
         content (TextField): メッセージの本文（テキストまたは生成物のURL）。
-        model_name (CharField): 使用された LLM のモデル名（例: gpt-4o, gemini-2.0-flash）。
-        use_case_type (CharField): 使用されたユースケースタイプ（例: OpenAIGpt, Riddle, OpenAIDalle）。
+        model_name (CharField): 使用された LLM のモデル名（例: gpt-4o, gpt-image-1-mini）。
+        use_case_type (CharField): 使用されたユースケースタイプ（例: OpenAIGpt, Riddle, OpenAIImage）。
             ステートレスなHTTP通信において、過去の履歴から「なぞなぞ継続中か」や
             「どのユースケースを使用したか」をサーバー側で確実かつ永続的に判定するために保持します。
             具体的には、最新の履歴が `use_case_type="Riddle"` かつ終了メッセージを含まない場合に
@@ -31,7 +31,7 @@ class ChatLogs(models.Model):
         (UseCaseType.OPENAI_GPT, "OpenAI GPT"),
         (UseCaseType.OPENAI_GPT_STREAMING, "OpenAI GPT Streaming"),
         (UseCaseType.GEMINI, "Gemini"),
-        (UseCaseType.OPENAI_DALLE, "OpenAI Dall-e"),
+        (UseCaseType.OPENAI_IMAGE, "OpenAI Image Generation"),
         (UseCaseType.OPENAI_TEXT_TO_SPEECH, "OpenAI Text to Speech"),
         (UseCaseType.OPENAI_SPEECH_TO_TEXT, "OpenAI Speech to Text"),
         (UseCaseType.OPENAI_RAG, "OpenAI RAG"),
@@ -49,6 +49,7 @@ class ChatLogs(models.Model):
         max_length=50,
         choices=USE_CASE_TYPE_CHOICES,
         default=UseCaseType.OPENAI_GPT,
+        help_text="使用されたユースケースタイプ（例: OpenAIGpt, Riddle, OpenAIImage）",
     )
     riddle_scores = models.JSONField(
         null=True,

--- a/llm_chat/templates/llm_chat/index.html
+++ b/llm_chat/templates/llm_chat/index.html
@@ -17,7 +17,8 @@
             <div class="col-12">
                 <div class="bg-light p-5 rounded shadow-sm">
                     <h1 class="display-4">QA with LLM</h1>
-                    <p class="lead">ChatGPT (Streaming), Dall-e-3, TextToSpeech, SpeechToText, RAG and Riddle</p>
+                    <p class="lead">ChatGPT (Streaming), gpt-image-1-mini, TextToSpeech, SpeechToText, RAG and
+                        Riddle</p>
                 </div>
             </div>
 
@@ -41,7 +42,8 @@
                                 {% endif %}
                             </div>
                             {% if chat_log.use_case_type == "Riddle" and chat_log.next_riddle_state %}
-                                <div class="riddle-indicator mb-2" data-states="{{ chat_log.next_riddle_state }}" data-role="{{ chat_log.role }}"></div>
+                                <div class="riddle-indicator mb-2" data-states="{{ chat_log.next_riddle_state }}"
+                                     data-role="{{ chat_log.role }}"></div>
                             {% endif %}
                             {% if chat_log.file_name|split_ext == "jpg" %}
                                 <img src="{{ chat_log.file_url }}" class="img-fluid mt-2" alt="Responsive image">
@@ -76,24 +78,31 @@
                                 {{ form.gender }}
                             </div>
                             <div id="loading-indicator" class="align-items-center mt-2 d-none">
-                                <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>
+                                <div class="spinner-border spinner-border-sm me-2" role="status"
+                                     aria-hidden="true"></div>
                                 <span class="small">処理中です。少々お待ちください…</span>
                             </div>
                             <div class="d-flex justify-content-end mt-3 gap-2">
                                 {% if user.is_authenticated %}
                                     {% if is_riddle_active %}
-                                        <input id="riddleButton" class="btn btn-warning" type="button" value="なぞなぞをリセット">
+                                        <input id="riddleButton" class="btn btn-warning" type="button"
+                                               value="なぞなぞをリセット">
                                     {% else %}
-                                        <input id="riddleButton" class="btn btn-success" type="button" value="なぞなぞをスタート">
+                                        <input id="riddleButton" class="btn btn-success" type="button"
+                                               value="なぞなぞをスタート">
                                     {% endif %}
                                     <input id="sendButton" class="btn btn-primary" type="button" value="送信">
                                 {% else %}
-                                    <input id="riddleButton" class="btn btn-outline-secondary" type="button" value="なぞなぞをスタート" disabled>
-                                    <input id="sendButton" class="btn btn-outline-secondary" type="button" value="送信" disabled>
+                                    <input id="riddleButton" class="btn btn-outline-secondary" type="button"
+                                           value="なぞなぞをスタート" disabled>
+                                    <input id="sendButton" class="btn btn-outline-secondary" type="button" value="送信"
+                                           disabled>
                                 {% endif %}
                             </div>
                             {% if not user.is_authenticated %}
-                                <div class="d-flex justify-content-end mt-2 text-muted small">ログインしないと送信できません</div>
+                                <div class="d-flex justify-content-end mt-2 text-muted small">
+                                    ログインしないと送信できません
+                                </div>
                             {% endif %}
                         </form>
                     </div>

--- a/llm_chat/tests/domain/factory/completion/test_use_case.py
+++ b/llm_chat/tests/domain/factory/completion/test_use_case.py
@@ -1,20 +1,22 @@
 from unittest.mock import patch
-from django.test import TestCase
+
 from django.core.files.uploadedfile import SimpleUploadedFile
-from llm_chat.domain.valueobject.completion.use_case import UseCaseType
+from django.test import TestCase
+
+from lib.llm.valueobject.config import GeminiConfig, OpenAIGptConfig
 from llm_chat.domain.factory.completion.use_case import UseCaseFactory
 from llm_chat.domain.use_case.completion.chat import (
     LlmChatUseCase,
     OpenAIGptStreamingUseCase,
 )
 from llm_chat.domain.use_case.completion.multimedia import (
-    OpenAIDalleUseCase,
+    OpenAIImageUseCase,
     OpenAITextToSpeechUseCase,
     OpenAISpeechToTextUseCase,
 )
 from llm_chat.domain.use_case.completion.rag import OpenAIRagUseCase
 from llm_chat.domain.use_case.completion.riddle import RiddleUseCase
-from lib.llm.valueobject.config import GeminiConfig, OpenAIGptConfig
+from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 
 
 class UseCaseFactoryTest(TestCase):
@@ -32,9 +34,9 @@ class UseCaseFactoryTest(TestCase):
         use_case = UseCaseFactory.create(UseCaseType.OPENAI_GPT_STREAMING)
         self.assertIsInstance(use_case, OpenAIGptStreamingUseCase)
 
-    def test_create_openai_dalle(self):
-        use_case = UseCaseFactory.create(UseCaseType.OPENAI_DALLE)
-        self.assertIsInstance(use_case, OpenAIDalleUseCase)
+    def test_create_openai_image(self):
+        use_case = UseCaseFactory.create(UseCaseType.OPENAI_IMAGE)
+        self.assertIsInstance(use_case, OpenAIImageUseCase)
 
     def test_create_openai_text_to_speech(self):
         use_case = UseCaseFactory.create(UseCaseType.OPENAI_TEXT_TO_SPEECH)

--- a/llm_chat/tests/domain/use_case/completion/test_multimedia.py
+++ b/llm_chat/tests/domain/use_case/completion/test_multimedia.py
@@ -46,12 +46,19 @@ class OpenAiMultimediaUseCaseTest(TestCase):
         """
         # 画像生成サービスと画像処理をモック化
         mock_response = MagicMock()
-        mock_response.data = [MagicMock(url="http://example.com/image.jpg")]
+        # gpt-image-1-mini の仕様に合わせて b64_json を設定
+        mock_image_data = MagicMock()
+        mock_image_data.b64_json = (
+            "ZmFrZV9pbWFnZV9jb250ZW50"  # "fake_image_content" の base64
+        )
+        mock_image_data.url = None
+        mock_response.data = [mock_image_data]
         mock_image_service.return_value.retrieve_answer.return_value = mock_response
 
-        mock_get_response = MagicMock()
-        mock_get_response.content = b"fake_image_content"
-        mock_get.return_value = mock_get_response
+        # Image.open のモック化とリサイズの検証用
+        mock_img = MagicMock()
+        mock_image_open.return_value = mock_img
+        mock_img.resize.return_value = mock_img
 
         # UseCase 実行
         use_case = OpenAIImageUseCase()
@@ -60,6 +67,9 @@ class OpenAiMultimediaUseCaseTest(TestCase):
         # 結果の MessageDTO を検証
         self.assertIsNotNone(result.file_path)
         self.assertEqual(result.model_name, ModelName.GPT_IMAGE_1_MINI)
+
+        # リサイズ処理が 128x128 で呼ばれたことを確認
+        mock_img.resize.assert_called_once_with((128, 128))
 
         # DB への保存を検証
         self._assert_chat_log_saved(

--- a/llm_chat/tests/domain/use_case/completion/test_multimedia.py
+++ b/llm_chat/tests/domain/use_case/completion/test_multimedia.py
@@ -1,16 +1,18 @@
-from django.test import TestCase
+from unittest.mock import patch, MagicMock
+
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
-from unittest.mock import patch, MagicMock
+from django.test import TestCase
+
 from lib.llm.valueobject.completion import RoleType
 from lib.llm.valueobject.config import ModelName
-from llm_chat.models import ChatLogs
-from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 from llm_chat.domain.use_case.completion.multimedia import (
-    OpenAIDalleUseCase,
+    OpenAIImageUseCase,
     OpenAITextToSpeechUseCase,
     OpenAISpeechToTextUseCase,
 )
+from llm_chat.domain.valueobject.completion.use_case import UseCaseType
+from llm_chat.models import ChatLogs
 
 
 class OpenAiMultimediaUseCaseTest(TestCase):
@@ -29,41 +31,40 @@ class OpenAiMultimediaUseCaseTest(TestCase):
         self.assertEqual(last_log.model_name, model_name)
         self.assertEqual(last_log.use_case_type, use_case_type)
 
-    @patch("llm_chat.domain.service.completion.multimedia.OpenAILlmDalleService")
+    @patch("llm_chat.domain.service.completion.multimedia.OpenAILlmImageService")
     @patch("llm_chat.domain.service.completion.multimedia.requests.get")
     @patch("llm_chat.domain.service.completion.multimedia.Image.open")
-    def test_dalle_use_case_saves_file_path(
-        self, mock_image_open, mock_get, mock_dalle_service
+    def test_image_use_case_saves_file_path(
+        self, mock_image_open, mock_get, mock_image_service
     ):
         """
-        [シナリオ: DALL-E 3画像生成]
-        1. OpenAIDalleUseCase を実行して画像を生成
+        [シナリオ: OpenAI画像生成]
+        1. OpenAIImageUseCase を実行して画像を生成
         2. 期待値:
            - 返された MessageDTO に file_path が含まれていること
            - DB (ChatLogs) にファイルパスとモデル名が正しく保存されていること
         """
-        # DALL-E サービスと画像処理をモック化
+        # 画像生成サービスと画像処理をモック化
         mock_response = MagicMock()
         mock_response.data = [MagicMock(url="http://example.com/image.jpg")]
-        mock_dalle_service.return_value.retrieve_answer.return_value = mock_response
+        mock_image_service.return_value.retrieve_answer.return_value = mock_response
 
         mock_get_response = MagicMock()
         mock_get_response.content = b"fake_image_content"
         mock_get.return_value = mock_get_response
 
-        mock_img = MagicMock()
-        mock_image_open.return_value.resize.return_value = mock_img
-
         # UseCase 実行
-        use_case = OpenAIDalleUseCase()
+        use_case = OpenAIImageUseCase()
         result = use_case.execute(self.user, "ねこの画像を生成して")
 
         # 結果の MessageDTO を検証
         self.assertIsNotNone(result.file_path)
-        self.assertEqual(result.model_name, ModelName.DALLE_3)
+        self.assertEqual(result.model_name, ModelName.GPT_IMAGE_1_MINI)
 
         # DB への保存を検証
-        self._assert_chat_log_saved(ModelName.DALLE_3, UseCaseType.OPENAI_DALLE)
+        self._assert_chat_log_saved(
+            ModelName.GPT_IMAGE_1_MINI, UseCaseType.OPENAI_IMAGE
+        )
 
     @patch("llm_chat.domain.service.completion.multimedia.OpenAILlmTextToSpeech")
     def test_tts_use_case_saves_file_path(self, mock_tts_service):

--- a/llm_chat/tests/domain/use_case/completion/test_riddle.py
+++ b/llm_chat/tests/domain/use_case/completion/test_riddle.py
@@ -1,9 +1,14 @@
-from django.test import TestCase
-from django.contrib.auth.models import User
 from unittest.mock import patch, MagicMock
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
 from lib.llm.valueobject.completion import RoleType
 from lib.llm.valueobject.config import OpenAIGptConfig, ModelName
-from llm_chat.models import ChatLogs, RiddleQuestion
+from llm_chat.domain.repository.completion.chat import ChatLogRepository
+from llm_chat.domain.service.completion.chat import ChatService
+from llm_chat.domain.service.completion.riddle import RiddleService
+from llm_chat.domain.use_case.completion.riddle import RiddleUseCase
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.riddle import (
     Gender,
@@ -12,10 +17,7 @@ from llm_chat.domain.valueobject.completion.riddle import (
     RiddleTurnEvaluation,
 )
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
-from llm_chat.domain.service.completion.chat import ChatService
-from llm_chat.domain.service.completion.riddle import RiddleChatService
-from llm_chat.domain.use_case.completion.riddle import RiddleUseCase
-from llm_chat.domain.repository.completion.chat import ChatLogRepository
+from llm_chat.models import ChatLogs, RiddleQuestion
 
 
 class RiddleUseCaseTest(TestCase):
@@ -65,7 +67,7 @@ class RiddleUseCaseTest(TestCase):
         self.assertEqual(db_logs.count(), 1)
         self.assertEqual(db_logs[0].role, RoleType.USER.value)
 
-    @patch("llm_chat.domain.service.completion.riddle.RiddleChatService.evaluate_turn")
+    @patch("llm_chat.domain.service.completion.riddle.RiddleService.evaluate_turn")
     @patch("lib.llm.service.completion.LlmCompletionService.retrieve_answer")
     def test_riddle_use_case_extra_question_removal(
         self, mock_retrieve, mock_turn_eval
@@ -121,7 +123,7 @@ class RiddleUseCaseTest(TestCase):
             "僕は呼吸をするけど生きていない...\n"
             "続けて別のなぞなぞを出しましょうか？\n"
             f"ご回答をどうぞ。\n\n"
-            f"{RiddleChatService.RIDDLE_END_MESSAGE}"
+            f"{RiddleService.RIDDLE_END_MESSAGE}"
         )
         mock_retrieve.return_value = MagicMock(answer=assistant_content)
         mock_turn_eval.return_value = RiddleTurnEvaluation(
@@ -137,12 +139,12 @@ class RiddleUseCaseTest(TestCase):
 
         # 「第3問」や継続提案が消えていることを確認
         self.assertIn("正解です！たいまつで合っています。", result.content)
-        self.assertIn(RiddleChatService.RIDDLE_END_MESSAGE, result.content)
+        self.assertIn(RiddleService.RIDDLE_END_MESSAGE, result.content)
         self.assertNotIn("第3問", result.content)
         self.assertNotIn("続けて別のなぞなぞを出しましょうか？", result.content)
         self.assertIn("あなたの回答傾向", result.content)
 
-    @patch("llm_chat.domain.service.completion.riddle.RiddleChatService.evaluate_turn")
+    @patch("llm_chat.domain.service.completion.riddle.RiddleService.evaluate_turn")
     @patch("lib.llm.service.completion.LlmCompletionService.retrieve_answer")
     def test_riddle_use_case_end_detection_invalid_json(
         self, mock_retrieve, mock_turn_eval
@@ -158,7 +160,7 @@ class RiddleUseCaseTest(TestCase):
         mock_retrieve.side_effect = [
             MagicMock(answer="質問1..."),
             MagicMock(answer="質問2..."),
-            MagicMock(answer=f"正解です！ {RiddleChatService.RIDDLE_END_MESSAGE}"),
+            MagicMock(answer=f"正解です！ {RiddleService.RIDDLE_END_MESSAGE}"),
         ]
         mock_turn_eval.return_value = RiddleTurnEvaluation(
             correctness=3, reasoning=0, creativity=0, rebuttal=0
@@ -180,11 +182,11 @@ class RiddleUseCaseTest(TestCase):
             self.user, "答えはたいまつです", gender=Gender(GenderType.MAN)
         )
 
-        self.assertIn(RiddleChatService.RIDDLE_END_MESSAGE, result.content)
+        self.assertIn(RiddleService.RIDDLE_END_MESSAGE, result.content)
         self.assertIn("あなたの回答傾向", result.content)
         self.assertEqual(result.use_case_type, UseCaseType.RIDDLE)
 
-    @patch("llm_chat.domain.service.completion.riddle.RiddleChatService.evaluate_turn")
+    @patch("llm_chat.domain.service.completion.riddle.RiddleService.evaluate_turn")
     @patch("lib.llm.service.completion.LlmCompletionService.retrieve_answer")
     def test_riddle_use_case_end_detection(self, mock_retrieve, mock_turn_eval):
         """
@@ -199,7 +201,7 @@ class RiddleUseCaseTest(TestCase):
         # 1回目は普通の回答、2回目は終了メッセージを含む回答
         mock_retrieve.side_effect = [
             MagicMock(answer="こんにちは！質問1です。"),
-            MagicMock(answer=f"正解です！ {RiddleChatService.RIDDLE_END_MESSAGE}"),
+            MagicMock(answer=f"正解です！ {RiddleService.RIDDLE_END_MESSAGE}"),
         ]
 
         config = OpenAIGptConfig(
@@ -219,12 +221,12 @@ class RiddleUseCaseTest(TestCase):
             self.user, "答えは人間です", gender=Gender(GenderType.MAN)
         )
 
-        self.assertIn(RiddleChatService.RIDDLE_END_MESSAGE, result.content)
+        self.assertIn(RiddleService.RIDDLE_END_MESSAGE, result.content)
         self.assertIn("あなたの回答傾向", result.content)
         self.assertEqual(result.use_case_type, UseCaseType.RIDDLE)
 
     @patch("llm_chat.domain.repository.completion.chat.ChatLogRepository.clear_all")
-    @patch("llm_chat.domain.service.completion.riddle.RiddleChatService.evaluate_turn")
+    @patch("llm_chat.domain.service.completion.riddle.RiddleService.evaluate_turn")
     @patch("lib.llm.service.completion.LlmCompletionService.retrieve_answer")
     def test_riddle_use_case_forced_end(
         self, mock_retrieve, mock_turn_eval, mock_clear
@@ -262,7 +264,7 @@ class RiddleUseCaseTest(TestCase):
             self.user, "それはたいまつです", gender=Gender(GenderType.MAN)
         )
 
-        self.assertIn(RiddleChatService.RIDDLE_END_MESSAGE, result.content)
+        self.assertIn(RiddleService.RIDDLE_END_MESSAGE, result.content)
         self.assertIn("あなたの回答傾向", result.content)
         self.assertEqual(result.use_case_type, UseCaseType.RIDDLE)
 

--- a/llm_chat/tests/domain/use_case/completion/test_riddle_state.py
+++ b/llm_chat/tests/domain/use_case/completion/test_riddle_state.py
@@ -1,6 +1,7 @@
-from django.test import TestCase
-from django.contrib.auth.models import User
 from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
 
 from lib.llm.valueobject.completion import ChatResult, RoleType
 from lib.llm.valueobject.config import OpenAIGptConfig
@@ -118,7 +119,7 @@ class RiddleSessionStateTest(TestCase):
             states, [SessionState.EVALUATE.value, SessionState.USER_INPUT.value]
         )
 
-    @patch("llm_chat.domain.service.completion.riddle.RiddleChatService.evaluate_turn")
+    @patch("llm_chat.domain.service.completion.riddle.RiddleService.evaluate_turn")
     @patch("lib.llm.service.completion.LlmCompletionService.retrieve_answer")
     def test_session_finished_state(self, mock_retrieve, mock_turn_eval):
         """
@@ -128,13 +129,13 @@ class RiddleSessionStateTest(TestCase):
         - 期待値: 最終的な next_riddle_state が FINISHED（終了）状態であること。
         """
         # 終了定型文を含む回答をモック
-        from llm_chat.domain.service.completion.riddle import RiddleChatService
+        from llm_chat.domain.service.completion.riddle import RiddleService
 
         # 1回目の回答（開始時）
         start_response = ChatResult(answer="こんにちは！質問1です", explanation="")
         # 2回目の回答（終了時）
         end_response = ChatResult(
-            answer=f"正解です！\n\n{RiddleChatService.RIDDLE_END_MESSAGE}",
+            answer=f"正解です！\n\n{RiddleService.RIDDLE_END_MESSAGE}",
             explanation="",
         )
         mock_retrieve.side_effect = [start_response, end_response]

--- a/llm_chat/tests/test_views.py
+++ b/llm_chat/tests/test_views.py
@@ -1,17 +1,19 @@
-import time
 import io
+import time
 from datetime import timedelta
-from django.test import TestCase, RequestFactory
-from django.contrib.sessions.backends.db import SessionStore
+
 from django.contrib.auth.models import User
-from django.utils import timezone
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import TestCase, RequestFactory
 from django.urls import reverse
+from django.utils import timezone
+
 from lib.llm.valueobject.completion import RoleType
 from lib.llm.valueobject.config import ModelName
+from llm_chat.domain.service.completion.riddle import RiddleService
+from llm_chat.domain.valueobject.completion.use_case import UseCaseType
 from llm_chat.models import ChatLogs, RiddleQuestion
 from llm_chat.views import IndexView, RiddleSampleCSVView, RiddleCSVUploadView
-from llm_chat.domain.valueobject.completion.use_case import UseCaseType
-from llm_chat.domain.service.completion.riddle import RiddleChatService
 
 
 class ViewLogicTest(TestCase):
@@ -53,7 +55,7 @@ class ViewLogicTest(TestCase):
         ChatLogs.objects.create(
             user=self.user,
             role=RoleType.ASSISTANT.value,
-            content=f"お疲れ様でした。 {RiddleChatService.RIDDLE_END_MESSAGE}",
+            content=f"お疲れ様でした。 {RiddleService.RIDDLE_END_MESSAGE}",
             use_case_type=UseCaseType.RIDDLE,
         )
         context = view.get_context_data()
@@ -63,7 +65,7 @@ class ViewLogicTest(TestCase):
         """
         [シナリオ: IndexView の get_initial() による直近ユースケースタイプの取得]
         1. 履歴がない場合: デフォルト値が返ることを確認
-        2. 直近の履歴が Dall-e の場合: OpenAIDalle が返ることを確認
+        2. 直近の履歴が OpenAI Image の場合: OpenAIImage が返ることを確認
         3. 直近の履歴が なぞなぞ (進行中) の場合: Riddle が返ることを確認
         4. 直近の履歴が なぞなぞ (終了) の場合: 直近の model_name に基づく値が返ることを確認
         """
@@ -80,18 +82,18 @@ class ViewLogicTest(TestCase):
         initial = view.get_initial()
         self.assertEqual(initial.get("use_case_type"), UseCaseType.OPENAI_GPT_STREAMING)
 
-        # 2. 直近が Dall-e
+        # 2. 直近が OpenAI Image
         ChatLogs.objects.create(
             user=self.user,
             role=RoleType.ASSISTANT.value,
             content="Image URL",
-            model_name=ModelName.DALLE_3,
-            use_case_type=UseCaseType.OPENAI_DALLE,
+            model_name=ModelName.GPT_IMAGE_1_MINI,
+            use_case_type=UseCaseType.OPENAI_IMAGE,
             created_at=timezone.now(),
         )
         time.sleep(0.01)
         initial = view.get_initial()
-        self.assertEqual(initial.get("use_case_type"), UseCaseType.OPENAI_DALLE)
+        self.assertEqual(initial.get("use_case_type"), UseCaseType.OPENAI_IMAGE)
 
         # 3. なぞなぞ (進行中)
         ChatLogs.objects.create(
@@ -110,7 +112,7 @@ class ViewLogicTest(TestCase):
         ChatLogs.objects.create(
             user=self.user,
             role=RoleType.ASSISTANT.value,
-            content=f"正解です！ {RiddleChatService.RIDDLE_END_MESSAGE}",
+            content=f"正解です！ {RiddleService.RIDDLE_END_MESSAGE}",
             model_name=ModelName.GPT_5_MINI,
             use_case_type=UseCaseType.RIDDLE,
             created_at=timezone.now(),


### PR DESCRIPTION
## 概要
画像生成モデルを従来の `dall-e-3` から最新 di `gpt-image-1-mini` へ完全に移行しました。新モデルの特性である `b64_json` 形式での応答に対応し、APIパラメータの最適化、表示用リサイズ処理（128x128）の維持、およびサービス・クラス・メソッド名の整理を行い、コードの一貫性と保守性を向上させました。

## 主な変更内容
- **モデルの移行とAPIパラメータの最終調整**:
  - `OpenAiModel` 定数を `gpt-image-1-mini` に更新。
  - **[修正]** 新モデルで非対応の `quality` および `response_format` パラメータを削除。
  - **[修正]** サイズ指定をサポート対象の `1024x1024`, `1024x1536`, `1536x1024`, `auto` に更新（デフォルトは `auto` に設定）。
- **画像取得ロジックの刷新（b64_json 対応）**:
  - **[重要]** 新モデルで主流となる `b64_json` 形式のレスポンスに対応しました。`b64_json` がある場合はデコードし、URL がある場合は従来通り `requests` で取得するハイブリッドな取得ロジックを `OpenAIImageService.generate` に実装しました。
- **画像処理の最適化（リサイズの適用）**:
  - API から取得した画像（1024x1024等）は、表示負荷とストレージ消費を抑えるために、保存時に **`128x128`** へのリサイズを適用するようにしました。
- **命名の整理とポリモーフィズムの導入**:
  - サービス名から `Chat` 接頭辞を除去（例: `OpenAIImageService`, `OpenAITextToSpeechService`, `OpenAIStreamingService`）。
  - 各種マルチメディアサービスの保存メソッド名を `save` に統一。
  - 内部識別子を `OpenAIDalle` から `OpenAIImage` へ変更し、UI上のラベルも「OpenAI Image Generation」に更新。
- **コードの健全化**:
  - テストコードを現在の実装（128x128 リサイズ後の保存や新モデル名）に合わせて修正し、`MagicMock` 関連の型エラーを解消。

## 動作確認観点
`llm_chat` アプリケーションにおいて、以下のすべてのモデルおよび機能が正常に動作することを確認します。

1.  **OpenAI Image Generation (gpt-image-1-mini)**:
    - **[重要]** 画像が正常に生成され、**`128x128`** にリサイズされて保存・表示されること。
    - パラメータエラー（400 Bad Request）や URL 取得エラーが発生しないこと。
2.  **OpenAI GPT / OpenAI Streaming**:
    - 通常のテキスト応答およびストリーミング応答が正常に返ること。
3.  **Gemini**:
    - Google Gemini モデルによる応答が正常に返ること。
4.  **OpenAI Text to Speech / Speech to Text**:
    - 音声合成および音声認識（ファイル保存含む）が正常に動作すること。
5.  **OpenAI RAG**:
    - 知識ベースに基づいた回答が正常に生成されること。
6.  **Riddle (なぞなぞモード)**:
    - なぞなぞの出題、回答判定、スコアリングが正常に進行すること。
7.  **共通表示**:
    - `home` および `llm_chat` の画面上で、モデル名が `gpt-image-1-mini` と正しく表示されていること。
