### PR TITLE
MSCIレポートの過去分閲覧機能の追加および最新版以外のPDFリンク無効化

### DIFF
--- a/usa_research/templates/usa_research/index.html
+++ b/usa_research/templates/usa_research/index.html
@@ -361,15 +361,29 @@
         <!-- 2. MSCIレポートの要約 -->
         <section id="msci" class="mb-5 border p-4 rounded shadow-sm bg-light">
             <div class="mb-4 d-flex justify-content-between align-items-center">
-                <div>
+                <div class="d-flex flex-column">
                     <h4 class="text-primary mb-1"><i class="fas fa-chart-pie"></i> 2. MSCIレポートの要約</h4>
-                    {% if msci_report %}
-                        <p class="text-muted mb-0 small"><i class="fas fa-calendar-alt"></i> Report
-                            Date: {{ msci_report.report_date|date:"Y/m/d" }}</p>
-                    {% endif %}
+                    <div class="d-flex align-items-center">
+                        {% if msci_report %}
+                            <p class="text-muted mb-0 small me-3"><i class="fas fa-calendar-alt"></i> Report
+                                Date: {{ msci_report.report_date|date:"Y/m/d" }}</p>
+                        {% endif %}
+                        {% if msci_report_dates %}
+                            <select id="report-date-select" class="form-select form-select-sm" style="width: auto;">
+                                {% for r_date in msci_report_dates %}
+                                    <option value="{{ r_date|date:"Y-m-d" }}"
+                                            {% if msci_report.report_date == r_date %}selected{% endif %}>
+                                        {{ r_date|date:"Y/m/d" }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        {% endif %}
+                    </div>
                 </div>
                 {% if msci_report %}
-                    <a href="{{ msci_report.pdf_url }}" target="_blank" class="btn btn-outline-secondary btn-sm">
+                    <a href="{{ msci_report.pdf_url }}" target="_blank"
+                       class="btn btn-outline-secondary btn-sm {% if not is_latest_report %}disabled{% endif %}"
+                       {% if not is_latest_report %}aria-disabled="true" tabindex="-1"{% endif %}>
                         <i class="fas fa-file-pdf"></i> Original PDF
                     </a>
                 {% endif %}
@@ -750,5 +764,20 @@
                 <a href="#top" class="text-muted small"><i class="fas fa-chevron-up"></i> TOPに戻る</a>
             </div>
         </section>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const select = document.getElementById('report-date-select');
+                if (select) {
+                    select.addEventListener('change', function () {
+                        const date = this.value;
+                        const url = new URL(window.location.href);
+                        url.searchParams.set('report_date', date);
+                        // アンカーを維持しつつリロード
+                        url.hash = 'msci';
+                        window.location.href = url.toString();
+                    });
+                }
+            });
+        </script>
     </div>
 {% endblock %}

--- a/usa_research/tests/test_msci_views.py
+++ b/usa_research/tests/test_msci_views.py
@@ -1,0 +1,65 @@
+import datetime
+
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from usa_research.models import MsciCountryWeightReport
+
+
+class MsciReportViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        # テストデータの作成
+        self.report1 = MsciCountryWeightReport.objects.create(
+            report_date=datetime.date(2024, 4, 1),
+            summary_md="Summary 2024-04-01",
+            pdf_url="http://example.com/20240401.pdf",
+        )
+        self.report2 = MsciCountryWeightReport.objects.create(
+            report_date=datetime.date(2024, 5, 1),
+            summary_md="Summary 2024-05-01",
+            pdf_url="http://example.com/20240501.pdf",
+        )
+
+    def test_index_view_shows_latest_report_by_default(self):
+        response = self.client.get(reverse("usa:index"))
+        self.assertEqual(response.status_code, 200)
+        # 最新のレポート（5/1）が表示されていることを確認
+        self.assertEqual(response.context["msci_report"], self.report2)
+        self.assertContains(response, "2024/05/01")
+        self.assertContains(response, "Summary 2024-05-01")
+
+    def test_index_view_shows_selected_report(self):
+        # クエリパラメータで過去の日付を指定
+        response = self.client.get(reverse("usa:index") + "?report_date=2024-04-01")
+        self.assertEqual(response.status_code, 200)
+        # 指定したレポート（4/1）が表示されていることを確認
+        self.assertEqual(response.context["msci_report"], self.report1)
+        self.assertContains(response, "2024/04/01")
+        self.assertContains(response, "Summary 2024-04-01")
+
+    def test_index_view_context_contains_all_report_dates(self):
+        response = self.client.get(reverse("usa:index"))
+        self.assertIn("msci_report_dates", response.context)
+        dates = response.context["msci_report_dates"]
+        self.assertEqual(len(dates), 2)
+        self.assertEqual(dates[0], self.report2.report_date)
+        self.assertEqual(dates[1], self.report1.report_date)
+
+    def test_is_latest_report_flag(self):
+        # デフォルト（最新）
+        response = self.client.get(reverse("usa:index"))
+        self.assertTrue(response.context["is_latest_report"])
+        self.assertNotContains(response, 'disabled aria-disabled="true" tabindex="-1"')
+
+        # 過去分
+        response = self.client.get(reverse("usa:index") + "?report_date=2024-04-01")
+        self.assertFalse(response.context["is_latest_report"])
+        self.assertContains(response, "disabled")
+        self.assertContains(response, 'aria-disabled="true"')
+
+    def test_dropdown_contains_dates(self):
+        response = self.client.get(reverse("usa:index"))
+        self.assertContains(response, '<select id="report-date-select"')
+        self.assertContains(response, "2024/05/01")
+        self.assertContains(response, "2024/04/01")

--- a/usa_research/views.py
+++ b/usa_research/views.py
@@ -55,13 +55,30 @@ class IndexView(TemplateView):
         # RSSフィードを取得 (最新20件)
         context["rss_feeds"] = RssFeed.objects.select_related("source").all()[:20]
 
-        # MSCIレポートを取得 (最新1件)
-        latest_report = MsciCountryWeightReport.objects.first()
-        if latest_report:
-            latest_report.summary_html = markdown.markdown(
-                latest_report.summary_md, extensions=["extra", "tables"]
+        # MSCIレポートを取得 (過去分も含めて取得可能にする)
+        report_date_param = self.request.GET.get("report_date")
+        if report_date_param:
+            msci_report = MsciCountryWeightReport.objects.filter(
+                report_date=report_date_param
+            ).first()
+        else:
+            msci_report = MsciCountryWeightReport.objects.first()
+
+        if msci_report:
+            msci_report.summary_html = markdown.markdown(
+                msci_report.summary_md, extensions=["extra", "tables"]
             )
-            context["msci_report"] = latest_report
+            context["msci_report"] = msci_report
+
+        # 過去のレポート日付リストを取得 (ドロップダウン用)
+        context["msci_report_dates"] = MsciCountryWeightReport.objects.values_list(
+            "report_date", flat=True
+        )
+        # 表示中のレポートが最新かどうか
+        latest_report = MsciCountryWeightReport.objects.first()
+        context["is_latest_report"] = (
+            msci_report == latest_report if msci_report and latest_report else True
+        )
 
         # 資産クラスの長期推移
         # グラフ表示用にデータを取得。

--- a/usa_research/views.py
+++ b/usa_research/views.py
@@ -55,13 +55,16 @@ class IndexView(TemplateView):
         # RSSフィードを取得 (最新20件)
         context["rss_feeds"] = RssFeed.objects.select_related("source").all()[:20]
 
-        # MSCIレポートを取得 (過去分も含めて取得可能にする)
+        # MSCIレポートを取得
         report_date_param = self.request.GET.get("report_date")
         if report_date_param:
+            # 【A】ドロップダウンで過去の日付が選択された場合
+            # filter() は複数の可能性を返すため、.first() で1つのオブジェクトに確定させる
             msci_report = MsciCountryWeightReport.objects.filter(
                 report_date=report_date_param
             ).first()
         else:
+            # 【B】初期表示。最新のレポートを1件取得する
             msci_report = MsciCountryWeightReport.objects.first()
 
         if msci_report:


### PR DESCRIPTION
## Summary
MSCIレポート（MsciCountryWeightReport）の過去分をドロップダウンで選択して閲覧できる機能を追加しました。また、過去のレポートを表示している間は、最新版のPDFへのリンク（Original PDFボタン）を無効化する制御を実装しました。

- MSCIレポートセクションに日付選択ドロップダウンを追加し、過去のレポートを表示可能にしました。
- 過去レポート表示時は「Original PDF」ボタンを disabled にし、最新版のみ閲覧可能としました。
- 選択したレポートの日付をクエリパラメータで保持し、ページリロード時に該当セクションへ自動スクロールする処理を実装しました。
- ビュー内の取得ロジックに詳細なコメントを追加し、可読性を向上させました。

## 目検による動作確認手順
- [x] 米国株リサーチ画面（`usa_research/`）にアクセスし、MSCIレポートセクションに日付選択ドロップダウンが表示されていることを確認する。
- [x] ドロップダウンから過去の日付を選択し、ページがリロードされ、該当する日付のレポート内容が表示されることを確認する。
- [x] 過去のレポートを表示している際、「Original PDF」ボタンがグレーアウト（disabled）されており、クリックできないことを確認する。
- [x] 最新のレポートを表示した際、「Original PDF」ボタンが有効になり、PDFが開けることを確認する。

## 自動テストでカバーできた範囲
- `usa_research/tests/test_msci_views.py`:
    - デフォルトで最新レポートが表示されることの検証
    - クエリパラメータによる過去レポートの切り替え検証
    - ドロップダウン内の日付リストの正確性検証
    - 最新フラグ（`is_latest_report`）およびPDFボタンの無効化状態の検証

## 関連Issue
https://github.com/duri0214/portfolio/issues/676