### PR TITLE
yfinance のキャッシュディレクトリ競合エラー (Errno 17) の修正

### DIFF
--- a/media/yfinance_cache/.gitignore
+++ b/media/yfinance_cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/usa_research/management/commands/monthly_update_historical_assets.py
+++ b/usa_research/management/commands/monthly_update_historical_assets.py
@@ -1,7 +1,9 @@
+import os
 from datetime import datetime, timedelta
 
 import pandas as pd
 import yfinance as yf
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from usa_research.models import AssetPrice
@@ -23,6 +25,15 @@ TICKERS = {
 
 class Command(BaseCommand):
     help = "Fetch historical asset prices (ETF and Indices) from Yahoo Finance and save to AssetPrice model"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # yfinanceのタイムゾーンキャッシュディレクトリに関するエラー(Issue #545)を回避するため、
+        # プロジェクト内のディレクトリをキャッシュ先として指定する。
+        # matplotlibの例に倣い、MEDIA_ROOT 内に配置する。
+        cache_dir = os.path.join(settings.MEDIA_ROOT, "yfinance_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        yf.set_tz_cache_location(cache_dir)
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/usa_research/management/commands/monthly_update_nasdaq100_list.py
+++ b/usa_research/management/commands/monthly_update_nasdaq100_list.py
@@ -1,9 +1,11 @@
+import os
 from datetime import datetime
 from io import StringIO
 
 import pandas as pd
 import requests
 import yfinance as yf
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from usa_research.models import Nasdaq100Company
@@ -11,6 +13,15 @@ from usa_research.models import Nasdaq100Company
 
 class Command(BaseCommand):
     help = "Fetch NASDAQ100 components from Wikipedia"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # yfinanceのタイムゾーンキャッシュディレクトリに関するエラー(Issue #545)を回避するため、
+        # プロジェクト内のディレクトリをキャッシュ先として指定する。
+        # matplotlibの例に倣い、MEDIA_ROOT 内に配置する。
+        cache_dir = os.path.join(settings.MEDIA_ROOT, "yfinance_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        yf.set_tz_cache_location(cache_dir)
 
     def handle(self, *args, **options):
         """

--- a/usa_research/management/commands/update_macro_indicators.py
+++ b/usa_research/management/commands/update_macro_indicators.py
@@ -1,7 +1,11 @@
-import yfinance as yf
-import pandas as pd
+import os
 from datetime import datetime, timedelta
+
+import pandas as pd
+import yfinance as yf
+from django.conf import settings
 from django.core.management.base import BaseCommand
+
 from usa_research.models import MacroIndicator
 
 TICKERS = {
@@ -13,6 +17,15 @@ TICKERS = {
 
 class Command(BaseCommand):
     help = "Fetch macro indicators (ISM, US10Y, VIX) from Yahoo Finance and save to MacroIndicator model"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # yfinanceのタイムゾーンキャッシュディレクトリに関するエラー(Issue #545)を回避するため、
+        # プロジェクト内のディレクトリをキャッシュ先として指定する。
+        # matplotlibの例に倣い、MEDIA_ROOT 内に配置する。
+        cache_dir = os.path.join(settings.MEDIA_ROOT, "yfinance_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        yf.set_tz_cache_location(cache_dir)
 
     def handle(self, *args, **options):
         """

--- a/usa_research/management/commands/update_sector_rotation.py
+++ b/usa_research/management/commands/update_sector_rotation.py
@@ -1,7 +1,11 @@
+import os
+from datetime import datetime, timedelta
+
 import pandas as pd
 import yfinance as yf
-from datetime import datetime, timedelta
+from django.conf import settings
 from django.core.management.base import BaseCommand
+
 from usa_research.models import Sector, SectorDailySnapshot
 
 SECTORS = {
@@ -22,6 +26,15 @@ BENCHMARK = "SPY"
 
 class Command(BaseCommand):
     help = "Fetch US sector ETF data and update sector rotation table"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # yfinanceのタイムゾーンキャッシュディレクトリに関するエラー(Issue #545)を回避するため、
+        # プロジェクト内のディレクトリをキャッシュ先として指定する。
+        # matplotlibの例に倣い、MEDIA_ROOT 内に配置する。
+        cache_dir = os.path.join(settings.MEDIA_ROOT, "yfinance_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        yf.set_tz_cache_location(cache_dir)
 
     def handle(self, *args, **options):
         """


### PR DESCRIPTION
## Summary
`yfinance` ライブラリが OS 標準のキャッシュディレクトリ（`/home/ubuntu/.cache/py-yfinance`）を作成・使用する際に発生する権限エラーや競合（`[Errno 17] File exists`）を解決しました。

- `yfinance` のキャッシュ先をプロジェクト管理下の `media/yfinance_cache` に明示的に固定しました。
- 既存の `matplotlib` のキャッシュ管理（`media/matplotlib_cache`）と階層・手法を統一しました。
- `usa_research` アプリ内の `yfinance` を利用する全4つの管理コマンドに修正を適用しました。
- キャッシュの実データ（SQLite DB等）を Git 管理から除外しつつ、ディレクトリ構造を保持するため、`.gitignore` と `.gitkeep` を配置しました。

## 目検による動作確認手順
- [x] 以下の管理コマンドを実行し、`Failed to create TzCache` などのエラーが表示されないことを確認する
    - `python manage.py monthly_update_historical_assets`
- [x] `media/yfinance_cache/` 内に `cookies.db` および `tkr-tz.db` が生成されていることを確認する
- [x] `git status` を実行し、`media/` 下の `.db` ファイルが `Untracked files` に含まれていないことを確認する
- [x] `media/matplotlib_cache/` 内の `.gitignore` と `.gitkeep` が存在することを確認する

## 自動テストでカバーできた範囲
自動テストは実施していませんが、ローカル環境（Windows）にて各管理コマンドを実行し、指定した `media/yfinance_cache` ディレクトリに正常にキャッシュが生成され、データ取得が完了することを確認済みです。

## 関連Issue
https://github.com/duri0214/portfolio/issues/545