### PR TITLE
（子チケット1.5）chemical_load_dataをhardnessトンマナへ整理し、row単位で帳簿解決する

### DIFF
--- a/soil_analysis/management/commands/chemical_load_data.py
+++ b/soil_analysis/management/commands/chemical_load_data.py
@@ -338,7 +338,7 @@ class Command(BaseCommand):
     川田研究所が提供する化学分析結果Excel(.xlsx)を読み込み、
     指定されたLandLedgerに紐づけてLandScoreChemicalテーブルにデータを一括登録する。
 
-    1つの圃場データを9ブロック（A1-C3）すべてにコピーする仕様。
+    1つの圃場データを5ブロック（1,3,5,7,9）にコピーする仕様。
 
     使用方法:
         python manage.py chemical_load_data <excel_path> --land-ledger-id=<id> [--overwrite]
@@ -365,6 +365,42 @@ class Command(BaseCommand):
     """
 
     help = "Import chemical analysis data from Excel (Kawada format)"
+
+    @staticmethod
+    def _resolve_target_ledger(
+        row: ParsedRow, default_ledger: LandLedger
+    ) -> tuple[LandLedger | None, str | None]:
+        """行データに対応する取り込み先帳簿を解決する。
+
+        優先順位:
+        1. 画面選択された帳簿と同一時期(land_period)かつ land.name 一致
+        2. land.name 一致のみ
+        """
+        same_period_ledgers = LandLedger.objects.select_related("land").filter(
+            land__name=row.land_name,
+            land_period=default_ledger.land_period,
+        )
+        same_period_count = same_period_ledgers.count()
+        if same_period_count == 1:
+            return same_period_ledgers.first(), None
+        if same_period_count > 1:
+            return (
+                None,
+                f"帳簿特定不可(同名圃場が同一時期に複数) row={row.row_number}, land_name={row.land_name}",
+            )
+
+        name_only_ledgers = LandLedger.objects.select_related("land").filter(
+            land__name=row.land_name
+        )
+        name_only_count = name_only_ledgers.count()
+        if name_only_count == 1:
+            return name_only_ledgers.first(), None
+        if name_only_count > 1:
+            return (
+                None,
+                f"帳簿特定不可(同名圃場の帳簿が複数) row={row.row_number}, land_name={row.land_name}",
+            )
+        return None, f"帳簿未検出 row={row.row_number}, land_name={row.land_name}"
 
     def add_arguments(self, parser):
         parser.add_argument("file_path", type=str, help="Path to Excel file (.xlsx)")
@@ -409,9 +445,9 @@ class Command(BaseCommand):
                 self.stderr.write(self.style.WARNING("取り込み対象行がありません。"))
                 return
 
-            # LandLedgerの存在確認
+            # 画面で選択した帳簿をアンカーとして使用（時期判定の基準）
             try:
-                ledger = LandLedger.objects.get(id=land_ledger_id)
+                default_ledger = LandLedger.objects.get(id=land_ledger_id)
             except LandLedger.DoesNotExist:
                 self.stderr.write(
                     self.style.ERROR(
@@ -431,6 +467,13 @@ class Command(BaseCommand):
 
             with transaction.atomic():
                 for row in parse_result.rows:
+                    ledger, resolve_warning = self._resolve_target_ledger(
+                        row=row, default_ledger=default_ledger
+                    )
+                    if resolve_warning:
+                        warnings.append(resolve_warning)
+                        continue
+
                     for block_id in BLOCK_IDS:
                         defaults = {**row.values, "remark": REMARK_IMPORT_MODE}
                         existing = LandScoreChemical.objects.filter(

--- a/soil_analysis/tests/domain/service/test_chemical_import.py
+++ b/soil_analysis/tests/domain/service/test_chemical_import.py
@@ -6,6 +6,7 @@ from openpyxl import Workbook
 
 from soil_analysis.management.commands.chemical_load_data import (
     BLOCK_IDS,
+    Command,
     ParsedRow,
     parse_kawada_worksheet,
 )
@@ -59,6 +60,24 @@ class ChemicalImportServiceTests(TestCase):
             sampling_method=sampling_method,
             sampling_staff=self.user,
         )
+        land_b = Land.objects.create(
+            name="圃場B",
+            jma_city=jma_city,
+            center="35.2,139.2",
+            area=120,
+            company=company,
+            cultivation_type=cultivation,
+            owner=self.user,
+        )
+        self.ledger_b = LandLedger.objects.create(
+            sampling_date=date(2026, 5, 2),
+            analytical_agency=company,
+            crop=crop,
+            land=land_b,
+            land_period=period,
+            sampling_method=sampling_method,
+            sampling_staff=self.user,
+        )
         for block_id in BLOCK_IDS:
             LandBlock.objects.create(id=block_id, name=f"Block{block_id}")
 
@@ -88,3 +107,14 @@ class ChemicalImportServiceTests(TestCase):
         self.assertEqual(result.rows, [])
         self.assertTrue(len(result.errors) > 0)
 
+    def test_resolve_target_ledger_by_land_name_and_period(self):
+        row_a = ParsedRow(row_number=4, land_name="圃場A", values={})
+        row_b = ParsedRow(row_number=5, land_name="圃場B", values={})
+
+        ledger_a, warning_a = Command._resolve_target_ledger(row_a, self.ledger)
+        ledger_b, warning_b = Command._resolve_target_ledger(row_b, self.ledger)
+
+        self.assertEqual(warning_a, None)
+        self.assertEqual(warning_b, None)
+        self.assertEqual(ledger_a.id, self.ledger.id)
+        self.assertEqual(ledger_b.id, self.ledger_b.id)

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -422,7 +422,7 @@ class ChemicalSuccessView(TemplateView):
                 ).get(id=land_ledger_id)
                 chemical_data = LandScoreChemical.objects.filter(
                     land_ledger=land_ledger,
-                    remark="import_mode=field_level_copied_to_9_blocks",
+                    remark="import_mode=field_level_copied_to_5_blocks",
                 )
                 context["land_ledger"] = land_ledger
                 context["created_count"] = chemical_data.count()


### PR DESCRIPTION
## 概要
`chemical_load_data.py` の取り込み処理を `hardness_load_data.py` 側のトンマナに寄せて整理。  
従来の「全rowを選択した1つの圃場帳簿に登録」挙動を改め、Excel rowごとに取り込み先帳簿を解決するように変更した。

## 変更内容
- `soil_analysis/management/commands/chemical_load_data.py`
  - rowごとの取り込み先帳簿解決メソッド `_resolve_target_ledger` を追加
  - 解決優先順位:
    1. 選択帳簿と同一 `land_period` + `land.name` 一致
    2. `land.name` 一致のみ
  - 曖昧（複数件）/未検出（0件）は warning にして該当rowをスキップ
  - 取り込み処理を「rowごと解決→5ブロック保存」に整理
- `soil_analysis/views.py`
  - `ChemicalSuccessView` の `remark` フィルタを `import_mode=field_level_copied_to_5_blocks` に修正
- `soil_analysis/tests/domain/service/test_chemical_import.py`
  - rowごと帳簿解決のテストを追加

## 背景
- 親チケット: #429
- 子チケット1.5対応
- 1.6でUIフロー（rowごと画面遷移assign）を hardness と統一予定

## 動作確認
- `python manage.py test soil_analysis.tests.domain.service.test_chemical_import -v 2`
- 結果: OK（3 tests）


## 動作確認観点チェックリスト（必須）

### A. 基本取り込み
- [ ] `.xlsx` をアップロードできる
- [ ] 取り込み対象rowがある場合に処理が開始される
- [ ] 取り込み完了時に新規/更新/警告件数が表示される

### B. rowごとの帳簿解決（今回の主変更）
- [ ] 同一Excel内で `land_name` が異なる複数rowを用意したとき、rowごとに別 `land_ledger` へ登録される
- [ ] 選択帳簿と同じ `land_period` の同名圃場帳簿がある場合、それが優先される
- [ ] 同名圃場帳簿が複数あり特定不能なrowは warning になり、保存されない
- [ ] 対応する帳簿が存在しないrowは warning になり、保存されない

### C. 既存データとの関係
- [ ] `overwrite` OFF: 既存データがある block はスキップされ warning が出る
- [ ] `overwrite` ON: 既存データが更新される
- [ ] 1rowあたり5ブロック（1,3,5,7,9）で作成/更新される

### D. 画面表示
- [ ] success画面で `remark=import_mode=field_level_copied_to_5_blocks` のデータが表示対象になる
- [ ] 想定件数（作成/更新）が画面上の件数と整合する

### E. 回帰
- [ ] 既存の chemical import テストが通る
- [ ] 追加した row解決テストが通る
- [ ] hardness 側の既存フローに影響がない