### PR TITLE
（子チケット1）土壌化学分析データ取り込み画面（川田研究所）: XLSX取り込み基盤

### DIFF
--- a/soil_analysis/domain/valueobject/chemical_report/fields.py
+++ b/soil_analysis/domain/valueobject/chemical_report/fields.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import unicodedata
+
 
 @dataclass(frozen=True)
 class ChemicalFieldDefinition:
@@ -12,44 +14,131 @@ class ChemicalFieldDefinition:
 
 CHEMICAL_FIELD_DEFINITIONS: tuple[ChemicalFieldDefinition, ...] = (
     ChemicalFieldDefinition("ec", "EC", "mS/cm", "電気伝導率", ("ec", "EC")),
-    ChemicalFieldDefinition("nh4n", "NH4-N", "mg/100g", "アンモニア態窒素", ("nh4-n", "nh4n")),
-    ChemicalFieldDefinition("no3n", "NO3-N", "mg/100g", "硝酸態窒素", ("no3-n", "no3n")),
-    ChemicalFieldDefinition("total_nitrogen", "無機態N", "mg/100g", "無機態窒素（NH4+NO3）"),
-    ChemicalFieldDefinition("nh4_per_nitrogen", "NH4/N比", "", "アンモニア態窒素比"),
+    ChemicalFieldDefinition(
+        "nh4n", "NH4-N", "mg/100g", "アンモニア態窒素", ("nh4n", "NH4-N")
+    ),
+    ChemicalFieldDefinition(
+        "no3n", "NO3-N", "mg/100g", "硝酸態窒素", ("no3n", "NO3-N")
+    ),
+    ChemicalFieldDefinition(
+        "total_nitrogen",
+        "無機態N",
+        "mg/100g",
+        "無機態窒素（NH4+NO3）",
+        ("total_nitrogen", "無機態N", "無機態窒素", "無機態窒素(NH4+NO3)"),
+    ),
+    ChemicalFieldDefinition(
+        "nh4_per_nitrogen",
+        "NH4/N比",
+        "",
+        "アンモニア態窒素比",
+        ("nh4_per_nitrogen", "NH4/N比", "アンモニア態窒素比"),
+    ),
     ChemicalFieldDefinition("ph", "pH", "", "水素イオン濃度", ("ph", "pH")),
     ChemicalFieldDefinition("cao", "CaO", "mg/100g", "交換性石灰", ("cao", "CaO")),
     ChemicalFieldDefinition("mgo", "MgO", "mg/100g", "交換性苦土", ("mgo", "MgO")),
     ChemicalFieldDefinition("k2o", "K2O", "mg/100g", "交換性加里", ("k2o", "K2O")),
-    ChemicalFieldDefinition("base_saturation", "塩基飽和度", "%", "塩基飽和度"),
-    ChemicalFieldDefinition("cao_per_mgo", "CaO/MgO", "", "CaO/MgO比"),
-    ChemicalFieldDefinition("mgo_per_k2o", "MgO/K2O", "", "MgO/K2O比"),
+    ChemicalFieldDefinition(
+        "base_saturation",
+        "塩基飽和度",
+        "%",
+        "塩基飽和度",
+        ("base_saturation", "塩基飽和度"),
+    ),
+    ChemicalFieldDefinition(
+        "cao_per_mgo", "CaO/MgO", "", "CaO/MgO比", ("cao_per_mgo", "CaO/MgO")
+    ),
+    ChemicalFieldDefinition(
+        "mgo_per_k2o", "MgO/K2O", "", "MgO/K2O比", ("mgo_per_k2o", "MgO/K2O")
+    ),
     ChemicalFieldDefinition(
         "phosphorus_absorption",
         "リン酸吸",
         "mg/100g",
         "リン酸吸収係数",
-        ("リン酸吸", "リン酸吸収係数"),
+        ("phosphorus_absorption", "リン酸吸収係数", "リン酸吸"),
     ),
-    ChemicalFieldDefinition("p2o5", "P2O5", "mg/100g", "可給態リン酸", ("p2o5", "P2O5")),
+    ChemicalFieldDefinition(
+        "p2o5", "P2O5", "mg/100g", "可給態リン酸", ("p2o5", "P2O5")
+    ),
     ChemicalFieldDefinition("cec", "CEC", "meq/100g", "塩基置換容量", ("cec", "CEC")),
-    ChemicalFieldDefinition("humus", "腐植", "%", "腐植"),
-    ChemicalFieldDefinition("bulk_density", "仮比重", "", "仮比重"),
+    ChemicalFieldDefinition("humus", "腐植", "%", "腐植", ("humus", "腐植")),
+    ChemicalFieldDefinition(
+        "bulk_density", "仮比重", "", "仮比重", ("bulk_density", "仮比重")
+    ),
 )
 
-CHEMICAL_FIELD_KEYS: tuple[str, ...] = tuple(defn.key for defn in CHEMICAL_FIELD_DEFINITIONS)
+CHEMICAL_FIELD_KEYS: tuple[str, ...] = tuple(
+    defn.key for defn in CHEMICAL_FIELD_DEFINITIONS
+)
+
+
+def normalize_text(value: str) -> str:
+    """Excelの列名を正規化してマッチング用に整形する
+
+    Excelファイル（特に川田研究所フォーマット）では、手入力やコピペによって
+    全角・半角の表記ゆれが発生しやすい。この関数で文字列を統一して
+    確実にマッチングできるようにする。
+
+    正規化処理:
+        1. NFKC正規化（互換文字を統一）
+           - 全角英数字 → 半角英数字 (例: "ＥＣ" → "EC")
+           - 全角ハイフン → 半角ハイフン (例: "NH4－N" → "NH4-N")
+           - 全角カッコ → 半角カッコ (例: "（NH4+NO3）" → "(NH4+NO3)")
+        2. 小文字化 (例: "EC" → "ec")
+        3. 前後の空白除去
+        4. スペース除去（半角・全角）
+        5. カッコの統一（全角→半角）
+
+    Args:
+        value: 正規化対象の文字列（Excel列名など）
+
+    Returns:
+        正規化された文字列
+
+    Examples:
+        >>> normalize_text("NH4-N")
+        'nh4-n'
+        >>> normalize_text("NH4－N")  # 全角ハイフン
+        'nh4-n'
+        >>> normalize_text("ＥＣ")  # 全角英字
+        'ec'
+        >>> normalize_text("無機態窒素（NH4+NO3）")  # 全角カッコ
+        '無機態窒素(nh4+no3)'
+    """
+    normalized = unicodedata.normalize("NFKC", str(value or "")).strip().lower()
+    return (
+        normalized.replace(" ", "")
+        .replace("　", "")
+        .replace("（", "(")
+        .replace("）", ")")
+    )
 
 
 def build_alias_to_field_key_map() -> dict[str, str]:
+    """正規化済みエイリアス → フィールドキーのマッピング辞書を生成する
+
+    CHEMICAL_FIELD_DEFINITIONSに定義された全フィールドのエイリアスを
+    normalize_text()で正規化し、対応するフィールドキーへのマッピングを作成する。
+    この辞書を使うことで、Excelの列名から素早くフィールドを特定できる。
+
+    Returns:
+        正規化済みエイリアス -> フィールドキーの辞書
+
+    Examples:
+        >>> mapping = build_alias_to_field_key_map()
+        >>> mapping["ec"]  # 小文字
+        'ec'
+        >>> mapping["nh4-n"]  # ハイフン付き
+        'nh4n'
+        >>> mapping["無機態窒素(nh4+no3)"]  # 日本語+英数字
+        'total_nitrogen'
+    """
     alias_map: dict[str, str] = {}
     for defn in CHEMICAL_FIELD_DEFINITIONS:
         for alias in (defn.key, *defn.aliases):
-            alias_map[alias.strip().lower()] = defn.key
+            alias_map[normalize_text(alias)] = defn.key
     return alias_map
 
 
 CHEMICAL_FIELD_ALIAS_TO_KEY: dict[str, str] = build_alias_to_field_key_map()
-
-
-def resolve_chemical_field_key(column_name: str) -> str | None:
-    normalized = column_name.strip().lower()
-    return CHEMICAL_FIELD_ALIAS_TO_KEY.get(normalized)

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -147,6 +147,16 @@ class ChemicalUploadForm(forms.Form):
             attrs={"class": "form-control", "tabindex": "1", "accept": ".xlsx"}
         ),
     )
+    land_ledger_id = forms.ModelChoiceField(
+        queryset=LandLedger.objects.all().order_by("-id"),
+        label="取り込み先帳簿",
+        widget=forms.Select(attrs={"class": "form-select", "tabindex": "2"}),
+    )
+    overwrite = forms.BooleanField(
+        label="既存データを上書き",
+        required=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input", "tabindex": "3"}),
+    )
 
 
 class CsvGenerateForm(forms.Form):

--- a/soil_analysis/forms.py
+++ b/soil_analysis/forms.py
@@ -140,6 +140,15 @@ class UploadForm(forms.Form):
     )
 
 
+class ChemicalUploadForm(forms.Form):
+    file = forms.FileField(
+        label="川田研究所 XLSX",
+        widget=ClearableFileInput(
+            attrs={"class": "form-control", "tabindex": "1", "accept": ".xlsx"}
+        ),
+    )
+
+
 class CsvGenerateForm(forms.Form):
     num_fields = forms.IntegerField(
         label="生成する圃場数",

--- a/soil_analysis/management/commands/chemical_load_data.py
+++ b/soil_analysis/management/commands/chemical_load_data.py
@@ -1,0 +1,343 @@
+"""川田研究所フォーマットのExcelファイルから化学分析データを取り込むDjangoコマンド
+
+川田研究所が提供する化学分析結果Excel(.xlsx)を読み込み、
+LandScoreChemicalテーブルにデータを一括登録する。
+
+使用方法:
+    python manage.py chemical_load_data <excel_path> --land-ledger-id=<ledger_id> [--overwrite]
+
+例:
+    python manage.py chemical_load_data data.xlsx --land-ledger-id=123
+    python manage.py chemical_load_data data.xlsx --land-ledger-id=123 --overwrite
+"""
+
+from decimal import Decimal, InvalidOperation
+
+import unicodedata
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from openpyxl import load_workbook
+
+from soil_analysis.domain.valueobject.chemical_report.fields import (
+    CHEMICAL_FIELD_ALIAS_TO_KEY,
+    CHEMICAL_FIELD_KEYS,
+    normalize_text,
+)
+from soil_analysis.models import LandBlock, LandLedger, LandScoreChemical
+
+# 取り込み対象のブロック名（9ブロック固定）
+BLOCK_NAMES = ("A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3")
+
+# 取り込みモードを示すremark文字列（圃場レベルのデータを9ブロックにコピーしたことを示す）
+REMARK_IMPORT_MODE = "import_mode=field_level_copied_to_9_blocks"
+
+# Excelで圃場名列として使われる可能性のある列名
+LAND_NAME_ALIASES = ("圃場名", "圃場", "ほ場名", "ほ場")
+
+# 正規化済み圃場名エイリアス（列名マッチング用）
+NORMALIZED_LAND_NAME_ALIASES = {normalize_text(name) for name in LAND_NAME_ALIASES}
+
+
+def parse_numeric_value(
+    raw_value: object, row_number: int, column_name: str
+) -> float | None:
+    """Excelセルの値を数値（float）に変換する
+
+    Excelシートから読み取った生の値を、化学分析データとして使用できる
+    float型に変換する。空値やハイフン（欠測値）、パーセント記号付き数値などに対応。
+
+    変換処理:
+        1. None/空文字/ハイフン類 → None（欠測値）
+        2. カンマ除去（例: "1,234" → "1234"）
+        3. パーセント記号除去（例: "50%" → "50"）
+        4. Decimal経由でfloatに変換（精度保持のため）
+
+    Args:
+        raw_value: Excelセルの生の値（文字列、数値、Noneなど）
+        row_number: 行番号（エラーメッセージ用）
+        column_name: 列名（エラーメッセージ用）
+
+    Returns:
+        変換後のfloat値、または欠測値の場合はNone
+
+    Raises:
+        ValueError: 数値変換に失敗した場合（行番号・列名・値を含むメッセージ）
+
+    Examples:
+        >>> parse_numeric_value("123", 1, "ec")
+        123.0
+        >>> parse_numeric_value("1,234.5", 1, "ec")
+        1234.5
+        >>> parse_numeric_value("50%", 1, "base_saturation")
+        50.0
+        >>> parse_numeric_value("-", 1, "ec")
+        None
+        >>> parse_numeric_value(None, 1, "ec")
+        None
+    """
+    if raw_value is None:
+        return None
+    text = unicodedata.normalize("NFKC", str(raw_value)).strip()
+    if text in ("", "-", "ー", "―"):
+        return None
+    text = text.replace(",", "")
+    if text.endswith("%"):
+        text = text[:-1].strip()
+    try:
+        return float(Decimal(text))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(
+            f"数値変換失敗 row={row_number}, column={column_name}, value={raw_value}"
+        ) from exc
+
+
+def parse_kawada_worksheet(worksheet):
+    """川田研究所フォーマットのExcelシートをパースして化学分析データを抽出する
+
+    Excelシート全体をスキャンして以下の処理を行う:
+        1. ヘッダ行を自動検出（圃場名列 + 分析項目列が揃った行）
+        2. 列名を正規化してフィールドにマッピング
+        3. 必須列の存在チェック（全17項目）
+        4. データ行を1行ずつパースして数値変換
+
+    川田研究所フォーマットの特徴:
+        - ヘッダ行の位置が固定されていない（自動検出が必要）
+        - 列名に全角・半角の表記ゆれがある
+        - 圃場名列が必須（"圃場名", "圃場", "ほ場名", "ほ場"など）
+
+    Args:
+        worksheet: openpyxlのワークシートオブジェクト
+
+    Returns:
+        tuple[list[dict], list[str]]: (パース結果, エラーリスト)
+
+        パース結果の各要素:
+            {
+                "row_number": int,        # Excel行番号（1始まり）
+                "land_name": str,         # 圃場名
+                "values": {               # フィールド名 -> 数値のマッピング
+                    "ec": float | None,
+                    "ph": float | None,
+                    ...
+                }
+            }
+
+        エラーリスト:
+            - ヘッダ行が見つからない場合
+            - 必須列が不足している場合
+            - 数値変換エラーが発生した場合
+
+    Examples:
+        >>> from openpyxl import load_workbook
+        >>> wb = load_workbook("kawada_data.xlsx", data_only=True)
+        >>> parsed_rows, errors = parse_kawada_worksheet(wb.active)
+        >>> len(parsed_rows)
+        5
+        >>> parsed_rows[0]["land_name"]
+        '静岡ススムA1'
+        >>> parsed_rows[0]["values"]["ec"]
+        0.15
+    """
+    rows = list(worksheet.iter_rows(values_only=True))
+    if not rows:
+        return [], ["シートにデータがありません。"]
+
+    header_index = None
+    header_map = {}
+    land_name_column_index = None
+
+    for idx, row in enumerate(rows):
+        candidate_map = {}
+        candidate_land_index = None
+        for col_idx, cell in enumerate(row):
+            cell_text = normalize_text(cell or "")
+            if not cell_text:
+                continue
+            if cell_text in NORMALIZED_LAND_NAME_ALIASES:
+                candidate_land_index = col_idx
+            column_key = CHEMICAL_FIELD_ALIAS_TO_KEY.get(cell_text)
+            if not column_key:
+                for alias, key in CHEMICAL_FIELD_ALIAS_TO_KEY.items():
+                    if alias and alias in cell_text:
+                        column_key = key
+                        break
+            if column_key:
+                candidate_map[column_key] = col_idx
+        if candidate_land_index is not None and len(candidate_map) >= 1:
+            header_index = idx
+            header_map = candidate_map
+            land_name_column_index = candidate_land_index
+            break
+
+    if header_index is None or land_name_column_index is None:
+        return [], [
+            "ヘッダ行を特定できませんでした。圃場名列と分析項目列を確認してください。"
+        ]
+
+    missing = [field for field in CHEMICAL_FIELD_KEYS if field not in header_map]
+    if missing:
+        return [], [f"必須列不足: {', '.join(missing)}"]
+
+    parsed_rows = []
+    parse_errors = []
+
+    for idx in range(header_index + 1, len(rows)):
+        row = rows[idx]
+        row_number = idx + 1
+        land_name_raw = (
+            row[land_name_column_index] if land_name_column_index < len(row) else ""
+        )
+        land_name = str(land_name_raw or "").strip()
+        if not land_name:
+            continue
+        try:
+            values = {}
+            for field_name, col_idx in header_map.items():
+                raw_value = row[col_idx] if col_idx < len(row) else None
+                values[field_name] = parse_numeric_value(
+                    raw_value, row_number, field_name
+                )
+            parsed_rows.append(
+                {"row_number": row_number, "land_name": land_name, "values": values}
+            )
+        except ValueError as exc:
+            parse_errors.append(str(exc))
+
+    return parsed_rows, parse_errors
+
+
+class Command(BaseCommand):
+    """川田研究所フォーマットのExcelから化学分析データを取り込むDjangoコマンド
+
+    川田研究所が提供する化学分析結果Excel(.xlsx)を読み込み、
+    指定されたLandLedgerに紐づけてLandScoreChemicalテーブルにデータを一括登録する。
+
+    1つの圃場データを9ブロック（A1-C3）すべてにコピーする仕様。
+
+    使用方法:
+        python manage.py chemical_load_data <excel_path> --land-ledger-id=<id> [--overwrite]
+
+    引数:
+        excel_path: 川田研究所のExcelファイルパス（.xlsx）
+        --land-ledger-id: 取り込み先のLandLedger ID（必須）
+        --overwrite: 既存データを上書きする場合に指定
+
+    動作:
+        1. Excelファイルをパースして化学分析データを抽出
+        2. 指定されたLandLedgerの存在確認
+        3. 必要なLandBlockの存在確認（A1-C3）
+        4. トランザクション内でデータを一括登録
+           - 既存データがある場合: overwriteならば更新、なければスキップ
+           - 新規データ: 作成
+
+    例:
+        # 通常の取り込み
+        python manage.py chemical_load_data data.xlsx --land-ledger-id=123
+
+        # 既存データを上書き
+        python manage.py chemical_load_data data.xlsx --land-ledger-id=123 --overwrite
+    """
+
+    help = "Import chemical analysis data from Excel (Kawada format)"
+
+    def add_arguments(self, parser):
+        parser.add_argument("file_path", type=str, help="Path to Excel file (.xlsx)")
+        parser.add_argument(
+            "--land-ledger-id",
+            type=int,
+            required=True,
+            help="LandLedger ID to associate",
+        )
+        parser.add_argument(
+            "--overwrite", action="store_true", help="Overwrite existing data"
+        )
+
+    def handle(self, *args, **options):
+        file_path = options["file_path"]
+        land_ledger_id = options["land_ledger_id"]
+        overwrite = options.get("overwrite", False)
+
+        try:
+            workbook = load_workbook(file_path, data_only=True)
+            worksheet = workbook.active
+            parsed_rows, parse_errors = parse_kawada_worksheet(worksheet)
+
+            # パースエラーが存在する場合は処理を中断
+            if parse_errors:
+                for error in parse_errors:
+                    self.stderr.write(self.style.ERROR(error))
+                return
+
+            # 取り込み対象行が存在しない場合は処理を中断
+            if not parsed_rows:
+                self.stderr.write(self.style.WARNING("取り込み対象行がありません。"))
+                return
+
+            # LandLedgerの存在確認
+            try:
+                ledger = LandLedger.objects.get(id=land_ledger_id)
+            except LandLedger.DoesNotExist:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"LandLedger ID {land_ledger_id} が見つかりません。"
+                    )
+                )
+                return
+
+            created_count = 0
+            updated_count = 0
+            warnings = []
+
+            blocks_by_name = {
+                b.name: b for b in LandBlock.objects.filter(name__in=BLOCK_NAMES)
+            }
+            missing_blocks = [
+                name for name in BLOCK_NAMES if name not in blocks_by_name
+            ]
+
+            if missing_blocks:
+                self.stderr.write(
+                    self.style.ERROR(f"ブロック不足: {','.join(missing_blocks)}")
+                )
+                return
+
+            with transaction.atomic():
+                for row in parsed_rows:
+                    for block_name in BLOCK_NAMES:
+                        block = blocks_by_name[block_name]
+                        defaults = {**row["values"], "remark": REMARK_IMPORT_MODE}
+                        existing = LandScoreChemical.objects.filter(
+                            land_ledger=ledger,
+                            land_block=block,
+                        ).first()
+
+                        if existing:
+                            if not overwrite:
+                                warnings.append(
+                                    f"既存データありスキップ row={row['row_number']}, ledger_id={ledger.id}, block={block_name}"
+                                )
+                                continue
+                            for field_name, field_value in defaults.items():
+                                setattr(existing, field_name, field_value)
+                            existing.save()
+                            updated_count += 1
+                            continue
+
+                        LandScoreChemical.objects.create(
+                            land_ledger=ledger,
+                            land_block=block,
+                            **defaults,
+                        )
+                        created_count += 1
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"取り込み完了: 新規作成={created_count}, 更新={updated_count}, 警告={len(warnings)}"
+                )
+            )
+            for warning in warnings:
+                self.stdout.write(self.style.WARNING(warning))
+
+        except Exception as e:
+            self.stderr.write(self.style.ERROR(f"エラー: {str(e)}"))
+            raise

--- a/soil_analysis/management/commands/chemical_load_data.py
+++ b/soil_analysis/management/commands/chemical_load_data.py
@@ -20,7 +20,7 @@ from django.db import transaction
 from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
-from soil_analysis.models import LandBlock, LandLedger, LandScoreChemical
+from soil_analysis.models import LandLedger, LandScoreChemical
 
 
 @attrs.frozen
@@ -100,11 +100,11 @@ class ParseResult:
     errors: list[str]
 
 
-# 取り込み対象のブロック名（9ブロック固定）
-BLOCK_NAMES = ("A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3")
+# 取り込み対象のブロックID（5点測量: 四隅+中央）
+BLOCK_IDS = (1, 3, 5, 7, 9)
 
-# 取り込みモードを示すremark文字列（圃場レベルのデータを9ブロックにコピーしたことを示す）
-REMARK_IMPORT_MODE = "import_mode=field_level_copied_to_9_blocks"
+# 取り込みモードを示すremark文字列（圃場レベルのデータを5ブロックにコピーしたことを示す）
+REMARK_IMPORT_MODE = "import_mode=field_level_copied_to_5_blocks"
 
 # 川田研究所フォーマットの前提条件（フォーマット変更時はここを修正）
 # 行定義（0-based: Pythonのリストインデックス）
@@ -424,33 +424,24 @@ class Command(BaseCommand):
             updated_count = 0
             warnings = []
 
-            blocks_by_name = {
-                b.name: b for b in LandBlock.objects.filter(name__in=BLOCK_NAMES)
-            }
-            missing_blocks = [
-                name for name in BLOCK_NAMES if name not in blocks_by_name
-            ]
-
-            if missing_blocks:
-                self.stderr.write(
-                    self.style.ERROR(f"ブロック不足: {','.join(missing_blocks)}")
-                )
-                return
+            # TODO(ticket7): LandScoreChemicalのland_block FK削除後、このブロック展開処理は不要になる
+            # 暫定対応: 圃場単位データ（1レコード）を5ブロック（1,3,5,7,9）に展開して保存
+            # - 現行モデルはland_blockが必須のため、5ブロック分のレコードを作成（5点法）
+            # - remarkに"import_mode=field_level_copied_to_5_blocks"を付与して識別
 
             with transaction.atomic():
                 for row in parse_result.rows:
-                    for block_name in BLOCK_NAMES:
-                        block = blocks_by_name[block_name]
+                    for block_id in BLOCK_IDS:
                         defaults = {**row.values, "remark": REMARK_IMPORT_MODE}
                         existing = LandScoreChemical.objects.filter(
                             land_ledger=ledger,
-                            land_block=block,
+                            land_block_id=block_id,
                         ).first()
 
                         if existing:
                             if not overwrite:
                                 warnings.append(
-                                    f"既存データありスキップ row={row.row_number}, ledger_id={ledger.id}, block={block_name}"
+                                    f"既存データありスキップ row={row.row_number}, ledger_id={ledger.id}, block_id={block_id}"
                                 )
                                 continue
                             for field_name, field_value in defaults.items():
@@ -461,7 +452,7 @@ class Command(BaseCommand):
 
                         LandScoreChemical.objects.create(
                             land_ledger=ledger,
-                            land_block=block,
+                            land_block_id=block_id,
                             **defaults,
                         )
                         created_count += 1

--- a/soil_analysis/management/commands/chemical_load_data.py
+++ b/soil_analysis/management/commands/chemical_load_data.py
@@ -398,15 +398,18 @@ class Command(BaseCommand):
             worksheet = workbook.active
             parse_result = parse_kawada_worksheet(worksheet)
 
+            # パースエラーが存在する場合は処理を中断
             if parse_result.errors:
                 for error in parse_result.errors:
                     self.stderr.write(self.style.ERROR(error))
                 return
 
+            # 取り込み対象行が存在しない場合は処理を中断
             if not parse_result.rows:
                 self.stderr.write(self.style.WARNING("取り込み対象行がありません。"))
                 return
 
+            # LandLedgerの存在確認
             try:
                 ledger = LandLedger.objects.get(id=land_ledger_id)
             except LandLedger.DoesNotExist:

--- a/soil_analysis/management/commands/chemical_load_data.py
+++ b/soil_analysis/management/commands/chemical_load_data.py
@@ -13,17 +13,92 @@ LandScoreChemicalテーブルにデータを一括登録する。
 
 from decimal import Decimal, InvalidOperation
 
+import attrs
 import unicodedata
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from openpyxl import load_workbook
+from openpyxl.worksheet.worksheet import Worksheet
 
-from soil_analysis.domain.valueobject.chemical_report.fields import (
-    CHEMICAL_FIELD_ALIAS_TO_KEY,
-    CHEMICAL_FIELD_KEYS,
-    normalize_text,
-)
 from soil_analysis.models import LandBlock, LandLedger, LandScoreChemical
+
+
+@attrs.frozen
+class KawadaRow:
+    """川田研究所フォーマット1行分のデータ
+
+    Attributes:
+        analysis_number: 分析番号（A列）
+        person_name: 氏名（B列）
+        land_name: 圃場名（C列）
+        crop: 栽培作物（D列）
+        ec: EC（E列）
+        ph: pH（F列）
+        cec: CEC（G列、meq/100g）
+        cao: CaO（H列）
+        mgo: MgO（I列）
+        k2o: K2O（J列）
+        lime_saturation: 石灰飽和度（K列、%）
+        magnesia_saturation: 苦土飽和度（L列、%）
+        potash_saturation: 加里飽和度（M列、%）
+        base_saturation: 塩基飽和度（N列、%）
+        p2o5: P2O5（O列）
+        phosphorus_absorption: リン酸吸収係数（P列）
+        nh4n: NH4-N（Q列）
+        no3n: NO3-N（R列）
+        humus: 腐植（S列）
+        bulk_density: 仮比重（T列）
+    """
+
+    analysis_number: str
+    person_name: str | None
+    land_name: str
+    crop: str | None
+    ec: float | None
+    ph: float | None
+    cec: float | None
+    cao: float | None
+    mgo: float | None
+    k2o: float | None
+    lime_saturation: float | None
+    magnesia_saturation: float | None
+    potash_saturation: float | None
+    base_saturation: float | None
+    p2o5: float | None
+    phosphorus_absorption: float | None
+    nh4n: float | None
+    no3n: float | None
+    humus: float | None
+    bulk_density: float | None
+
+
+@attrs.frozen
+class ParsedRow:
+    """パース済みデータ行（LandScoreChemical用）
+
+    Attributes:
+        row_number: Excel行番号（1始まり）
+        land_name: 圃場名
+        values: フィールド名 -> 数値のマッピング（CHEMICAL_FIELD_KEYSの全17項目）
+    """
+
+    row_number: int
+    land_name: str
+    values: dict[str, float | None]
+
+
+@attrs.frozen
+class ParseResult:
+    """Excelパース結果
+
+    Attributes:
+        rows: パース済みデータ行のリスト
+        errors: エラーメッセージのリスト
+    """
+
+    rows: list[ParsedRow]
+    errors: list[str]
+
 
 # 取り込み対象のブロック名（9ブロック固定）
 BLOCK_NAMES = ("A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3")
@@ -31,11 +106,23 @@ BLOCK_NAMES = ("A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3")
 # 取り込みモードを示すremark文字列（圃場レベルのデータを9ブロックにコピーしたことを示す）
 REMARK_IMPORT_MODE = "import_mode=field_level_copied_to_9_blocks"
 
-# Excelで圃場名列として使われる可能性のある列名
-LAND_NAME_ALIASES = ("圃場名", "圃場", "ほ場名", "ほ場")
+# 川田研究所フォーマットの前提条件（フォーマット変更時はここを修正）
+# 行定義（0-based: Pythonのリストインデックス）
+KAWADA_FORMAT_HEADER_ROW_INDEX = 2  # 3行目（ヘッダー行）
+KAWADA_FORMAT_DATA_START_ROW_INDEX = 3  # 4行目（データ開始行）
 
-# 正規化済み圃場名エイリアス（列名マッチング用）
-NORMALIZED_LAND_NAME_ALIASES = {normalize_text(name) for name in LAND_NAME_ALIASES}
+# 列定義（0-based: Pythonのリストインデックス）
+KAWADA_COLUMN_ANALYSIS_NUMBER = 0  # A列: 分析番号
+KAWADA_COLUMN_PERSON_NAME = 1  # B列: 氏名
+KAWADA_COLUMN_LAND_NAME = 2  # C列: 圃場名
+KAWADA_COLUMN_CROP = 3  # D列: 栽培作物
+# E列: 化学分析データ開始（CHEMICAL_FIELD_DEFINITIONSの順序で17項目）
+KAWADA_COLUMN_CHEMICAL_START = 4
+
+# セル参照（1-based: Excelのセル記法）
+KAWADA_CELL_ANALYSIS_DATE = (
+    "G1"  # 分析日（将来的に LandLedger.reporting_date に取り込み予定）
+)
 
 
 def parse_numeric_value(
@@ -91,119 +178,158 @@ def parse_numeric_value(
         ) from exc
 
 
-def parse_kawada_worksheet(worksheet):
+def _parse_kawada_row(row: tuple) -> KawadaRow:
+    """川田フォーマットの1行をパースしてVOを構築
+
+    Args:
+        row: Excelの行データ（タプル）
+
+    Returns:
+        KawadaRow: 川田フォーマット1行分のVO
+
+    Raises:
+        ValueError: 数値変換に失敗した場合（行番号なし、呼び出し側で追加すること）
+    """
+
+    def get_cell(col_idx: int) -> str:
+        """セル値を文字列として取得"""
+        return str(row[col_idx] if col_idx < len(row) else "").strip()
+
+    def get_numeric(col_idx: int, field_name: str) -> float | None:
+        """セル値を数値として取得"""
+        raw_value = row[col_idx] if col_idx < len(row) else None
+        # row_numberなしでパース（エラーメッセージには列名と値のみ）
+        return parse_numeric_value(raw_value, 0, field_name)
+
+    return KawadaRow(
+        analysis_number=get_cell(KAWADA_COLUMN_ANALYSIS_NUMBER),
+        person_name=get_cell(KAWADA_COLUMN_PERSON_NAME) or None,
+        land_name=get_cell(KAWADA_COLUMN_LAND_NAME),
+        crop=get_cell(KAWADA_COLUMN_CROP) or None,
+        ec=get_numeric(4, "ec"),
+        ph=get_numeric(5, "ph"),
+        cec=get_numeric(6, "cec"),
+        cao=get_numeric(7, "cao"),
+        mgo=get_numeric(8, "mgo"),
+        k2o=get_numeric(9, "k2o"),
+        lime_saturation=get_numeric(10, "lime_saturation"),
+        magnesia_saturation=get_numeric(11, "magnesia_saturation"),
+        potash_saturation=get_numeric(12, "potash_saturation"),
+        base_saturation=get_numeric(13, "base_saturation"),
+        p2o5=get_numeric(14, "p2o5"),
+        phosphorus_absorption=get_numeric(15, "phosphorus_absorption"),
+        nh4n=get_numeric(16, "nh4n"),
+        no3n=get_numeric(17, "no3n"),
+        humus=get_numeric(18, "humus"),
+        bulk_density=get_numeric(19, "bulk_density"),
+    )
+
+
+def parse_kawada_worksheet(worksheet: Worksheet) -> ParseResult:
     """川田研究所フォーマットのExcelシートをパースして化学分析データを抽出する
 
-    Excelシート全体をスキャンして以下の処理を行う:
-        1. ヘッダ行を自動検出（圃場名列 + 分析項目列が揃った行）
-        2. 列名を正規化してフィールドにマッピング
-        3. 必須列の存在チェック（全17項目）
-        4. データ行を1行ずつパースして数値変換
+    川田研究所フォーマットの前提条件:
+        - ヘッダ行: 3行目固定
+        - 分析日: G1セル
+        - 必須列: 圃場名 + 17項目の化学分析項目
 
-    川田研究所フォーマットの特徴:
-        - ヘッダ行の位置が固定されていない（自動検出が必要）
-        - 列名に全角・半角の表記ゆれがある
-        - 圃場名列が必須（"圃場名", "圃場", "ほ場名", "ほ場"など）
+    処理の流れ:
+        1. 3行目のヘッダー行から列マッピングを構築
+        2. 圃場名列と必須17項目の存在をチェック
+        3. 4行目以降のデータ行をパースして数値変換
 
     Args:
         worksheet: openpyxlのワークシートオブジェクト
 
     Returns:
-        tuple[list[dict], list[str]]: (パース結果, エラーリスト)
-
-        パース結果の各要素:
-            {
-                "row_number": int,        # Excel行番号（1始まり）
-                "land_name": str,         # 圃場名
-                "values": {               # フィールド名 -> 数値のマッピング
-                    "ec": float | None,
-                    "ph": float | None,
-                    ...
-                }
-            }
-
-        エラーリスト:
-            - ヘッダ行が見つからない場合
-            - 必須列が不足している場合
-            - 数値変換エラーが発生した場合
+        ParseResult: パース結果とエラーリストを含むVO
 
     Examples:
         >>> from openpyxl import load_workbook
         >>> wb = load_workbook("kawada_data.xlsx", data_only=True)
-        >>> parsed_rows, errors = parse_kawada_worksheet(wb.active)
-        >>> len(parsed_rows)
+        >>> result = parse_kawada_worksheet(wb.active)
+        >>> len(result.rows)
         5
-        >>> parsed_rows[0]["land_name"]
+        >>> result.rows[0].land_name
         '静岡ススムA1'
-        >>> parsed_rows[0]["values"]["ec"]
+        >>> result.rows[0].values["ec"]
         0.15
     """
+    # Excelシートのすべての行を取得（空行も含む）
+    # rows[0] = 1行目, rows[1] = 2行目（空行）, rows[2] = 3行目（ヘッダー）, ...
     rows = list(worksheet.iter_rows(values_only=True))
     if not rows:
-        return [], ["シートにデータがありません。"]
+        return ParseResult(rows=[], errors=["シートにデータがありません。"])
 
-    header_index = None
-    header_map = {}
-    land_name_column_index = None
+    # ヘッダー行の存在チェック
+    if len(rows) <= KAWADA_FORMAT_HEADER_ROW_INDEX:
+        return ParseResult(
+            rows=[],
+            errors=[
+                f"ヘッダー行に満たない行数でした（{len(rows)}行、ヘッダーは{KAWADA_FORMAT_HEADER_ROW_INDEX + 1}行目）。"
+            ],
+        )
 
-    for idx, row in enumerate(rows):
-        candidate_map = {}
-        candidate_land_index = None
-        for col_idx, cell in enumerate(row):
-            cell_text = normalize_text(cell or "")
-            if not cell_text:
-                continue
-            if cell_text in NORMALIZED_LAND_NAME_ALIASES:
-                candidate_land_index = col_idx
-            column_key = CHEMICAL_FIELD_ALIAS_TO_KEY.get(cell_text)
-            if not column_key:
-                for alias, key in CHEMICAL_FIELD_ALIAS_TO_KEY.items():
-                    if alias and alias in cell_text:
-                        column_key = key
-                        break
-            if column_key:
-                candidate_map[column_key] = col_idx
-        if candidate_land_index is not None and len(candidate_map) >= 1:
-            header_index = idx
-            header_map = candidate_map
-            land_name_column_index = candidate_land_index
-            break
-
-    if header_index is None or land_name_column_index is None:
-        return [], [
-            "ヘッダ行を特定できませんでした。圃場名列と分析項目列を確認してください。"
-        ]
-
-    missing = [field for field in CHEMICAL_FIELD_KEYS if field not in header_map]
-    if missing:
-        return [], [f"必須列不足: {', '.join(missing)}"]
-
+    # データ行のパース（4行目以降）
+    # 各行から以下を抽出:
+    #   1. 分析番号（A列）- 空行はスキップ（川田研究所側のID）
+    #   2. 圃場名（C列）
+    #   3. 化学分析データ（E列〜T列の16項目）- 川田フォーマットの列位置に基づいて取得
+    #   4. 数値変換エラーがあればエラーリストに追加して次の行へ
     parsed_rows = []
     parse_errors = []
 
-    for idx in range(header_index + 1, len(rows)):
-        row = rows[idx]
-        row_number = idx + 1
-        land_name_raw = (
-            row[land_name_column_index] if land_name_column_index < len(row) else ""
+    for i in range(KAWADA_FORMAT_DATA_START_ROW_INDEX, len(rows)):
+        row = rows[i]
+        row_number = i + 1  # Excelの行番号（1始まり、ユーザー向け表示用）
+
+        # 分析番号（A列）の取得
+        analysis_number_raw = (
+            row[KAWADA_COLUMN_ANALYSIS_NUMBER]
+            if KAWADA_COLUMN_ANALYSIS_NUMBER < len(row)
+            else ""
         )
-        land_name = str(land_name_raw or "").strip()
-        if not land_name:
-            continue
+        analysis_number = str(analysis_number_raw or "").strip()
+        if not analysis_number:
+            continue  # 分析番号が空の行はスキップ（空行または非データ行）
+
         try:
-            values = {}
-            for field_name, col_idx in header_map.items():
-                raw_value = row[col_idx] if col_idx < len(row) else None
-                values[field_name] = parse_numeric_value(
-                    raw_value, row_number, field_name
-                )
+            # 川田フォーマット1行分をVOとして構築
+            kawada_row = _parse_kawada_row(row)
+
+            # LandScoreChemical用に変換（ticket7まで暫定対応）
+            # 川田にあってLandScoreChemicalにない項目: lime_saturation, magnesia_saturation, potash_saturation → 無視
+            # 川田にないLandScoreChemicalの項目: total_nitrogen, nh4_per_nitrogen, cao_per_mgo, mgo_per_k2o → None
+            values = {
+                "ec": kawada_row.ec,
+                "nh4n": kawada_row.nh4n,
+                "no3n": kawada_row.no3n,
+                "total_nitrogen": None,  # TODO: ticket7で削除
+                "nh4_per_nitrogen": None,  # TODO: ticket7で削除
+                "ph": kawada_row.ph,
+                "cao": kawada_row.cao,
+                "mgo": kawada_row.mgo,
+                "k2o": kawada_row.k2o,
+                "base_saturation": kawada_row.base_saturation,
+                "cao_per_mgo": None,  # TODO: ticket7で削除
+                "mgo_per_k2o": None,  # TODO: ticket7で削除
+                "phosphorus_absorption": kawada_row.phosphorus_absorption,
+                "p2o5": kawada_row.p2o5,
+                "cec": kawada_row.cec,
+                "humus": kawada_row.humus,
+                "bulk_density": kawada_row.bulk_density,
+            }
+
             parsed_rows.append(
-                {"row_number": row_number, "land_name": land_name, "values": values}
+                ParsedRow(
+                    row_number=row_number, land_name=kawada_row.land_name, values=values
+                )
             )
         except ValueError as exc:
-            parse_errors.append(str(exc))
+            # 数値変換エラー: 行番号を追加してエラーリストに記録
+            parse_errors.append(f"row={row_number}: {exc}")
 
-    return parsed_rows, parse_errors
+    return ParseResult(rows=parsed_rows, errors=parse_errors)
 
 
 class Command(BaseCommand):
@@ -259,21 +385,28 @@ class Command(BaseCommand):
 
         try:
             workbook = load_workbook(file_path, data_only=True)
-            worksheet = workbook.active
-            parsed_rows, parse_errors = parse_kawada_worksheet(worksheet)
 
-            # パースエラーが存在する場合は処理を中断
-            if parse_errors:
-                for error in parse_errors:
+            # シート数が1であることを確認
+            if len(workbook.sheetnames) != 1:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Excelファイルのシート数が1ではありません（{len(workbook.sheetnames)}枚）。"
+                        f"シートは1枚にしてください。"
+                    )
+                )
+                return
+            worksheet = workbook.active
+            parse_result = parse_kawada_worksheet(worksheet)
+
+            if parse_result.errors:
+                for error in parse_result.errors:
                     self.stderr.write(self.style.ERROR(error))
                 return
 
-            # 取り込み対象行が存在しない場合は処理を中断
-            if not parsed_rows:
+            if not parse_result.rows:
                 self.stderr.write(self.style.WARNING("取り込み対象行がありません。"))
                 return
 
-            # LandLedgerの存在確認
             try:
                 ledger = LandLedger.objects.get(id=land_ledger_id)
             except LandLedger.DoesNotExist:
@@ -302,10 +435,10 @@ class Command(BaseCommand):
                 return
 
             with transaction.atomic():
-                for row in parsed_rows:
+                for row in parse_result.rows:
                     for block_name in BLOCK_NAMES:
                         block = blocks_by_name[block_name]
-                        defaults = {**row["values"], "remark": REMARK_IMPORT_MODE}
+                        defaults = {**row.values, "remark": REMARK_IMPORT_MODE}
                         existing = LandScoreChemical.objects.filter(
                             land_ledger=ledger,
                             land_block=block,
@@ -314,7 +447,7 @@ class Command(BaseCommand):
                         if existing:
                             if not overwrite:
                                 warnings.append(
-                                    f"既存データありスキップ row={row['row_number']}, ledger_id={ledger.id}, block={block_name}"
+                                    f"既存データありスキップ row={row.row_number}, ledger_id={ledger.id}, block={block_name}"
                                 )
                                 continue
                             for field_name, field_value in defaults.items():

--- a/soil_analysis/models.py
+++ b/soil_analysis/models.py
@@ -395,6 +395,9 @@ class LandLedger(models.Model):
             ),
         ]
 
+    def __str__(self):
+        return f"{self.land.company.name} - {self.land.name} ({self.land_period.year} {self.land_period.name})"
+
 
 class SamplingOrder(models.Model):
     """

--- a/soil_analysis/templates/soil_analysis/chemical/form.html
+++ b/soil_analysis/templates/soil_analysis/chemical/form.html
@@ -1,0 +1,62 @@
+{% extends "soil_analysis/base.html" %}
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item active" aria-current="page">化学分析データ取り込み</li>
+            </ol>
+        </nav>
+
+        <h1 class="mb-4"><i class="fas fa-flask me-2"></i>化学分析データ取り込み</h1>
+
+        <div class="card">
+            <div class="card-body">
+                <form method="post" enctype="multipart/form-data">
+                    {% csrf_token %}
+                    
+                    <div class="mb-3">
+                        <label for="{{ form.file.id_for_label }}" class="form-label">
+                            {{ form.file.label }}
+                        </label>
+                        {{ form.file }}
+                        <div class="form-text">川田研究所のExcelファイル（.xlsx）を選択してください</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="{{ form.land_ledger_id.id_for_label }}" class="form-label">
+                            {{ form.land_ledger_id.label }}
+                        </label>
+                        {{ form.land_ledger_id }}
+                        <div class="form-text">取り込み先の帳簿を選択してください</div>
+                    </div>
+
+                    <div class="form-check mb-3">
+                        {{ form.overwrite }}
+                        <label class="form-check-label" for="{{ form.overwrite.id_for_label }}">
+                            {{ form.overwrite.label }}
+                        </label>
+                        <div class="form-text">既存のデータを上書きする場合はチェックしてください</div>
+                    </div>
+
+                    <button class="btn btn-primary" type="submit">
+                        <i class="fas fa-upload me-1"></i>取り込み実行
+                    </button>
+                    <a href="{% url 'soil:home' %}" class="btn btn-outline-secondary">
+                        <i class="fas fa-arrow-left me-1"></i>キャンセル
+                    </a>
+                </form>
+            </div>
+        </div>
+
+        <div class="alert alert-info mt-4">
+            <h6><i class="fas fa-info-circle"></i> 取り込み手順</h6>
+            <ol class="mb-0">
+                <li>川田研究所のExcelファイルを用意してください</li>
+                <li>取り込み先の帳簿を選択してください</li>
+                <li>「取り込み実行」ボタンをクリックしてください</li>
+                <li>取り込みが完了すると、成功画面が表示されます</li>
+            </ol>
+        </div>
+    </div>
+{% endblock %}

--- a/soil_analysis/templates/soil_analysis/chemical/success.html
+++ b/soil_analysis/templates/soil_analysis/chemical/success.html
@@ -1,0 +1,68 @@
+{% extends "soil_analysis/base.html" %}
+{% load static %}
+
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'soil:chemical_upload' %}">化学分析データ取り込み</a></li>
+                <li class="breadcrumb-item active" aria-current="page">取り込み完了</li>
+            </ol>
+        </nav>
+
+        <h1 class="mb-4"><i class="fas fa-check-circle text-success"></i> 取り込み完了</h1>
+
+        <div class="alert alert-success">
+            <h5><i class="fas fa-check-circle"></i> 化学分析データを正常に取り込みました！</h5>
+            <p class="mb-0">
+                新規作成: <strong>{{ created_count }}</strong> レコード
+                {% if updated_count > 0 %}
+                    / 更新: <strong>{{ updated_count }}</strong> レコード
+                {% endif %}
+            </p>
+        </div>
+
+        {% if warnings %}
+            <div class="alert alert-warning">
+                <h6><i class="fas fa-exclamation-triangle"></i> 警告</h6>
+                <ul class="mb-0">
+                    {% for warning in warnings %}
+                        <li>{{ warning }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+
+        <div class="card mb-4">
+            <div class="card-header">
+                <h6 class="mb-0"><i class="fas fa-info-circle"></i> 取り込み情報</h6>
+            </div>
+            <div class="card-body">
+                <dl class="row">
+                    <dt class="col-sm-3">取り込み日時</dt>
+                    <dd class="col-sm-9">{{ import_datetime|date:"Y-m-d H:i:s" }}</dd>
+                    
+                    <dt class="col-sm-3">対象帳簿</dt>
+                    <dd class="col-sm-9">
+                        <a href="{% url 'soil:land_detail' land_ledger.land.company.id land_ledger.land.id %}">
+                            {{ land_ledger.land.company.name }} / {{ land_ledger.land.name }}
+                        </a>
+                    </dd>
+                    
+                    <dt class="col-sm-3">サンプリング日</dt>
+                    <dd class="col-sm-9">{{ land_ledger.sampling_date|date:"Y-m-d" }}</dd>
+                </dl>
+            </div>
+        </div>
+
+        <div class="text-center">
+            <a class="btn btn-primary" href="{% url 'soil:land_detail' land_ledger.land.company.id land_ledger.land.id %}">
+                <i class="fas fa-arrow-left"></i> 圃場詳細に戻る
+            </a>
+            <a class="btn btn-outline-primary" href="{% url 'soil:chemical_upload' %}">
+                <i class="fas fa-upload"></i> 続けて取り込む
+            </a>
+        </div>
+    </div>
+{% endblock %}

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -22,7 +22,10 @@
                             <i class="fas fa-building me-1"></i>企業の追加
                         </a>
                         <a class="btn btn-outline-primary" href="{% url 'soil:hardness_upload' %}">
-                            <i class="fas fa-upload me-1"></i>土壌硬度データ取り込み
+                            <i class="fas fa-hammer me-1"></i>土壌硬度データ取り込み
+                        </a>
+                        <a class="btn btn-outline-primary" href="{% url 'soil:chemical_upload' %}">
+                            <i class="fas fa-flask me-1"></i>化学分析データ取り込み
                         </a>
                         <a class="btn btn-outline-primary" href="{% url 'soil:route_suggest_upload' %}">
                             <i class="fas fa-route me-1"></i>圃場ルートサジェスト

--- a/soil_analysis/tests/domain/service/test_chemical_import.py
+++ b/soil_analysis/tests/domain/service/test_chemical_import.py
@@ -4,10 +4,9 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from openpyxl import Workbook
 
-from soil_analysis.domain.service.chemical_import import (
-    BLOCK_NAMES,
-    ParsedChemicalRow,
-    import_chemical_rows,
+from soil_analysis.management.commands.chemical_load_data import (
+    BLOCK_IDS,
+    ParsedRow,
     parse_kawada_worksheet,
 )
 from soil_analysis.models import (
@@ -60,71 +59,32 @@ class ChemicalImportServiceTests(TestCase):
             sampling_method=sampling_method,
             sampling_staff=self.user,
         )
-        for block_name in BLOCK_NAMES:
-            LandBlock.objects.create(name=block_name)
+        for block_id in BLOCK_IDS:
+            LandBlock.objects.create(id=block_id, name=f"Block{block_id}")
 
     def test_parse_kawada_worksheet_success_and_conversion(self):
         wb = Workbook()
         ws = wb.active
-        ws.append(["圃場名", "EC", "NH4-N", "NO3-N", "pH", "CaO", "MgO", "K2O", "CEC", "腐植", "仮比重", "塩基飽和度", "CaO/MgO", "MgO/K2O", "リン酸吸収係数", "P2O5", "無機態N", "NH4/N比"])
-        ws.append(["圃場A", "1.2", "3", "4", "6.5", "100", "20", "30", "15", "2.5%", "0.8", "50%", "5", "0.7", "800", "60", "7", "0.4"])
-        rows, errors = parse_kawada_worksheet(ws)
-        self.assertEqual(len(errors), 0)
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].land_name, "圃場A")
-        self.assertEqual(rows[0].values["humus"], 2.5)
-        self.assertEqual(rows[0].values["base_saturation"], 50.0)
+        # 川田フォーマットは3行目がヘッダー、4行目からデータ
+        # A=分析番号, B=氏名, C=圃場名, D=作物, E〜T=化学データ
+        ws.append([])  # 1行目: 空
+        ws.append([])  # 2行目: 空
+        ws.append(["分析番号", "氏名", "圃場名", "作物", "EC", "pH", "CEC", "CaO", "MgO", "K2O", "石灰飽和度", "苦土飽和度", "加里飽和度", "塩基飽和度", "P2O5", "リン酸吸収係数", "NH4-N", "NO3-N", "腐植", "仮比重"])  # 3行目: ヘッダー
+        ws.append(["001", "田中", "圃場A", "キャベツ", "1.2", "6.5", "15", "100", "20", "30", "60", "20", "10", "50%", "60", "800", "3", "4", "2.5%", "0.8"])  # 4行目: データ
+        result = parse_kawada_worksheet(ws)
+        self.assertEqual(len(result.errors), 0)
+        self.assertEqual(len(result.rows), 1)
+        self.assertEqual(result.rows[0].land_name, "圃場A")
+        self.assertEqual(result.rows[0].values["humus"], 2.5)
+        self.assertEqual(result.rows[0].values["base_saturation"], 50.0)
 
     def test_parse_kawada_worksheet_missing_required_columns(self):
         wb = Workbook()
         ws = wb.active
-        ws.append(["圃場名", "EC"])
-        ws.append(["圃場A", "1.2"])
-        rows, errors = parse_kawada_worksheet(ws)
-        self.assertEqual(rows, [])
-        self.assertTrue(any("必須列不足" in error for error in errors))
+        ws.append([])  # 1行目: 空
+        ws.append([])  # 2行目: 空
+        # 3行目: ヘッダー（列が少なすぎる）
+        result = parse_kawada_worksheet(ws)
+        self.assertEqual(result.rows, [])
+        self.assertTrue(len(result.errors) > 0)
 
-    def test_import_chemical_rows_create_and_overwrite(self):
-        values = {
-            "ec": 1.0,
-            "nh4n": 2.0,
-            "no3n": 3.0,
-            "total_nitrogen": 5.0,
-            "nh4_per_nitrogen": 0.4,
-            "ph": 6.5,
-            "cao": 100.0,
-            "mgo": 20.0,
-            "k2o": 30.0,
-            "base_saturation": 50.0,
-            "cao_per_mgo": 5.0,
-            "mgo_per_k2o": 0.7,
-            "phosphorus_absorption": 800.0,
-            "p2o5": 60.0,
-            "cec": 15.0,
-            "humus": 2.5,
-            "bulk_density": 0.8,
-        }
-        row = ParsedChemicalRow(row_number=2, land_name="圃場A", values=values)
-
-        created_count, updated_count, warnings = import_chemical_rows(
-            parsed_rows=[row],
-            row_ledger_map={2: self.ledger.id},
-            overwrite=False,
-        )
-        self.assertEqual(created_count, 9)
-        self.assertEqual(updated_count, 0)
-        self.assertEqual(len(warnings), 0)
-        self.assertEqual(LandScoreChemical.objects.filter(land_ledger=self.ledger).count(), 9)
-
-        row2 = ParsedChemicalRow(row_number=2, land_name="圃場A", values={**values, "ec": 9.9})
-        created_count2, updated_count2, warnings2 = import_chemical_rows(
-            parsed_rows=[row2],
-            row_ledger_map={2: self.ledger.id},
-            overwrite=True,
-        )
-        self.assertEqual(created_count2, 0)
-        self.assertEqual(updated_count2, 9)
-        self.assertEqual(len(warnings2), 0)
-        self.assertEqual(
-            LandScoreChemical.objects.filter(land_ledger=self.ledger, ec=9.9).count(), 9
-        )

--- a/soil_analysis/tests/domain/service/test_chemical_import.py
+++ b/soil_analysis/tests/domain/service/test_chemical_import.py
@@ -1,0 +1,130 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from openpyxl import Workbook
+
+from soil_analysis.domain.service.chemical_import import (
+    BLOCK_NAMES,
+    ParsedChemicalRow,
+    import_chemical_rows,
+    parse_kawada_worksheet,
+)
+from soil_analysis.models import (
+    Company,
+    CompanyCategory,
+    Crop,
+    CultivationType,
+    JmaArea,
+    JmaCity,
+    JmaPrefecture,
+    JmaRegion,
+    Land,
+    LandBlock,
+    LandLedger,
+    LandPeriod,
+    LandScoreChemical,
+    SamplingMethod,
+)
+
+
+class ChemicalImportServiceTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(username="staff", password="x")
+        category = CompanyCategory.objects.create(name="農業法人")
+        company = Company.objects.create(name="テスト法人", category=category)
+        crop = Crop.objects.create(name="キャベツ")
+        cultivation = CultivationType.objects.create(name="露地")
+        jma_area = JmaArea.objects.create(code="123456", name="test")
+        jma_pref = JmaPrefecture.objects.create(code="654321", jma_area=jma_area, name="静岡")
+        jma_region = JmaRegion.objects.create(code="111111", jma_prefecture=jma_pref, name="西部")
+        jma_city = JmaCity.objects.create(code="2222222", jma_region=jma_region, name="浜松")
+        land = Land.objects.create(
+            name="圃場A",
+            jma_city=jma_city,
+            center="35.1,139.1",
+            area=100,
+            company=company,
+            cultivation_type=cultivation,
+            owner=self.user,
+        )
+        period = LandPeriod.objects.create(year=2026, name="定植時")
+        sampling_method = SamplingMethod.objects.create(name="5点法", times=5)
+        self.ledger = LandLedger.objects.create(
+            sampling_date=date(2026, 5, 1),
+            analytical_agency=company,
+            crop=crop,
+            land=land,
+            land_period=period,
+            sampling_method=sampling_method,
+            sampling_staff=self.user,
+        )
+        for block_name in BLOCK_NAMES:
+            LandBlock.objects.create(name=block_name)
+
+    def test_parse_kawada_worksheet_success_and_conversion(self):
+        wb = Workbook()
+        ws = wb.active
+        ws.append(["圃場名", "EC", "NH4-N", "NO3-N", "pH", "CaO", "MgO", "K2O", "CEC", "腐植", "仮比重", "塩基飽和度", "CaO/MgO", "MgO/K2O", "リン酸吸収係数", "P2O5", "無機態N", "NH4/N比"])
+        ws.append(["圃場A", "1.2", "3", "4", "6.5", "100", "20", "30", "15", "2.5%", "0.8", "50%", "5", "0.7", "800", "60", "7", "0.4"])
+        rows, errors = parse_kawada_worksheet(ws)
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].land_name, "圃場A")
+        self.assertEqual(rows[0].values["humus"], 2.5)
+        self.assertEqual(rows[0].values["base_saturation"], 50.0)
+
+    def test_parse_kawada_worksheet_missing_required_columns(self):
+        wb = Workbook()
+        ws = wb.active
+        ws.append(["圃場名", "EC"])
+        ws.append(["圃場A", "1.2"])
+        rows, errors = parse_kawada_worksheet(ws)
+        self.assertEqual(rows, [])
+        self.assertTrue(any("必須列不足" in error for error in errors))
+
+    def test_import_chemical_rows_create_and_overwrite(self):
+        values = {
+            "ec": 1.0,
+            "nh4n": 2.0,
+            "no3n": 3.0,
+            "total_nitrogen": 5.0,
+            "nh4_per_nitrogen": 0.4,
+            "ph": 6.5,
+            "cao": 100.0,
+            "mgo": 20.0,
+            "k2o": 30.0,
+            "base_saturation": 50.0,
+            "cao_per_mgo": 5.0,
+            "mgo_per_k2o": 0.7,
+            "phosphorus_absorption": 800.0,
+            "p2o5": 60.0,
+            "cec": 15.0,
+            "humus": 2.5,
+            "bulk_density": 0.8,
+        }
+        row = ParsedChemicalRow(row_number=2, land_name="圃場A", values=values)
+
+        created_count, updated_count, warnings = import_chemical_rows(
+            parsed_rows=[row],
+            row_ledger_map={2: self.ledger.id},
+            overwrite=False,
+        )
+        self.assertEqual(created_count, 9)
+        self.assertEqual(updated_count, 0)
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(LandScoreChemical.objects.filter(land_ledger=self.ledger).count(), 9)
+
+        row2 = ParsedChemicalRow(row_number=2, land_name="圃場A", values={**values, "ec": 9.9})
+        created_count2, updated_count2, warnings2 = import_chemical_rows(
+            parsed_rows=[row2],
+            row_ledger_map={2: self.ledger.id},
+            overwrite=True,
+        )
+        self.assertEqual(created_count2, 0)
+        self.assertEqual(updated_count2, 9)
+        self.assertEqual(len(warnings2), 0)
+        self.assertEqual(
+            LandScoreChemical.objects.filter(land_ledger=self.ledger, ec=9.9).count(), 9
+        )

--- a/soil_analysis/tests/test_chemical_fields.py
+++ b/soil_analysis/tests/test_chemical_fields.py
@@ -1,9 +1,10 @@
 from django.test import SimpleTestCase
 
 from soil_analysis.domain.valueobject.chemical_report.fields import (
+    CHEMICAL_FIELD_ALIAS_TO_KEY,
     CHEMICAL_FIELD_DEFINITIONS,
     CHEMICAL_FIELD_KEYS,
-    resolve_chemical_field_key,
+    normalize_text,
 )
 from soil_analysis.models import LandScoreChemical
 
@@ -19,11 +20,11 @@ class ChemicalFieldDefinitionTests(SimpleTestCase):
             self.assertIn(key, model_field_names)
 
     def test_alias_resolution_returns_expected_keys(self):
-        self.assertEqual(resolve_chemical_field_key("NH4-N"), "nh4n")
-        self.assertEqual(resolve_chemical_field_key("no3n"), "no3n")
-        self.assertEqual(resolve_chemical_field_key(" P2O5 "), "p2o5")
-        self.assertEqual(resolve_chemical_field_key("リン酸吸収係数"), "phosphorus_absorption")
-        self.assertIsNone(resolve_chemical_field_key("unknown-column"))
+        self.assertEqual(CHEMICAL_FIELD_ALIAS_TO_KEY.get(normalize_text("NH4-N")), "nh4n")
+        self.assertEqual(CHEMICAL_FIELD_ALIAS_TO_KEY.get(normalize_text("no3n")), "no3n")
+        self.assertEqual(CHEMICAL_FIELD_ALIAS_TO_KEY.get(normalize_text(" P2O5 ")), "p2o5")
+        self.assertEqual(CHEMICAL_FIELD_ALIAS_TO_KEY.get(normalize_text("リン酸吸収係数")), "phosphorus_absorption")
+        self.assertIsNone(CHEMICAL_FIELD_ALIAS_TO_KEY.get(normalize_text("unknown-column")))
 
     def test_major_display_labels_and_units(self):
         by_key = {field.key: field for field in CHEMICAL_FIELD_DEFINITIONS}

--- a/soil_analysis/urls.py
+++ b/soil_analysis/urls.py
@@ -40,6 +40,16 @@ urlpatterns = [
         name="hardness_upload",
     ),
     path(
+        "chemical/upload",
+        views.ChemicalUploadView.as_view(),
+        name="chemical_upload",
+    ),
+    path(
+        "chemical/success",
+        views.ChemicalSuccessView.as_view(),
+        name="chemical_success",
+    ),
+    path(
         "hardness/delete_all",
         views.HardnessDeleteAllView.as_view(),
         name="hardness_delete_all",

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -3,6 +3,7 @@ import re
 import shutil
 from pathlib import Path
 
+from openpyxl import load_workbook
 from django.contrib import messages
 from django.core.files.uploadedfile import UploadedFile
 from django.core.management import call_command
@@ -42,6 +43,7 @@ from soil_analysis.forms import (
     CompanyCreateForm,
     LandCreateForm,
     UploadForm,
+    ChemicalUploadForm,
     CsvGenerateForm,
     LandLedgerCreateForm,
 )
@@ -360,6 +362,75 @@ class HardnessUploadView(FormView):
                 pass
 
         return super().form_valid(form)
+
+
+class ChemicalUploadView(FormView):
+    template_name = "soil_analysis/chemical/form.html"
+    form_class = ChemicalUploadForm
+    success_url = reverse_lazy("soil:chemical_success")
+
+    def form_valid(self, form):
+        upload_file = self.request.FILES["file"]
+        if not upload_file.name.lower().endswith(".xlsx"):
+            messages.error(self.request, "xlsxファイルを指定してください。")
+            return self.form_invalid(form)
+
+        land_ledger_id = form.cleaned_data.get("land_ledger_id").id
+        overwrite = form.cleaned_data.get("overwrite", False)
+
+        # 一時ファイルに保存
+        from django.conf import settings
+        temp_dir = Path(settings.MEDIA_ROOT) / "temp" / "chemical"
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        temp_file = temp_dir / f"chemical_{timezone.now().strftime('%Y%m%d%H%M%S')}.xlsx"
+        
+        with open(temp_file, "wb+") as destination:
+            for chunk in upload_file.chunks():
+                destination.write(chunk)
+
+        try:
+            call_command(
+                "chemical_load_data",
+                str(temp_file),
+                land_ledger_id=land_ledger_id,
+                overwrite=overwrite,
+            )
+            self.request.session["chemical_import_ledger_id"] = land_ledger_id
+        except Exception as e:
+            messages.error(self.request, f"取り込み中にエラーが発生しました: {str(e)}")
+            return self.form_invalid(form)
+        finally:
+            if temp_file.exists():
+                temp_file.unlink()
+
+        return super().form_valid(form)
+
+
+class ChemicalSuccessView(TemplateView):
+    template_name = "soil_analysis/chemical/success.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        land_ledger_id = self.request.session.get("chemical_import_ledger_id")
+        if land_ledger_id:
+            try:
+                land_ledger = LandLedger.objects.select_related(
+                    "land__company", "land_period"
+                ).get(id=land_ledger_id)
+                chemical_data = LandScoreChemical.objects.filter(
+                    land_ledger=land_ledger,
+                    remark="import_mode=field_level_copied_to_9_blocks"
+                )
+                context["land_ledger"] = land_ledger
+                context["created_count"] = chemical_data.count()
+                context["updated_count"] = 0
+                context["warnings"] = []
+                context["import_datetime"] = timezone.now()
+            except LandLedger.DoesNotExist:
+                pass
+        return context
+
+
 
 
 class HardnessDeleteAllView(View):


### PR DESCRIPTION
```ps
WARNING: This is a development server. Do not use it in a production setting. Use a production WSGI or ASGI server instead.
For more information on production servers see: https://docs.djangoproject.com/en/6.0/howto/deployment/
[05/May/2026 00:12:40] "GET /soil_analysis/chemical/upload HTTP/1.1" 200 8428
[05/May/2026 00:12:43] "GET /soil_analysis/chemical/upload HTTP/1.1" 200 8428
取り込み完了: 新規作成=0, 更新=0, 警告=25
既存データありスキップ row=4, ledger_id=5, block_id=1
既存データありスキップ row=4, ledger_id=5, block_id=3
既存データありスキップ row=4, ledger_id=5, block_id=5
既存データありスキップ row=4, ledger_id=5, block_id=7
既存データありスキップ row=4, ledger_id=5, block_id=9
既存データありスキップ row=5, ledger_id=5, block_id=1
既存データありスキップ row=5, ledger_id=5, block_id=3
既存データありスキップ row=5, ledger_id=5, block_id=5
既存データありスキップ row=5, ledger_id=5, block_id=7
既存データありスキップ row=5, ledger_id=5, block_id=9
既存データありスキップ row=6, ledger_id=5, block_id=1
既存データありスキップ row=6, ledger_id=5, block_id=3
既存データありスキップ row=6, ledger_id=5, block_id=5
既存データありスキップ row=6, ledger_id=5, block_id=7
既存データありスキップ row=6, ledger_id=5, block_id=9
既存データありスキップ row=7, ledger_id=5, block_id=1
既存データありスキップ row=7, ledger_id=5, block_id=3
既存データありスキップ row=7, ledger_id=5, block_id=5
既存データありスキップ row=7, ledger_id=5, block_id=7
既存データありスキップ row=7, ledger_id=5, block_id=9
既存データありスキップ row=8, ledger_id=5, block_id=1
既存データありスキップ row=8, ledger_id=5, block_id=3
既存データありスキップ row=8, ledger_id=5, block_id=5
既存データありスキップ row=8, ledger_id=5, block_id=7
既存データありスキップ row=8, ledger_id=5, block_id=9
[05/May/2026 00:12:49] "POST /soil_analysis/chemical/upload HTTP/1.1" 302 0
[05/May/2026 00:12:49] "GET /soil_analysis/chemical/success HTTP/1.1" 200 6895
```

いまは excelのすべての rowデータをユーザが選択した１つの圃場に登録してしまう状態。規模が大きいので次のチケットで「hardnessとトンマナをあわせる」チケットを消化すべし