### PR TITLE
硬度アップロード成功画面がDB全量を集計してしまう不具合を修正する

### DIFF
--- a/soil_analysis/domain/repository/hardness_measurement.py
+++ b/soil_analysis/domain/repository/hardness_measurement.py
@@ -10,7 +10,9 @@ class SoilHardnessMeasurementRepository:
     """
 
     @staticmethod
-    def get_folder_stats(associated_only: bool = False) -> list[FolderStats]:
+    def get_folder_stats(
+        associated_only: bool = False, folder_names: list[str] | None = None
+    ) -> list[FolderStats]:
         """
         フォルダ別の統計情報を取得します
 
@@ -18,6 +20,7 @@ class SoilHardnessMeasurementRepository:
             associated_only: データの処理段階に応じて対象を絞り込む
                            False: CSVインポート直後の全データが対象
                            True:  圃場関連付け完了後のデータが対象
+            folder_names: 指定した場合、そのフォルダ名の測定データだけを対象にする
 
         Returns:
             list[FolderStats]: フォルダ別統計情報のリスト
@@ -36,6 +39,9 @@ class SoilHardnessMeasurementRepository:
         """
         # 基本クエリを構築
         queryset = SoilHardnessMeasurement.objects.select_related("set_device")
+
+        if folder_names is not None:
+            queryset = queryset.filter(folder__in=folder_names)
 
         # 条件に応じて絞り込み
         if associated_only:

--- a/soil_analysis/domain/repository/land.py
+++ b/soil_analysis/domain/repository/land.py
@@ -20,6 +20,22 @@ class LandRepository:
         return Land.objects.filter(name=name).exists()
 
     @staticmethod
+    def exists_by_name_or_display_prefix(name: str) -> bool:
+        """
+        フォルダ名から推定した圃場名に対応する圃場が存在するか確認します。
+
+        Args:
+            name: フォルダ名から推定した圃場名
+
+        Returns:
+            bool: 完全一致、または「FIELD001（点検用圃場）」のような表示補足付き名称が存在する場合はTrue
+        """
+        return (
+            Land.objects.filter(name=name).exists()
+            or Land.objects.filter(name__startswith=f"{name}（").exists()
+        )
+
+    @staticmethod
     def get_land_to_ledgers_map(lands: list[Land]) -> dict[int, list]:
         """
         圃場ごとの帳簿マップを取得します

--- a/soil_analysis/domain/repository/land_ledger.py
+++ b/soil_analysis/domain/repository/land_ledger.py
@@ -160,9 +160,12 @@ class LandLedgerRepository:
         return response_data
 
     @staticmethod
-    def get_association_success_context() -> dict:
+    def get_association_success_context(folder_names: list[str] | None = None) -> dict:
         """
         関連付け完了画面用のコンテキストデータを取得
+
+        Args:
+            folder_names: 指定した場合、そのフォルダ名の関連付け済み測定データだけを対象にする
 
         Returns:
             コンテキストデータ辞書
@@ -171,10 +174,14 @@ class LandLedgerRepository:
         associated_measurements = SoilHardnessMeasurement.objects.filter(
             land_ledger__isnull=False, land_block__isnull=False
         )
+        if folder_names is not None:
+            associated_measurements = associated_measurements.filter(
+                folder__in=folder_names
+            )
 
         # CSVインポートされた硬度測定データをフォルダ名でグループ化し、各フォルダの統計情報を取得
         folder_stats = SoilHardnessMeasurementRepository.get_folder_stats(
-            associated_only=True
+            associated_only=True, folder_names=folder_names
         )
 
         # 各フォルダで使用された機材名とland_block、land_ledger情報を取得

--- a/soil_analysis/tests/test_hardness_views.py
+++ b/soil_analysis/tests/test_hardness_views.py
@@ -93,3 +93,53 @@ class HardnessViewsTest(TestCase):
         self.assertEqual(response.context["min_memory"], 1)
         self.assertEqual(response.context["max_memory"], 1)
         self.assertEqual(response.context["folder_name"], "Folder1")
+
+    def test_hardness_success_view_uses_current_import_folders(self):
+        """
+        シナリオ:
+        - 入力: DBには過去取り込みのFolder1と今回取り込みのFIELD001_ROUND02が混在し、セッションにはFIELD001_ROUND02だけを保持する。
+        - 処理: 硬度アップロード成功画面を表示する。
+        - 期待値: 取り込みデータ集計と総レコード数はFIELD001_ROUND02だけを対象にし、表示補足付き圃場を未作成扱いしない。
+        """
+        Land.objects.create(
+            name="FIELD001（点検用圃場）",
+            company=self.company,
+            jma_city=self.city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+        )
+        SoilHardnessMeasurement.objects.create(
+            set_device=self.device,
+            set_memory=2,
+            set_datetime=datetime(2023, 7, 2, 10, 0, 0),
+            set_depth=50,
+            set_spring=1,
+            set_cone=1,
+            depth=1,
+            pressure=110,
+            folder="FIELD001_ROUND02",
+        )
+        SoilHardnessMeasurement.objects.create(
+            set_device=self.device,
+            set_memory=3,
+            set_datetime=datetime(2023, 7, 2, 10, 0, 0),
+            set_depth=50,
+            set_spring=1,
+            set_cone=1,
+            depth=1,
+            pressure=120,
+            folder="FIELD001_ROUND02",
+        )
+        session = self.client.session
+        session["hardness_import_folders"] = ["FIELD001_ROUND02"]
+        session.save()
+
+        response = self.client.get(reverse("soil:hardness_success"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["total_records"], 2)
+        self.assertEqual(
+            [stats.folder for stats in response.context["folder_stats"]],
+            ["FIELD001_ROUND02"],
+        )
+        self.assertEqual(response.context["missing_lands"], [])

--- a/soil_analysis/tests/test_hardness_views.py
+++ b/soil_analysis/tests/test_hardness_views.py
@@ -15,6 +15,7 @@ from soil_analysis.models import (
     LandPeriod,
     CultivationType,
     SamplingMethod,
+    LandBlock,
     JmaArea,
     JmaPrefecture,
     JmaRegion,
@@ -143,3 +144,44 @@ class HardnessViewsTest(TestCase):
             ["FIELD001_ROUND02"],
         )
         self.assertEqual(response.context["missing_lands"], [])
+
+    def test_hardness_association_success_view_uses_current_import_folders(self):
+        """
+        シナリオ:
+        - 入力: DBには過去関連付け済みFolder1と今回関連付け済みFIELD001_ROUND02が混在し、セッションにはFIELD001_ROUND02だけを保持する。
+        - 処理: 硬度関連付け成功画面を表示する。
+        - 期待値: フォルダ別・Land Block別・Land Ledger別の集計はFIELD001_ROUND02だけを対象にし、DB全量を集計しない。
+        """
+        land_block = LandBlock.objects.create(name="A1")
+        for memory, folder in (
+            (10, "Folder1"),
+            (20, "FIELD001_ROUND02"),
+            (21, "FIELD001_ROUND02"),
+        ):
+            SoilHardnessMeasurement.objects.create(
+                set_device=self.device,
+                set_memory=memory,
+                set_datetime=datetime(2023, 7, 2, 10, 0, 0),
+                set_depth=50,
+                set_spring=1,
+                set_cone=1,
+                depth=1,
+                pressure=110,
+                folder=folder,
+                land_block=land_block,
+                land_ledger=self.ledger,
+            )
+        session = self.client.session
+        session["hardness_import_folders"] = ["FIELD001_ROUND02"]
+        session.save()
+
+        response = self.client.get(reverse("soil:hardness_association_success"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["total_records"], 2)
+        self.assertEqual(
+            [stats.folder for stats in response.context["folder_stats"]],
+            ["FIELD001_ROUND02"],
+        )
+        self.assertEqual(response.context["land_block_stats"][0]["count"], 2)
+        self.assertEqual(response.context["land_ledger_stats"][0]["count"], 2)

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -425,6 +425,7 @@ class HardnessUploadView(FormView):
         if os.path.exists(upload_folder):
             # エラーログのクリア
             HardnessImportErrorRepository.delete_all()
+            imported_folder_names = set()
 
             csv_files = glob.glob(
                 os.path.join(upload_folder, "**/*.csv"), recursive=True
@@ -436,6 +437,7 @@ class HardnessUploadView(FormView):
                 parse_result = HardnessImportService.parse_csv(csv_file)
 
                 if parse_result.errors:
+                    imported_folder_names.add(parent_folder)
                     for error_msg in parse_result.errors:
                         HardnessImportErrorRepository.create(
                             file=file_name,
@@ -445,6 +447,11 @@ class HardnessUploadView(FormView):
                     continue
 
                 HardnessImportService.save_import_data(parse_result.rows)
+                imported_folder_names.update(row.folder for row in parse_result.rows)
+
+            self.request.session["hardness_import_folders"] = sorted(
+                imported_folder_names
+            )
 
             try:
                 shutil.rmtree(upload_folder)
@@ -980,10 +987,11 @@ class HardnessSuccessView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["import_errors"] = HardnessImportErrorRepository.get_all()
+        import_folder_names = self.request.session.get("hardness_import_folders")
 
         # CSVインポートされた硬度測定データをフォルダ名でグループ化し、各フォルダの統計情報を取得
         folder_stats = SoilHardnessMeasurementRepository.get_folder_stats(
-            associated_only=False
+            associated_only=False, folder_names=import_folder_names
         )
 
         # フォルダ名に基づいて新規登録が必要な圃場を特定
@@ -992,15 +1000,15 @@ class HardnessSuccessView(TemplateView):
             folder_name = stats.folder
             land_name = self._extract_land_name_from_folder(folder_name)
 
-            if land_name and not LandRepository.exists_by_name(land_name):
+            if land_name and not LandRepository.exists_by_name_or_display_prefix(
+                land_name
+            ):
                 missing_lands.append(
                     {"folder_name": folder_name, "suggested_land_name": land_name}
                 )
 
         context["folder_stats"] = folder_stats
-        context["total_records"] = len(
-            SoilHardnessMeasurementRepository.get_folder_stats()
-        )
+        context["total_records"] = sum(stats.count for stats in folder_stats)
         context["missing_lands"] = missing_lands
 
         # 圃場作成用の会社一覧を追加（農業法人のみ）

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -1196,7 +1196,10 @@ class HardnessAssociationSuccessView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        repository_context = LandLedgerRepository.get_association_success_context()
+        import_folder_names = self.request.session.get("hardness_import_folders")
+        repository_context = LandLedgerRepository.get_association_success_context(
+            folder_names=import_folder_names
+        )
         context.update(repository_context)
 
         return context


### PR DESCRIPTION
## Summary
硬度アップロード成功画面と硬度関連付け成功画面が、今回取り込んだZIPではなくDB上の硬度データ全量を集計してしまう不具合を修正しました。

- 硬度アップロード時に今回取り込んだフォルダ名をセッションへ保存するようにしました。
- アップロード成功画面のフォルダ別集計と総レコード数を、今回取り込みフォルダだけに限定しました。
- 関連付け成功画面のフォルダ別・Land Block別・Land Ledger別集計と総レコード数を、今回取り込みフォルダだけに限定しました。
- `FIELD001（点検用圃場）` のような表示補足付き圃場名を、`FIELD001_ROUND02` から推定した圃場名の既存圃場として扱えるようにしました。
- DBに過去取り込みデータと今回取り込みデータが混在するケースの回帰テストを追加しました。

## 目検による動作確認手順
- [x] `/soil_analysis/hardness/upload` からROUND01相当のZIPをアップロードし、成功画面にROUND01のフォルダだけが表示されることを確認する。
- [x] 続けてROUND02相当のZIPをアップロードし、成功画面にROUND02のフォルダだけが表示され、ROUND01のフォルダが再表示されないことを確認する。
- [x] ROUND02を関連付け後、`/soil_analysis/hardness/association/success` の関連付けデータ集計、Land Block別集計、Land Ledger別集計にROUND02分だけが表示されることを確認する。
- [x] 点検用圃場 `FIELD001（点検用圃場）` が存在する場合、`FIELD001_ROUND02` が「圃場の事前作成が必要」に出ないことを確認する。

## 自動テストでカバーできた範囲
- `python manage.py test soil_analysis.tests.test_hardness_views`
  - アップロード成功画面がセッションに保存された今回取り込みフォルダだけを集計することを確認。
  - 関連付け成功画面がセッションに保存された今回取り込みフォルダだけを集計することを確認。
  - 表示補足付き圃場名を未作成扱いしないことを確認。
- `python manage.py test soil_analysis.tests.test_hardness_views soil_analysis.tests.test_hardness_import_service`
  - 硬度アップロード成功画面と硬度インポート関連の既存挙動に影響がないことを確認。
- `python manage.py test`
  - Django 全体の既存テスト280件が成功することを確認。

## 関連Issue
https://github.com/duri0214/portfolio/issues/722
