### PR TITLE
vnm: vietkabuスクレイピングのとき、thをそれぞれ検証することでスクレイピングのズレをなくす

### DIFF
--- a/vietnam_research/domain/valueobject/vietkabu.py
+++ b/vietnam_research/domain/valueobject/vietkabu.py
@@ -47,19 +47,33 @@ class MarketDataRowError(Exception):
 
 
 class MarketDataHeaderError(Exception):
-    """viet-kabuの株価テーブルヘッダーが期待と異なる場合の例外"""
+    """
+    viet-kabuの株価テーブルヘッダーが期待と異なる場合の例外。
+
+    ヘッダー不一致だけを呼び出し側で明示的にハンドリングするための専用例外。
+    `ValueError` などの汎用例外にすると、想定外の不具合まで同じ扱いで
+    握ってしまうリスクがあるため分離している。
+    """
 
 
 @dataclass(frozen=True)
 class MarketDataTableHeader:
     """
-    viet-kabuの株価テーブルヘッダーを検証し、列名からセル位置を引けるようにする。
+    viet-kabuの株価テーブルヘッダー定義を表す値オブジェクト。
+
+    `validate_from_soup` は以下を実行する:
+    - `th` から株価テーブルのヘッダー行を検出する
+    - ヘッダー文字列を正規化する（空白揺れ・全角括弧の揺れを吸収）
+    - 期待ヘッダー（列名 + 順序）と完全一致することを検証する
+
+    検証に成功した場合、列名からセル位置を引ける `column_indexes` を保持して返す。
+    検証に失敗した場合は `MarketDataHeaderError` を送出する。
     """
 
     column_indexes: dict[str, int]
 
     @classmethod
-    def from_soup(cls, soup) -> "MarketDataTableHeader":
+    def validate_from_soup(cls, soup) -> "MarketDataTableHeader":
         expected_columns = tuple(
             cls._normalize_text(c) for c in MARKET_DATA_EXPECTED_COLUMNS
         )

--- a/vietnam_research/domain/valueobject/vietkabu.py
+++ b/vietnam_research/domain/valueobject/vietkabu.py
@@ -68,6 +68,8 @@ class MarketDataTableHeader:
 
     検証に成功した場合、列名からセル位置を引ける `column_indexes` を保持して返す。
     検証に失敗した場合は `MarketDataHeaderError` を送出する。
+
+    See Also: https://www.viet-kabu.com/stock/hcm.html
     """
 
     column_indexes: dict[str, int]
@@ -104,6 +106,13 @@ class MarketDataTableHeader:
 
     @classmethod
     def _looks_like_market_data_header(cls, columns: tuple[str, ...]) -> bool:
+        """
+        与えられたヘッダー列が「株価データ本体のヘッダー行らしいか」を判定する。
+
+        この判定は完全一致チェックの前段で使う粗いフィルタで、ページ内の他テーブルや
+        装飾用ヘッダー行を除外する目的を持つ。
+        現在は株価テーブルに必須の `銘柄` と `業種` が同時に含まれることを条件にしている。
+        """
         return "銘柄" in columns and "業種" in columns
 
     @classmethod

--- a/vietnam_research/domain/valueobject/vietkabu.py
+++ b/vietnam_research/domain/valueobject/vietkabu.py
@@ -7,6 +7,24 @@ import numpy as np
 import pandas as pd
 from bs4 import Tag
 
+MARKET_DATA_EXPECTED_COLUMNS = (
+    "銘柄",
+    "前日 終値",
+    "取引値 (終値)",
+    "始値",
+    "高値",
+    "安値",
+    "前日比",
+    "前日比 (%)",
+    "売買高 (株)",
+    "時価総額 (百万ドン)",
+    "時価総額 (億円)",
+    "PER (倍)",
+    "外国人 [買]成立",
+    "外国人 [売]成立",
+    "業種",
+)
+
 
 class MarketDataRowError(Exception):
     """MarketDataRowの初期化に失敗した場合の例外"""
@@ -26,6 +44,63 @@ class MarketDataRowError(Exception):
             text = " ".join(text.split())
             td_texts.append(text)
         return ", ".join(td_texts)
+
+
+class MarketDataHeaderError(Exception):
+    """viet-kabuの株価テーブルヘッダーが期待と異なる場合の例外"""
+
+
+@dataclass(frozen=True)
+class MarketDataTableHeader:
+    """
+    viet-kabuの株価テーブルヘッダーを検証し、列名からセル位置を引けるようにする。
+    """
+
+    column_indexes: dict[str, int]
+
+    @classmethod
+    def from_soup(cls, soup) -> "MarketDataTableHeader":
+        expected_columns = tuple(
+            cls._normalize_text(c) for c in MARKET_DATA_EXPECTED_COLUMNS
+        )
+
+        for tr in soup.find_all("tr"):
+            th_tags = tr.find_all("th")
+            if not th_tags:
+                continue
+
+            columns = tuple(
+                cls._normalize_text(th.get_text(" ", strip=True)) for th in th_tags
+            )
+            if not cls._looks_like_market_data_header(columns):
+                continue
+
+            if columns != expected_columns:
+                raise MarketDataHeaderError(
+                    "viet-kabuの株価テーブルヘッダーが期待と異なります。"
+                    f" expected={expected_columns}, actual={columns}"
+                )
+
+            return cls({column: i for i, column in enumerate(columns)})
+
+        raise MarketDataHeaderError(
+            "viet-kabuの株価テーブルヘッダーが見つかりません。"
+            f" expected={expected_columns}"
+        )
+
+    @classmethod
+    def _looks_like_market_data_header(cls, columns: tuple[str, ...]) -> bool:
+        return "銘柄" in columns and "業種" in columns
+
+    @classmethod
+    def _normalize_text(cls, value: str) -> str:
+        text = value.replace("\xa0", " ")
+        text = text.replace("（", "(").replace("）", ")")
+        return " ".join(text.split())
+
+    def index(self, column: str) -> int:
+        normalized_column = self._normalize_text(column)
+        return self.column_indexes[normalized_column]
 
 
 @dataclass(frozen=True)
@@ -165,50 +240,59 @@ class MarketDataRow:
     marketcap: float
     per: float
 
-    def __init__(self, tr: Tag):
+    def __init__(self, tr: Tag, table_header: MarketDataTableHeader):
         super().__init__()
-        tag_tds_center = tr.find_all("td", class_="table_list_center")
+        tag_tds = [
+            td
+            for td in tr.find_all("td")
+            if "table_list_center" in td.get_attribute_list("class")
+            or "table_list_right" in td.get_attribute_list("class")
+        ]
 
         # 業種情報の存在チェック
-        if len(tag_tds_center) < 2:
+        if len(tag_tds) != len(MARKET_DATA_EXPECTED_COLUMNS):
             raise MarketDataRowError(
-                "業種情報（table_list_centerが2つ未満）がありません", tr
+                "データ列数がヘッダー列数と一致しません"
+                f"（expected={len(MARKET_DATA_EXPECTED_COLUMNS)}, actual={len(tag_tds)}）",
+                tr,
             )
 
+        ticker_cell = tag_tds[table_header.index("銘柄")]
+        industry_cell = tag_tds[table_header.index("業種")]
+
         # imgタグの存在チェック
-        if not tag_tds_center[1].find("img"):
+        if not industry_cell.find("img"):
             raise MarketDataRowError("業種画像（imgタグ）がありません", tr)
 
         try:
-            self.code = re.sub("＊", "", tag_tds_center[0].text.strip())
-            self.name = tag_tds_center[0].a.get("title")
-            self.industry_title = tag_tds_center[1].img.get("title")
+            self.code = re.sub("＊", "", ticker_cell.text.strip())
+            self.name = ticker_cell.a.get("title")
+            self.industry_title = industry_cell.img.get("title")
             self.industry1 = re.sub(r"\[(.+)]", "", self.industry_title)
             self.industry2 = re.search(
-                r"(?<=\[).*?(?=])", tag_tds_center[1].img.get("title")
+                r"(?<=\[).*?(?=])", industry_cell.img.get("title")
             ).group()
 
-            tag_tds_right = [
-                Counting(td.text.strip())
-                for td in tr.find_all("td", class_="table_list_right")
-            ]
-
-            # 計数データの存在チェック
-            if len(tag_tds_right) < 11:
-                raise MarketDataRowError(
-                    "計数データが不足しています（table_list_rightが11未満）", tr
-                )
-
-            self.open_price = tag_tds_right[2].value
-            self.high_price = tag_tds_right[3].value
-            self.low_price = tag_tds_right[4].value
-            self.closing_price = tag_tds_right[1].value
-            self.volume = tag_tds_right[7].value
-            self.marketcap = tag_tds_right[9].value
-            self.per = tag_tds_right[10].value
+            self.open_price = self._counting_value(tag_tds, table_header, "始値")
+            self.high_price = self._counting_value(tag_tds, table_header, "高値")
+            self.low_price = self._counting_value(tag_tds, table_header, "安値")
+            self.closing_price = self._counting_value(
+                tag_tds, table_header, "取引値 (終値)"
+            )
+            self.volume = self._counting_value(tag_tds, table_header, "売買高 (株)")
+            self.marketcap = self._counting_value(
+                tag_tds, table_header, "時価総額 (億円)"
+            )
+            self.per = self._counting_value(tag_tds, table_header, "PER (倍)")
 
         except (AttributeError, IndexError, TypeError) as e:
             raise MarketDataRowError(f"データ解析でエラーが発生しました: {str(e)}", tr)
+
+    @classmethod
+    def _counting_value(
+        cls, tag_tds: list[Tag], table_header: MarketDataTableHeader, column: str
+    ) -> float | None:
+        return Counting(tag_tds[table_header.index(column)].text.strip()).value
 
 
 class IndustryGraphVO:

--- a/vietnam_research/domain/valueobject/vietkabu.py
+++ b/vietnam_research/domain/valueobject/vietkabu.py
@@ -77,7 +77,8 @@ class MarketDataTableHeader:
     @classmethod
     def validate_from_soup(cls, soup) -> "MarketDataTableHeader":
         """
-        `soup` から株価テーブルのヘッダー行を検出し、期待ヘッダーと照合して検証する。
+        soupからtrを抽出した集まりの中で、`th` を持つ行を走査し、
+        株価テーブルのヘッダー行を検出して期待ヘッダーと照合する。
 
         処理の流れ:
         1. `th` を持つ行を走査し、`_looks_like_market_data_header` で候補行を絞る

--- a/vietnam_research/domain/valueobject/vietkabu.py
+++ b/vietnam_research/domain/valueobject/vietkabu.py
@@ -76,6 +76,21 @@ class MarketDataTableHeader:
 
     @classmethod
     def validate_from_soup(cls, soup) -> "MarketDataTableHeader":
+        """
+        `soup` から株価テーブルのヘッダー行を検出し、期待ヘッダーと照合して検証する。
+
+        処理の流れ:
+        1. `th` を持つ行を走査し、`_looks_like_market_data_header` で候補行を絞る
+        2. 候補行のヘッダー文字列を正規化する
+        3. `MARKET_DATA_EXPECTED_COLUMNS`（列名 + 順序）との完全一致を検証する
+
+        Returns:
+            検証済みヘッダーの `column_indexes` を保持した `MarketDataTableHeader`。
+
+        Raises:
+            MarketDataHeaderError:
+                株価テーブルのヘッダー行が見つからない、または期待ヘッダーと不一致の場合。
+        """
         expected_columns = tuple(
             cls._normalize_text(c) for c in MARKET_DATA_EXPECTED_COLUMNS
         )

--- a/vietnam_research/domain/valueobject/vietkabu.py
+++ b/vietnam_research/domain/valueobject/vietkabu.py
@@ -133,11 +133,24 @@ class MarketDataTableHeader:
 
     @classmethod
     def _normalize_text(cls, value: str) -> str:
+        """
+        ヘッダー比較用に文字列を正規化する。
+
+        - ノーブレークスペースを通常スペースへ置換
+        - 全角括弧を半角括弧へ統一
+        - 連続空白を1つに圧縮
+        """
         text = value.replace("\xa0", " ")
         text = text.replace("（", "(").replace("）", ")")
         return " ".join(text.split())
 
     def index(self, column: str) -> int:
+        """
+        列名から株価テーブル内のセル位置（0始まり）を返す。
+
+        `column` はヘッダー名（例: `始値`, `業種`）を受け取り、
+        検証済みの `column_indexes` から対応するインデックスを返す。
+        """
         normalized_column = self._normalize_text(column)
         return self.column_indexes[normalized_column]
 

--- a/vietnam_research/management/commands/daily_import_from_vietkabu.py
+++ b/vietnam_research/management/commands/daily_import_from_vietkabu.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now, localtime
 from vietnam_research.domain.valueobject.vietkabu import (
     TransactionDate,
     MarketDataTableHeader,
+    MarketDataHeaderError,
     MarketDataRow,
     MarketDataRowError,
 )
@@ -46,7 +47,17 @@ class Command(BaseCommand):
             transaction_date = TransactionDate(
                 th_tag=soup.find("th", class_="table_list_left")
             ).to_date()
-            table_header = MarketDataTableHeader.from_soup(soup)
+
+            # 列ズレ防止のため、株価テーブルのヘッダー（列名・順序）を検証する
+            try:
+                validated_table_header = MarketDataTableHeader.validate_from_soup(soup)
+            except MarketDataHeaderError as e:
+                message = (
+                    f"{market.code} のヘッダー検証に失敗したため処理対象外になりました: "
+                    f"{str(e)}"
+                )
+                print(message)
+                continue
 
             # 当日データがあったら処理しない
             if Industry.objects.filter(
@@ -65,7 +76,7 @@ class Command(BaseCommand):
             skip_count = 0
             for i, tag_tr in enumerate(tag_trs):
                 try:
-                    market_data_row = MarketDataRow(tag_tr, table_header)
+                    market_data_row = MarketDataRow(tag_tr, validated_table_header)
                     market_data_rows.append(market_data_row)
                 except MarketDataRowError as e:
                     skip_count += 1

--- a/vietnam_research/management/commands/daily_import_from_vietkabu.py
+++ b/vietnam_research/management/commands/daily_import_from_vietkabu.py
@@ -6,6 +6,7 @@ from django.core.management import BaseCommand
 from django.utils.timezone import now, localtime
 from vietnam_research.domain.valueobject.vietkabu import (
     TransactionDate,
+    MarketDataTableHeader,
     MarketDataRow,
     MarketDataRowError,
 )
@@ -45,6 +46,7 @@ class Command(BaseCommand):
             transaction_date = TransactionDate(
                 th_tag=soup.find("th", class_="table_list_left")
             ).to_date()
+            table_header = MarketDataTableHeader.from_soup(soup)
 
             # 当日データがあったら処理しない
             if Industry.objects.filter(
@@ -63,7 +65,7 @@ class Command(BaseCommand):
             skip_count = 0
             for i, tag_tr in enumerate(tag_trs):
                 try:
-                    market_data_row = MarketDataRow(tag_tr)
+                    market_data_row = MarketDataRow(tag_tr, table_header)
                     market_data_rows.append(market_data_row)
                 except MarketDataRowError as e:
                     skip_count += 1

--- a/vietnam_research/tests/management/test_daily_import_from_vietkabu.py
+++ b/vietnam_research/tests/management/test_daily_import_from_vietkabu.py
@@ -16,16 +16,18 @@ from vietnam_research.models import Symbol, IndClass, Market
 
 
 class TestCounting(TestCase):
-
     def test_valid_value(self):
+        """カンマと%を含む文字列を数値として解釈できる。"""
         c = Counting("1,000%")
         self.assertEqual(c.value, 1000.0)
 
     def test_empty_string(self):
+        """空文字は0.0として扱う。"""
         c = Counting("")
         self.assertEqual(c.value, 0.0)
 
     def test_invalid_value(self):
+        """ハイフンは欠損値としてNoneを返す。"""
         c = Counting("-")
         self.assertEqual(c.value, None)
 
@@ -66,12 +68,14 @@ class TestTransactionDate(TestCase):
         self.invalid_th_tag = BeautifulSoup(invalid_html, "html.parser").th
 
     def test_to_date(self):
+        """更新日時を含むthからdatetimeへ変換できる。"""
         self.assertEqual(
             TransactionDate(self.valid_th_tag).to_date(),
             datetime(2019, 8, 16, 17, 0, 0),
         )
 
     def test_to_date_invalid_value(self):
+        """更新日時フォーマットが崩れている場合はValueErrorにする。"""
         with self.assertRaises(ValueError):
             self.assertEqual(
                 TransactionDate(self.invalid_th_tag).to_date(),
@@ -101,6 +105,7 @@ class TestMarketDataRow(TestCase):
     """
 
     def test_market_data_row_from_html(self):
+        """検証済みヘッダーを使って1行分の株価データを正しく抽出できる。"""
         html = (
             self.header_html
             + """
@@ -141,7 +146,7 @@ class TestMarketDataRow(TestCase):
         validated_table_header = MarketDataTableHeader.validate_from_soup(soup)
         tr = soup.find("tr", id="APG")
         row = MarketDataRow(tr, validated_table_header)
-        # These values are checked using the html snippet above.
+        # These values are checked using the HTML snippet above.
         self.assertEqual(row.code, "APG")
         self.assertEqual(row.name, "APG証券")
         self.assertEqual(row.industry_title, "金融業[証券業]")
@@ -156,6 +161,7 @@ class TestMarketDataRow(TestCase):
         self.assertEqual(row.per, 11.11)
 
     def test_market_data_header_from_html(self):
+        """期待どおりのヘッダーから列名とインデックスの対応を作れる。"""
         soup = BeautifulSoup(self.header_html, "html.parser")
         validated_table_header = MarketDataTableHeader.validate_from_soup(soup)
 
@@ -165,6 +171,7 @@ class TestMarketDataRow(TestCase):
         self.assertEqual(validated_table_header.index("業種"), 14)
 
     def test_market_data_header_invalid_order(self):
+        """ヘッダーの順序が入れ替わっている場合は専用例外で検知する。"""
         invalid_header_html = self.header_html.replace(
             """<th class="table_list_right">始値</th>
         <th class="table_list_right">高値</th>""",

--- a/vietnam_research/tests/management/test_daily_import_from_vietkabu.py
+++ b/vietnam_research/tests/management/test_daily_import_from_vietkabu.py
@@ -138,9 +138,9 @@ class TestMarketDataRow(TestCase):
         """
         )
         soup = BeautifulSoup(html, "html.parser")
-        table_header = MarketDataTableHeader.from_soup(soup)
+        validated_table_header = MarketDataTableHeader.validate_from_soup(soup)
         tr = soup.find("tr", id="APG")
-        row = MarketDataRow(tr, table_header)
+        row = MarketDataRow(tr, validated_table_header)
         # These values are checked using the html snippet above.
         self.assertEqual(row.code, "APG")
         self.assertEqual(row.name, "APG証券")
@@ -157,12 +157,12 @@ class TestMarketDataRow(TestCase):
 
     def test_market_data_header_from_html(self):
         soup = BeautifulSoup(self.header_html, "html.parser")
-        table_header = MarketDataTableHeader.from_soup(soup)
+        validated_table_header = MarketDataTableHeader.validate_from_soup(soup)
 
-        self.assertEqual(table_header.index("銘柄"), 0)
-        self.assertEqual(table_header.index("取引値 (終値)"), 2)
-        self.assertEqual(table_header.index("時価総額 (億円)"), 10)
-        self.assertEqual(table_header.index("業種"), 14)
+        self.assertEqual(validated_table_header.index("銘柄"), 0)
+        self.assertEqual(validated_table_header.index("取引値 (終値)"), 2)
+        self.assertEqual(validated_table_header.index("時価総額 (億円)"), 10)
+        self.assertEqual(validated_table_header.index("業種"), 14)
 
     def test_market_data_header_invalid_order(self):
         invalid_header_html = self.header_html.replace(
@@ -175,4 +175,4 @@ class TestMarketDataRow(TestCase):
         soup = BeautifulSoup(invalid_header_html, "html.parser")
 
         with self.assertRaises(MarketDataHeaderError):
-            MarketDataTableHeader.from_soup(soup)
+            MarketDataTableHeader.validate_from_soup(soup)

--- a/vietnam_research/tests/management/test_daily_import_from_vietkabu.py
+++ b/vietnam_research/tests/management/test_daily_import_from_vietkabu.py
@@ -3,7 +3,12 @@ from datetime import datetime
 from bs4 import BeautifulSoup
 from django.test import TestCase
 
-from vietnam_research.domain.valueobject.vietkabu import Counting, MarketDataRow
+from vietnam_research.domain.valueobject.vietkabu import (
+    Counting,
+    MarketDataHeaderError,
+    MarketDataRow,
+    MarketDataTableHeader,
+)
 from vietnam_research.management.commands.daily_import_from_vietkabu import (
     TransactionDate,
 )
@@ -75,8 +80,30 @@ class TestTransactionDate(TestCase):
 
 
 class TestMarketDataRow(TestCase):
+    header_html = """
+    <tr>
+        <th class="table_list_center">銘柄</th>
+        <th class="table_list_right">前日<br>終値</th>
+        <th class="table_list_right">取引値<br>(終値)</th>
+        <th class="table_list_right">始値</th>
+        <th class="table_list_right">高値</th>
+        <th class="table_list_right">安値</th>
+        <th class="table_list_right">前日比</th>
+        <th class="table_list_right">前日比<br>(%)</th>
+        <th class="table_list_right">売買高<br>(株)</th>
+        <th class="table_list_right">時価総額<br>（百万ドン）</th>
+        <th class="table_list_right">時価総額<br>（億円）</th>
+        <th class="table_list_right">PER<br>(倍)</th>
+        <th class="table_list_right">外国人<br>[買]成立</th>
+        <th class="table_list_right">外国人<br>[売]成立</th>
+        <th class="table_list_center">業種</th>
+    </tr>
+    """
+
     def test_market_data_row_from_html(self):
-        html = """
+        html = (
+            self.header_html
+            + """
         <tr bgcolor="#FFFFFF" id="APG" onmouseover="on_over('APG','#DDEFFF')" onmouseout="on_out('APG','#FFFFFF')" style="background: rgb(255, 255, 255);">
             <td width="65" class="table_list_center">
                 <a title="APG証券" href="/hcm/APG.html">
@@ -109,9 +136,11 @@ class TestMarketDataRow(TestCase):
                <img title="金融業[証券業]" src="/images/stock/fnc.gif" width="28" height="13" style="margin:0 4px;"> </td>
         </tr>
         """
+        )
         soup = BeautifulSoup(html, "html.parser")
-        tr = soup.find("tr")
-        row = MarketDataRow(tr)
+        table_header = MarketDataTableHeader.from_soup(soup)
+        tr = soup.find("tr", id="APG")
+        row = MarketDataRow(tr, table_header)
         # These values are checked using the html snippet above.
         self.assertEqual(row.code, "APG")
         self.assertEqual(row.name, "APG証券")
@@ -125,3 +154,25 @@ class TestMarketDataRow(TestCase):
         self.assertEqual(row.volume, 304300)
         self.assertEqual(row.marketcap, 128.76)
         self.assertEqual(row.per, 11.11)
+
+    def test_market_data_header_from_html(self):
+        soup = BeautifulSoup(self.header_html, "html.parser")
+        table_header = MarketDataTableHeader.from_soup(soup)
+
+        self.assertEqual(table_header.index("銘柄"), 0)
+        self.assertEqual(table_header.index("取引値 (終値)"), 2)
+        self.assertEqual(table_header.index("時価総額 (億円)"), 10)
+        self.assertEqual(table_header.index("業種"), 14)
+
+    def test_market_data_header_invalid_order(self):
+        invalid_header_html = self.header_html.replace(
+            """<th class="table_list_right">始値</th>
+        <th class="table_list_right">高値</th>""",
+            """<th class="table_list_right">高値</th>
+        <th class="table_list_right">始値</th>""",
+            1,
+        )
+        soup = BeautifulSoup(invalid_header_html, "html.parser")
+
+        with self.assertRaises(MarketDataHeaderError):
+            MarketDataTableHeader.from_soup(soup)


### PR DESCRIPTION
## Summary
viet-kabu 取り込みバッチで、HTMLテーブルの列ズレを見逃したまま正常終了してしまうリスクを解消しました。  
`th` ヘッダーを先に検証し、期待構造と一致した場合のみデータ行を取り込むように変更しています。

- `daily_import_from_vietkabu` で `MarketDataTableHeader.validate_from_soup(soup)` を実行し、株価テーブルヘッダーの完全一致チェックを追加
- ヘッダー不一致時は `MarketDataHeaderError` を捕捉し、該当市場（HOSE/HNX）をスキップするように変更
- `MarketDataRow` をヘッダー依存の列名参照に変更し、固定インデックス直読みを廃止
- 型警告対応として `td.get("class", [])` を `td.get_attribute_list("class")` に変更
- 将来の保守向けに、ヘッダー判定/検証まわりの docstring とテストシナリオ記述を強化

## 目検による動作確認手順
- [x] `python manage.py daily_import_from_vietkabu` を実行し、HOSE/HNX の通常取り込みが完了すること
- [x] viet-kabu 側ヘッダーが期待どおりの状態で、従来どおり `Industry` へ値が登録されること

## 自動テストでカバーできた範囲
- 実行コマンド: `python manage.py test vietnam_research.tests.management.test_daily_import_from_vietkabu`
- 実行結果: 8 tests passed
- カバー内容:
  - `MarketDataTableHeader` の正常解析
  - ヘッダー順不一致時の `MarketDataHeaderError` 発生（列ズレ検知）
  - `MarketDataRow` の列名ベース解析（終値/始値/高値/安値/出来高/時価総額/PER）
  - 既存 `Counting` / `TransactionDate` の回帰

## 関連Issue
https://github.com/duri0214/portfolio/issues/146