### PR TITLE
土壌分析の帳簿関連付け候補に年度などの識別情報を表示する

### DIFF
--- a/soil_analysis/domain/service/chemical_import_service.py
+++ b/soil_analysis/domain/service/chemical_import_service.py
@@ -56,53 +56,34 @@ class ChemicalImportService:
         )
 
     @classmethod
-    def _get_target_period_id(
-        cls, company_ids: list[int], base_ledger_id: int | None = None
+    def _get_target_year(
+        cls, land_ids: list[int], base_ledger_id: int | None = None
     ) -> int | None:
         """
-        候補帳簿を絞り込むための対象時期IDを取得する。
+        候補帳簿を絞り込むための対象年度を取得する。
 
         Args:
-            company_ids: 候補対象の会社ID。
+            land_ids: 候補対象の圃場ID。
             base_ledger_id: 基準帳簿ID。
 
         Returns:
-            対象時期ID。判断できない場合は None。
+            対象年度。判断できない場合は None。
         """
         if base_ledger_id:
             return (
                 LandLedger.objects.filter(id=base_ledger_id)
-                .values_list("land_period_id", flat=True)
+                .values_list("land_period__year", flat=True)
                 .first()
             )
 
         used_ledger_ids = cls.get_used_ledger_ids()
-        unused_ledgers = (
-            LandLedger.objects.filter(land__company_id__in=company_ids)
+        return (
+            LandLedger.objects.filter(land_id__in=land_ids)
             .exclude(id__in=used_ledger_ids)
-            .select_related("land_period")
             .order_by("land_period__year", "sampling_date", "id")
-        )
-        latest_used_ledger = (
-            SoilChemicalMeasurement.objects.filter(
-                land_ledger__land__company_id__in=company_ids
-            )
-            .select_related("land_ledger__land_period")
-            .order_by(
-                "-land_ledger__land_period__year",
-                "-land_ledger__sampling_date",
-                "-land_ledger_id",
-            )
+            .values_list("land_period__year", flat=True)
             .first()
         )
-        if latest_used_ledger:
-            target_period_name = latest_used_ledger.land_ledger.land_period.name
-            return (
-                unused_ledgers.filter(land_period__name=target_period_name)
-                .values_list("land_period_id", flat=True)
-                .first()
-            )
-        return unused_ledgers.values_list("land_period_id", flat=True).first()
 
     @classmethod
     def get_suggested_ledgers(
@@ -112,21 +93,21 @@ class ChemicalImportService:
         圃場名から候補となる帳簿を検索する。
         base_ledger_id が指定されている場合、その帳簿と同じ period を持つものを優先する。
         """
-        # 圃場名から会社を特定し、同一会社内の対象LandPeriod帳簿を候補にする。
+        # 圃場名に一致する圃場について、未使用が残っている最古年度の帳簿を候補にする。
         lands = Land.objects.filter(name__icontains=land_name)
-        company_ids = list(lands.values_list("company_id", flat=True).distinct())
-        target_period_id = cls._get_target_period_id(company_ids, base_ledger_id)
-        if not target_period_id:
+        land_ids = list(lands.values_list("id", flat=True))
+        target_year = cls._get_target_year(land_ids, base_ledger_id)
+        if not target_year:
             return []
 
         ledgers = (
             LandLedger.objects.filter(
-                land__company_id__in=company_ids,
-                land_period_id=target_period_id,
+                land_id__in=land_ids,
+                land_period__year=target_year,
             )
             .exclude(id__in=cls.get_used_ledger_ids())
             .select_related("land", "land__company", "land_period")
-            .order_by("land__name", "id")
+            .order_by("sampling_date", "id")
         )
 
         return list(ledgers[:10])  # とりあえず上位10件

--- a/soil_analysis/domain/service/chemical_import_service.py
+++ b/soil_analysis/domain/service/chemical_import_service.py
@@ -43,6 +43,20 @@ class ChemicalImportService:
         return ParseResult(rows=result.rows, errors=result.errors)
 
     @classmethod
+    def get_used_ledger_ids(cls) -> list[int]:
+        """
+        化学分析データに紐付け済みの帳簿IDを取得する。
+
+        Returns:
+            使用済み帳簿IDのリスト。
+        """
+        return list(
+            SoilChemicalMeasurement.objects.values_list(
+                "land_ledger_id", flat=True
+            ).distinct()
+        )
+
+    @classmethod
     def get_suggested_ledgers(
         cls, land_name: str, base_ledger_id: int | None = None
     ) -> list[LandLedger]:
@@ -53,9 +67,11 @@ class ChemicalImportService:
         # 圃場名で検索（完全一致または部分一致）
         lands = Land.objects.filter(name__icontains=land_name)
 
-        # それらの圃場に紐づく帳簿を取得
-        ledgers = LandLedger.objects.filter(land__in=lands).select_related(
-            "land", "land__company", "land_period"
+        # それらの圃場に紐づく未使用の帳簿を取得
+        ledgers = (
+            LandLedger.objects.filter(land__in=lands)
+            .exclude(id__in=cls.get_used_ledger_ids())
+            .select_related("land", "land__company", "land_period")
         )
 
         if base_ledger_id:
@@ -96,6 +112,7 @@ class ChemicalImportService:
         lands = Land.objects.filter(query)
         all_ledgers = list(
             LandLedger.objects.filter(land__in=lands)
+            .exclude(id__in=cls.get_used_ledger_ids())
             .select_related("land", "land__company", "land_period")
             .order_by("-id")
         )

--- a/soil_analysis/domain/service/chemical_import_service.py
+++ b/soil_analysis/domain/service/chemical_import_service.py
@@ -56,28 +56,37 @@ class ChemicalImportService:
         )
 
     @classmethod
-    def _get_target_period_name(
-        cls, land_ids: list[int], base_ledger_id: int | None = None
-    ) -> str | None:
+    def _get_target_period_id(
+        cls, company_ids: list[int], base_ledger_id: int | None = None
+    ) -> int | None:
         """
-        候補帳簿を絞り込むための時期名を取得する。
+        候補帳簿を絞り込むための対象時期IDを取得する。
 
         Args:
-            land_ids: 候補対象の圃場ID。
+            company_ids: 候補対象の会社ID。
             base_ledger_id: 基準帳簿ID。
 
         Returns:
-            基準帳簿または直近使用済み帳簿の時期名。判断できない場合は None。
+            対象時期ID。判断できない場合は None。
         """
         if base_ledger_id:
             return (
                 LandLedger.objects.filter(id=base_ledger_id)
-                .values_list("land_period__name", flat=True)
+                .values_list("land_period_id", flat=True)
                 .first()
             )
 
+        used_ledger_ids = cls.get_used_ledger_ids()
+        unused_ledgers = (
+            LandLedger.objects.filter(land__company_id__in=company_ids)
+            .exclude(id__in=used_ledger_ids)
+            .select_related("land_period")
+            .order_by("land_period__year", "sampling_date", "id")
+        )
         latest_used_ledger = (
-            SoilChemicalMeasurement.objects.filter(land_ledger__land_id__in=land_ids)
+            SoilChemicalMeasurement.objects.filter(
+                land_ledger__land__company_id__in=company_ids
+            )
             .select_related("land_ledger__land_period")
             .order_by(
                 "-land_ledger__land_period__year",
@@ -87,8 +96,13 @@ class ChemicalImportService:
             .first()
         )
         if latest_used_ledger:
-            return latest_used_ledger.land_ledger.land_period.name
-        return None
+            target_period_name = latest_used_ledger.land_ledger.land_period.name
+            return (
+                unused_ledgers.filter(land_period__name=target_period_name)
+                .values_list("land_period_id", flat=True)
+                .first()
+            )
+        return unused_ledgers.values_list("land_period_id", flat=True).first()
 
     @classmethod
     def get_suggested_ledgers(
@@ -98,21 +112,22 @@ class ChemicalImportService:
         圃場名から候補となる帳簿を検索する。
         base_ledger_id が指定されている場合、その帳簿と同じ period を持つものを優先する。
         """
-        # 圃場名で検索（完全一致または部分一致）
+        # 圃場名から会社を特定し、同一会社内の対象LandPeriod帳簿を候補にする。
         lands = Land.objects.filter(name__icontains=land_name)
-        land_ids = list(lands.values_list("id", flat=True))
+        company_ids = list(lands.values_list("company_id", flat=True).distinct())
+        target_period_id = cls._get_target_period_id(company_ids, base_ledger_id)
+        if not target_period_id:
+            return []
 
-        # それらの圃場に紐づく未使用の帳簿を取得
         ledgers = (
-            LandLedger.objects.filter(land_id__in=land_ids)
+            LandLedger.objects.filter(
+                land__company_id__in=company_ids,
+                land_period_id=target_period_id,
+            )
             .exclude(id__in=cls.get_used_ledger_ids())
             .select_related("land", "land__company", "land_period")
-            .order_by("land_period__year", "sampling_date", "id")
+            .order_by("land__name", "id")
         )
-
-        target_period_name = cls._get_target_period_name(land_ids, base_ledger_id)
-        if target_period_name:
-            ledgers = ledgers.filter(land_period__name=target_period_name)
 
         return list(ledgers[:10])  # とりあえず上位10件
 

--- a/soil_analysis/domain/service/chemical_import_service.py
+++ b/soil_analysis/domain/service/chemical_import_service.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from django.db import transaction
-from django.db.models import Q
 from openpyxl.worksheet.worksheet import Worksheet
 
 from soil_analysis.domain.repository.chemical_import_error import (
@@ -57,6 +56,41 @@ class ChemicalImportService:
         )
 
     @classmethod
+    def _get_target_period_name(
+        cls, land_ids: list[int], base_ledger_id: int | None = None
+    ) -> str | None:
+        """
+        候補帳簿を絞り込むための時期名を取得する。
+
+        Args:
+            land_ids: 候補対象の圃場ID。
+            base_ledger_id: 基準帳簿ID。
+
+        Returns:
+            基準帳簿または直近使用済み帳簿の時期名。判断できない場合は None。
+        """
+        if base_ledger_id:
+            return (
+                LandLedger.objects.filter(id=base_ledger_id)
+                .values_list("land_period__name", flat=True)
+                .first()
+            )
+
+        latest_used_ledger = (
+            SoilChemicalMeasurement.objects.filter(land_ledger__land_id__in=land_ids)
+            .select_related("land_ledger__land_period")
+            .order_by(
+                "-land_ledger__land_period__year",
+                "-land_ledger__sampling_date",
+                "-land_ledger_id",
+            )
+            .first()
+        )
+        if latest_used_ledger:
+            return latest_used_ledger.land_ledger.land_period.name
+        return None
+
+    @classmethod
     def get_suggested_ledgers(
         cls, land_name: str, base_ledger_id: int | None = None
     ) -> list[LandLedger]:
@@ -66,28 +100,19 @@ class ChemicalImportService:
         """
         # 圃場名で検索（完全一致または部分一致）
         lands = Land.objects.filter(name__icontains=land_name)
+        land_ids = list(lands.values_list("id", flat=True))
 
         # それらの圃場に紐づく未使用の帳簿を取得
         ledgers = (
-            LandLedger.objects.filter(land__in=lands)
+            LandLedger.objects.filter(land_id__in=land_ids)
             .exclude(id__in=cls.get_used_ledger_ids())
             .select_related("land", "land__company", "land_period")
+            .order_by("land_period__year", "sampling_date", "id")
         )
 
-        if base_ledger_id:
-            try:
-                base_ledger = LandLedger.objects.get(id=base_ledger_id)
-
-                # 同じ period のものを優先的に並び替える
-                def sort_key(l):
-                    return (
-                        0 if l.land_period_id == base_ledger.land_period_id else 1,
-                        l.id,
-                    )
-
-                ledgers = sorted(ledgers, key=sort_key)
-            except LandLedger.DoesNotExist:
-                pass
+        target_period_name = cls._get_target_period_name(land_ids, base_ledger_id)
+        if target_period_name:
+            ledgers = ledgers.filter(land_period__name=target_period_name)
 
         return list(ledgers[:10])  # とりあえず上位10件
 
@@ -101,44 +126,9 @@ class ChemicalImportService:
         if not land_names:
             return {}
 
-        query = Q()
-        for name in set(land_names):
-            if name:
-                query |= Q(name__icontains=name)
-
-        if not query:
-            return {name: [] for name in land_names}
-
-        lands = Land.objects.filter(query)
-        all_ledgers = list(
-            LandLedger.objects.filter(land__in=lands)
-            .exclude(id__in=cls.get_used_ledger_ids())
-            .select_related("land", "land__company", "land_period")
-            .order_by("-id")
-        )
-
-        base_period_id = None
-        if base_ledger_id:
-            try:
-                base_period_id = LandLedger.objects.values_list(
-                    "land_period_id", flat=True
-                ).get(id=base_ledger_id)
-            except LandLedger.DoesNotExist:
-                pass
-
         result = {}
         for name in land_names:
-            # 各名称に合致するものを抽出（メモリ上でフィルタリング）
-            suggested = [l for l in all_ledgers if name.lower() in l.land.name.lower()]
-
-            if base_period_id:
-
-                def sort_key(l):
-                    return 0 if l.land_period_id == base_period_id else 1
-
-                suggested.sort(key=sort_key)
-
-            result[name] = suggested[:10]
+            result[name] = cls.get_suggested_ledgers(name, base_ledger_id)
 
         return result
 

--- a/soil_analysis/templates/soil_analysis/chemical/association/field_row.html
+++ b/soil_analysis/templates/soil_analysis/chemical/association/field_row.html
@@ -126,7 +126,7 @@
                                                 <option value="{{ ledger.pk }}"
                                                         {% if ledger.pk == selected_ledger_id %}selected{% endif %}>
                                                     {{ ledger.land.company.name }} - {{ ledger.land.name }}
-                                                    ({{ ledger.land_period.name }})
+                                                    ({{ ledger.land_period.year }} {{ ledger.land_period.name }} / 採土日: {{ ledger.sampling_date|date:"Y-m-d" }})
                                                 </option>
                                             {% endfor %}
                                         </optgroup>
@@ -136,7 +136,7 @@
                                             <option value="{{ ledger.pk }}"
                                                     {% if ledger.pk == selected_ledger_id %}selected{% endif %}>
                                                 {{ ledger.land.company.name }} - {{ ledger.land.name }}
-                                                ({{ ledger.land_period.name }})
+                                                ({{ ledger.land_period.year }} {{ ledger.land_period.name }} / 採土日: {{ ledger.sampling_date|date:"Y-m-d" }})
                                             </option>
                                         {% endfor %}
                                     </optgroup>

--- a/soil_analysis/templates/soil_analysis/chemical/association/list.html
+++ b/soil_analysis/templates/soil_analysis/chemical/association/list.html
@@ -35,7 +35,7 @@
                             <div class="card-header bg-success text-white">
                                 <h6 class="mb-0">
                                     <i class="fas fa-check-circle"></i>
-                                    処理済み - 行番号 (Excel): {{ row.row_number }}
+                                    処理済み - Excel行: {{ row.row_number }}
                                 </h6>
                             </div>
                             <div class="card-body">
@@ -62,7 +62,8 @@
                                             <p class="text-success mb-2">
                                                 {{ row.selected_ledger.land.company.name }}<br>
                                                 {{ row.selected_ledger.land.name }}<br>
-                                                {{ row.selected_ledger.land_period.name }}
+                                                {{ row.selected_ledger.land_period.year }} {{ row.selected_ledger.land_period.name }}<br>
+                                                採土日: {{ row.selected_ledger.sampling_date|date:"Y-m-d" }}
                                             </p>
                                         {% else %}
                                             <p class="text-muted mb-2">未設定</p>
@@ -82,7 +83,7 @@
                             <div class="card-header bg-warning text-dark">
                                 <h6 class="mb-0">
                                     <i class="fas fa-exclamation-triangle"></i>
-                                    未処理 - 行番号 (Excel): {{ row.row_number }}
+                                    未処理 - Excel行: {{ row.row_number }}
                                 </h6>
                             </div>
                             <div class="card-body">

--- a/soil_analysis/templates/soil_analysis/chemical/association/success.html
+++ b/soil_analysis/templates/soil_analysis/chemical/association/success.html
@@ -66,7 +66,7 @@
                                 <tr>
                                     <td>{{ row.company_name }}</td>
                                     <td><strong>{{ row.land_name }}</strong></td>
-                                    <td>{{ row.period_name }}</td>
+                                    <td>{{ row.period_year }} {{ row.period_name }}</td>
                                     <td><span class="badge bg-success">{{ row.total }}</span></td>
                                 </tr>
                             {% empty %}

--- a/soil_analysis/templates/soil_analysis/land/detail.html
+++ b/soil_analysis/templates/soil_analysis/land/detail.html
@@ -210,10 +210,20 @@
                                     <td>{{ ledger.sampling_date|default:"-" }}</td>
                                     <td>{{ ledger.analysis_number|default:"-" }}</td>
                                     <td>
-                                        <a href="{% url 'soil:standard_report' object.company.id ledger.id %}"
-                                           class="btn btn-sm btn-outline-primary">
-                                            <i class="fas fa-chart-bar"></i> 通知表を表示
-                                        </a>
+                                        {% if ledger.chemical_measurement_count or ledger.hardness_measurement_count %}
+                                            <a href="{% url 'soil:standard_report' object.company.id ledger.id %}"
+                                               class="btn btn-sm btn-outline-primary">
+                                                <i class="fas fa-chart-bar"></i> 通知表を表示
+                                            </a>
+                                        {% else %}
+                                            <button type="button"
+                                                    class="btn btn-sm btn-outline-secondary"
+                                                    disabled
+                                                    aria-disabled="true"
+                                                    title="化学データまたは硬度データが登録されると表示できます">
+                                                <i class="fas fa-chart-bar"></i> 通知表を表示
+                                            </button>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -124,6 +124,67 @@ class ChemicalAssociationViewsTest(TestCase):
         self.assertEqual(updated_session["status"], "confirmed")
         self.assertEqual(updated_session["selected_ledger_id"], self.ledger.id)
 
+    def test_row_confirmation_shows_year_and_sampling_date_in_ledger_options(self):
+        """
+        シナリオ:
+        - 入力: 同一圃場に、同じ時期名で年度が異なる帳簿を用意する。
+        - 処理: 化学分析の行別帳簿関連付け画面を表示する。
+        - 期待値: 候補帳簿の選択肢に年度と採土日が表示され、帳簿を区別できること。
+        """
+        period = LandPeriod.objects.create(name="播種時", year=2025)
+        other_ledger = LandLedger.objects.create(
+            land=self.ledger.land,
+            land_period=period,
+            sampling_date=date(2025, 4, 1),
+            analytical_agency=self.company,
+            crop=self.ledger.crop,
+            sampling_method=self.ledger.sampling_method,
+            sampling_staff=self.user,
+        )
+        session = self.client.session
+        session["chemical_import_session"] = {
+            "rows": [
+                {
+                    "row_data": {
+                        "row_number": 4,
+                        "analysis_number": "A001",
+                        "person_name": "テスト太郎",
+                        "land_name": "圃場A",
+                        "crop": "キャベツ",
+                        "ec": 0.1,
+                        "ph": 6.5,
+                        "cec": None,
+                        "cao": None,
+                        "mgo": None,
+                        "k2o": None,
+                        "lime_saturation": None,
+                        "magnesia_saturation": None,
+                        "potash_saturation": None,
+                        "base_saturation": None,
+                        "p2o5": None,
+                        "phosphorus_absorption": None,
+                        "nh4n": None,
+                        "no3n": None,
+                        "humus": None,
+                        "bulk_density": None,
+                    },
+                    "selected_ledger_id": None,
+                    "status": "pending",
+                }
+            ],
+            "total_rows": 1,
+        }
+        session.save()
+
+        response = self.client.get(
+            reverse("soil:chemical_association_field_row", kwargs={"row_index": 0})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "2024 2024年春 / 採土日: 2024-04-01")
+        self.assertContains(response, "2025 播種時 / 採土日: 2025-04-01")
+        self.assertContains(response, f'value="{other_ledger.id}"')
+
     def test_save_all_redirects_to_success(self):
         session = self.client.session
         session["chemical_import_session"] = {

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -491,6 +491,10 @@ class ChemicalAssociationViewsTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         summary_names = [row["land_name"] for row in response.context["ledger_summary"]]
+        summary_periods = [
+            f"{row['period_year']} {row['period_name']}"
+            for row in response.context["ledger_summary"]
+        ]
         self.assertEqual(
             summary_names,
             [
@@ -499,6 +503,8 @@ class ChemicalAssociationViewsTest(TestCase):
                 "FIELD003（点検用圃場）",
             ],
         )
+        self.assertEqual(summary_periods, ["2026 播種時", "2026 播種時", "2026 播種時"])
+        self.assertContains(response, "2026 播種時")
 
     def test_save_all_redirects_to_success(self):
         session = self.client.session

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -349,6 +349,39 @@ class ChemicalAssociationViewsTest(TestCase):
         )
         self.assertEqual(suggested_ledgers, expected_ledgers)
 
+    def test_association_list_shows_selected_ledger_year_and_sampling_date(self):
+        """
+        シナリオ:
+        - 入力: 関連付け済み行を含む化学分析取り込みセッションを用意する。
+        - 処理: 化学分析の関連付け一覧画面を表示する。
+        - 期待値: Excel行番号として表示され、関連付け済み帳簿に年度と採土日が表示されること。
+        """
+        session = self.client.session
+        session["chemical_import_session"] = {
+            "rows": [
+                {
+                    "row_data": {
+                        "row_number": 4,
+                        "analysis_number": "A001",
+                        "person_name": "テスト太郎",
+                        "land_name": "圃場A",
+                        "crop": "キャベツ",
+                    },
+                    "selected_ledger_id": self.ledger.id,
+                    "status": "confirmed",
+                }
+            ],
+            "total_rows": 1,
+        }
+        session.save()
+
+        response = self.client.get(reverse("soil:chemical_association"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "処理済み - Excel行: 4")
+        self.assertContains(response, "2024 2024年春")
+        self.assertContains(response, "採土日: 2024-04-01")
+
     def test_row_confirmation_rejects_used_chemical_ledger_post(self):
         """
         シナリオ:

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -255,64 +255,68 @@ class ChemicalAssociationViewsTest(TestCase):
     def test_association_list_candidate_count_uses_next_unused_same_period_name(self):
         """
         シナリオ:
-        - 入力: 2026年播種時を使用済みにし、同一圃場に収穫時と翌年播種時の未使用帳簿を用意する。
+        - 入力: 3圃場の2026年播種時を使用済みにし、2027年播種時の未使用帳簿を用意する。
         - 処理: 化学分析の関連付け一覧画面を表示する。
-        - 期待値: 候補数は同じ時期名を継続した未使用帳簿のみを数え、1件になること。
+        - 期待値: 候補数は次の未使用の播種時帳簿を数え、3件になること。
         """
-        land = Land.objects.create(
-            name="FIELD001（点検用圃場）",
-            company=self.company,
-            jma_city=self.ledger.land.jma_city,
-            cultivation_type=self.ledger.land.cultivation_type,
-            owner=self.user,
-            center="36.0,140.0",
-        )
         used_period = LandPeriod.objects.create(name="播種時", year=2026)
         harvest_period = LandPeriod.objects.create(name="収穫時", year=2026)
         next_sowing_period = LandPeriod.objects.create(name="播種時", year=2027)
         next_harvest_period = LandPeriod.objects.create(name="収穫時", year=2027)
-        used_ledger = LandLedger.objects.create(
-            land=land,
-            land_period=used_period,
-            sampling_date=date(2026, 3, 3),
-            analytical_agency=self.company,
-            crop=self.ledger.crop,
-            sampling_method=self.ledger.sampling_method,
-            sampling_staff=self.user,
-        )
-        LandLedger.objects.create(
-            land=land,
-            land_period=harvest_period,
-            sampling_date=date(2026, 9, 3),
-            analytical_agency=self.company,
-            crop=self.ledger.crop,
-            sampling_method=self.ledger.sampling_method,
-            sampling_staff=self.user,
-        )
-        expected_ledger = LandLedger.objects.create(
-            land=land,
-            land_period=next_sowing_period,
-            sampling_date=date(2027, 3, 3),
-            analytical_agency=self.company,
-            crop=self.ledger.crop,
-            sampling_method=self.ledger.sampling_method,
-            sampling_staff=self.user,
-        )
-        LandLedger.objects.create(
-            land=land,
-            land_period=next_harvest_period,
-            sampling_date=date(2027, 9, 3),
-            analytical_agency=self.company,
-            crop=self.ledger.crop,
-            sampling_method=self.ledger.sampling_method,
-            sampling_staff=self.user,
-        )
-        SoilChemicalMeasurement.objects.create(
-            land_ledger=used_ledger,
-            ph=6.5,
-            ec=0.1,
-            source_file="stage01.xlsx",
-        )
+        expected_ledgers = []
+        for number in range(1, 4):
+            land = Land.objects.create(
+                name=f"FIELD00{number}（点検用圃場）",
+                company=self.company,
+                jma_city=self.ledger.land.jma_city,
+                cultivation_type=self.ledger.land.cultivation_type,
+                owner=self.user,
+                center="36.0,140.0",
+            )
+            used_ledger = LandLedger.objects.create(
+                land=land,
+                land_period=used_period,
+                sampling_date=date(2026, 3, 3),
+                analytical_agency=self.company,
+                crop=self.ledger.crop,
+                sampling_method=self.ledger.sampling_method,
+                sampling_staff=self.user,
+            )
+            LandLedger.objects.create(
+                land=land,
+                land_period=harvest_period,
+                sampling_date=date(2026, 9, 3),
+                analytical_agency=self.company,
+                crop=self.ledger.crop,
+                sampling_method=self.ledger.sampling_method,
+                sampling_staff=self.user,
+            )
+            expected_ledgers.append(
+                LandLedger.objects.create(
+                    land=land,
+                    land_period=next_sowing_period,
+                    sampling_date=date(2027, 3, 3),
+                    analytical_agency=self.company,
+                    crop=self.ledger.crop,
+                    sampling_method=self.ledger.sampling_method,
+                    sampling_staff=self.user,
+                )
+            )
+            LandLedger.objects.create(
+                land=land,
+                land_period=next_harvest_period,
+                sampling_date=date(2027, 9, 3),
+                analytical_agency=self.company,
+                crop=self.ledger.crop,
+                sampling_method=self.ledger.sampling_method,
+                sampling_staff=self.user,
+            )
+            SoilChemicalMeasurement.objects.create(
+                land_ledger=used_ledger,
+                ph=6.5,
+                ec=0.1,
+                source_file="stage01.xlsx",
+            )
         session = self.client.session
         session["chemical_import_session"] = {
             "rows": [
@@ -335,7 +339,7 @@ class ChemicalAssociationViewsTest(TestCase):
         response = self.client.get(reverse("soil:chemical_association"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["rows"][0]["suggested_count"], 1)
+        self.assertEqual(response.context["rows"][0]["suggested_count"], 3)
         self.assertEqual(
             response.context["rows"][0]["selected_ledger"],
             None,
@@ -343,7 +347,7 @@ class ChemicalAssociationViewsTest(TestCase):
         suggested_ledgers = ChemicalImportService.get_suggested_ledgers(
             "FIELD001（点検用圃場）"
         )
-        self.assertEqual(suggested_ledgers, [expected_ledger])
+        self.assertEqual(suggested_ledgers, expected_ledgers)
 
     def test_row_confirmation_rejects_used_chemical_ledger_post(self):
         """

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -252,18 +252,18 @@ class ChemicalAssociationViewsTest(TestCase):
         self.assertNotContains(response, f'value="{self.ledger.id}"')
         self.assertContains(response, f'value="{unused_ledger.id}"')
 
-    def test_association_list_candidate_count_uses_next_unused_same_period_name(self):
+    def test_association_list_candidate_count_uses_oldest_unused_year_for_land(self):
         """
         シナリオ:
-        - 入力: 3圃場の2026年播種時を使用済みにし、2027年播種時の未使用帳簿を用意する。
+        - 入力: 3圃場の2026年播種時を使用済みにし、2026年収穫時と2027年播種時の未使用帳簿を用意する。
         - 処理: 化学分析の関連付け一覧画面を表示する。
-        - 期待値: 候補数は次の未使用の播種時帳簿を数え、3件になること。
+        - 期待値: FIELD001に一致する最古未使用年度の帳簿だけを数え、2026年収穫時の1件になること。
         """
         used_period = LandPeriod.objects.create(name="播種時", year=2026)
         harvest_period = LandPeriod.objects.create(name="収穫時", year=2026)
         next_sowing_period = LandPeriod.objects.create(name="播種時", year=2027)
         next_harvest_period = LandPeriod.objects.create(name="収穫時", year=2027)
-        expected_ledgers = []
+        expected_ledger = None
         for number in range(1, 4):
             land = Land.objects.create(
                 name=f"FIELD00{number}（点検用圃場）",
@@ -282,7 +282,7 @@ class ChemicalAssociationViewsTest(TestCase):
                 sampling_method=self.ledger.sampling_method,
                 sampling_staff=self.user,
             )
-            LandLedger.objects.create(
+            harvest_ledger = LandLedger.objects.create(
                 land=land,
                 land_period=harvest_period,
                 sampling_date=date(2026, 9, 3),
@@ -291,16 +291,16 @@ class ChemicalAssociationViewsTest(TestCase):
                 sampling_method=self.ledger.sampling_method,
                 sampling_staff=self.user,
             )
-            expected_ledgers.append(
-                LandLedger.objects.create(
-                    land=land,
-                    land_period=next_sowing_period,
-                    sampling_date=date(2027, 3, 3),
-                    analytical_agency=self.company,
-                    crop=self.ledger.crop,
-                    sampling_method=self.ledger.sampling_method,
-                    sampling_staff=self.user,
-                )
+            if number == 1:
+                expected_ledger = harvest_ledger
+            LandLedger.objects.create(
+                land=land,
+                land_period=next_sowing_period,
+                sampling_date=date(2027, 3, 3),
+                analytical_agency=self.company,
+                crop=self.ledger.crop,
+                sampling_method=self.ledger.sampling_method,
+                sampling_staff=self.user,
             )
             LandLedger.objects.create(
                 land=land,
@@ -339,7 +339,7 @@ class ChemicalAssociationViewsTest(TestCase):
         response = self.client.get(reverse("soil:chemical_association"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["rows"][0]["suggested_count"], 3)
+        self.assertEqual(response.context["rows"][0]["suggested_count"], 1)
         self.assertEqual(
             response.context["rows"][0]["selected_ledger"],
             None,
@@ -347,7 +347,7 @@ class ChemicalAssociationViewsTest(TestCase):
         suggested_ledgers = ChemicalImportService.get_suggested_ledgers(
             "FIELD001（点検用圃場）"
         )
-        self.assertEqual(suggested_ledgers, expected_ledgers)
+        self.assertEqual(suggested_ledgers, [expected_ledger])
 
     def test_association_list_shows_selected_ledger_year_and_sampling_date(self):
         """

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -252,6 +252,99 @@ class ChemicalAssociationViewsTest(TestCase):
         self.assertNotContains(response, f'value="{self.ledger.id}"')
         self.assertContains(response, f'value="{unused_ledger.id}"')
 
+    def test_association_list_candidate_count_uses_next_unused_same_period_name(self):
+        """
+        シナリオ:
+        - 入力: 2026年播種時を使用済みにし、同一圃場に収穫時と翌年播種時の未使用帳簿を用意する。
+        - 処理: 化学分析の関連付け一覧画面を表示する。
+        - 期待値: 候補数は同じ時期名を継続した未使用帳簿のみを数え、1件になること。
+        """
+        land = Land.objects.create(
+            name="FIELD001（点検用圃場）",
+            company=self.company,
+            jma_city=self.ledger.land.jma_city,
+            cultivation_type=self.ledger.land.cultivation_type,
+            owner=self.user,
+            center="36.0,140.0",
+        )
+        used_period = LandPeriod.objects.create(name="播種時", year=2026)
+        harvest_period = LandPeriod.objects.create(name="収穫時", year=2026)
+        next_sowing_period = LandPeriod.objects.create(name="播種時", year=2027)
+        next_harvest_period = LandPeriod.objects.create(name="収穫時", year=2027)
+        used_ledger = LandLedger.objects.create(
+            land=land,
+            land_period=used_period,
+            sampling_date=date(2026, 3, 3),
+            analytical_agency=self.company,
+            crop=self.ledger.crop,
+            sampling_method=self.ledger.sampling_method,
+            sampling_staff=self.user,
+        )
+        LandLedger.objects.create(
+            land=land,
+            land_period=harvest_period,
+            sampling_date=date(2026, 9, 3),
+            analytical_agency=self.company,
+            crop=self.ledger.crop,
+            sampling_method=self.ledger.sampling_method,
+            sampling_staff=self.user,
+        )
+        expected_ledger = LandLedger.objects.create(
+            land=land,
+            land_period=next_sowing_period,
+            sampling_date=date(2027, 3, 3),
+            analytical_agency=self.company,
+            crop=self.ledger.crop,
+            sampling_method=self.ledger.sampling_method,
+            sampling_staff=self.user,
+        )
+        LandLedger.objects.create(
+            land=land,
+            land_period=next_harvest_period,
+            sampling_date=date(2027, 9, 3),
+            analytical_agency=self.company,
+            crop=self.ledger.crop,
+            sampling_method=self.ledger.sampling_method,
+            sampling_staff=self.user,
+        )
+        SoilChemicalMeasurement.objects.create(
+            land_ledger=used_ledger,
+            ph=6.5,
+            ec=0.1,
+            source_file="stage01.xlsx",
+        )
+        session = self.client.session
+        session["chemical_import_session"] = {
+            "rows": [
+                {
+                    "row_data": {
+                        "row_number": 4,
+                        "analysis_number": "A101",
+                        "person_name": "テスト太郎",
+                        "land_name": "FIELD001（点検用圃場）",
+                        "crop": "キャベツ",
+                    },
+                    "selected_ledger_id": None,
+                    "status": "pending",
+                }
+            ],
+            "total_rows": 1,
+        }
+        session.save()
+
+        response = self.client.get(reverse("soil:chemical_association"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["rows"][0]["suggested_count"], 1)
+        self.assertEqual(
+            response.context["rows"][0]["selected_ledger"],
+            None,
+        )
+        suggested_ledgers = ChemicalImportService.get_suggested_ledgers(
+            "FIELD001（点検用圃場）"
+        )
+        self.assertEqual(suggested_ledgers, [expected_ledger])
+
     def test_row_confirmation_rejects_used_chemical_ledger_post(self):
         """
         シナリオ:
@@ -309,6 +402,66 @@ class ChemicalAssociationViewsTest(TestCase):
         updated_session = self.client.session["chemical_import_session"]["rows"][0]
         self.assertEqual(updated_session["status"], "pending")
         self.assertIsNone(updated_session["selected_ledger_id"])
+
+    def test_success_summary_orders_by_land_name_ascending(self):
+        """
+        シナリオ:
+        - 入力: FIELD003, FIELD002, FIELD001 の順に保存結果の帳簿IDをセッションへ入れる。
+        - 処理: 化学分析の関連付け完了画面を表示する。
+        - 期待値: 集計表示はセッション順ではなく圃場名昇順で FIELD001, FIELD002, FIELD003 になること。
+        """
+        period = LandPeriod.objects.create(name="播種時", year=2026)
+        ledgers = []
+        for land_name in (
+            "FIELD003（点検用圃場）",
+            "FIELD002（点検用圃場）",
+            "FIELD001（点検用圃場）",
+        ):
+            land = Land.objects.create(
+                name=land_name,
+                company=self.company,
+                jma_city=self.ledger.land.jma_city,
+                cultivation_type=self.ledger.land.cultivation_type,
+                owner=self.user,
+                center="36.0,140.0",
+            )
+            ledger = LandLedger.objects.create(
+                land=land,
+                land_period=period,
+                sampling_date=date(2026, 3, 3),
+                analytical_agency=self.company,
+                crop=self.ledger.crop,
+                sampling_method=self.ledger.sampling_method,
+                sampling_staff=self.user,
+            )
+            SoilChemicalMeasurement.objects.create(
+                land_ledger=ledger,
+                ph=6.5,
+                ec=0.1,
+                source_file="stage02.xlsx",
+            )
+            ledgers.append(ledger)
+        session = self.client.session
+        session["chemical_import_result"] = {
+            "created": 3,
+            "updated": 0,
+            "ledger_ids": [ledger.id for ledger in ledgers],
+            "error_count": 0,
+        }
+        session.save()
+
+        response = self.client.get(reverse("soil:chemical_association_success"))
+
+        self.assertEqual(response.status_code, 200)
+        summary_names = [row["land_name"] for row in response.context["ledger_summary"]]
+        self.assertEqual(
+            summary_names,
+            [
+                "FIELD001（点検用圃場）",
+                "FIELD002（点検用圃場）",
+                "FIELD003（点検用圃場）",
+            ],
+        )
 
     def test_save_all_redirects_to_success(self):
         session = self.client.session

--- a/soil_analysis/tests/test_chemical_association_views.py
+++ b/soil_analysis/tests/test_chemical_association_views.py
@@ -23,6 +23,7 @@ from soil_analysis.models import (
     LandPeriod,
     SamplingMethod,
     LandBlock,
+    SoilChemicalMeasurement,
 )
 
 
@@ -184,6 +185,130 @@ class ChemicalAssociationViewsTest(TestCase):
         self.assertContains(response, "2024 2024年春 / 採土日: 2024-04-01")
         self.assertContains(response, "2025 播種時 / 採土日: 2025-04-01")
         self.assertContains(response, f'value="{other_ledger.id}"')
+
+    def test_row_confirmation_excludes_used_chemical_ledger_options(self):
+        """
+        シナリオ:
+        - 入力: 化学分析データに紐付け済みの帳簿と未使用帳簿を用意する。
+        - 処理: 化学分析の行別帳簿関連付け画面を表示する。
+        - 期待値: 使用済み帳簿は候補帳簿にも全帳簿にも表示されず、未使用帳簿だけ選べること。
+        """
+        unused_period = LandPeriod.objects.create(name="2024年秋", year=2024)
+        unused_ledger = LandLedger.objects.create(
+            land=self.ledger.land,
+            land_period=unused_period,
+            sampling_date=date(2024, 10, 1),
+            analytical_agency=self.company,
+            crop=self.ledger.crop,
+            sampling_method=self.ledger.sampling_method,
+            sampling_staff=self.user,
+        )
+        SoilChemicalMeasurement.objects.create(
+            land_ledger=self.ledger,
+            ph=6.5,
+            ec=0.1,
+            source_file="used.xlsx",
+        )
+        session = self.client.session
+        session["chemical_import_session"] = {
+            "rows": [
+                {
+                    "row_data": {
+                        "row_number": 4,
+                        "analysis_number": "A001",
+                        "person_name": "テスト太郎",
+                        "land_name": "圃場A",
+                        "crop": "キャベツ",
+                        "ec": 0.1,
+                        "ph": 6.5,
+                        "cec": None,
+                        "cao": None,
+                        "mgo": None,
+                        "k2o": None,
+                        "lime_saturation": None,
+                        "magnesia_saturation": None,
+                        "potash_saturation": None,
+                        "base_saturation": None,
+                        "p2o5": None,
+                        "phosphorus_absorption": None,
+                        "nh4n": None,
+                        "no3n": None,
+                        "humus": None,
+                        "bulk_density": None,
+                    },
+                    "selected_ledger_id": None,
+                    "status": "pending",
+                }
+            ],
+            "total_rows": 1,
+        }
+        session.save()
+
+        response = self.client.get(
+            reverse("soil:chemical_association_field_row", kwargs={"row_index": 0})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, f'value="{self.ledger.id}"')
+        self.assertContains(response, f'value="{unused_ledger.id}"')
+
+    def test_row_confirmation_rejects_used_chemical_ledger_post(self):
+        """
+        シナリオ:
+        - 入力: 化学分析データに紐付け済みの帳簿IDをPOSTする。
+        - 処理: 行別帳簿関連付け画面で帳簿を確定しようとする。
+        - 期待値: 使用済み帳簿は確定されず、同じ行の関連付け画面に戻ること。
+        """
+        SoilChemicalMeasurement.objects.create(
+            land_ledger=self.ledger,
+            ph=6.5,
+            ec=0.1,
+            source_file="used.xlsx",
+        )
+        session = self.client.session
+        session["chemical_import_session"] = {
+            "rows": [
+                {
+                    "row_data": {
+                        "row_number": 4,
+                        "analysis_number": "A001",
+                        "person_name": "テスト太郎",
+                        "land_name": "圃場A",
+                        "crop": "キャベツ",
+                        "ec": 0.1,
+                        "ph": 6.5,
+                        "cec": None,
+                        "cao": None,
+                        "mgo": None,
+                        "k2o": None,
+                        "lime_saturation": None,
+                        "magnesia_saturation": None,
+                        "potash_saturation": None,
+                        "base_saturation": None,
+                        "p2o5": None,
+                        "phosphorus_absorption": None,
+                        "nh4n": None,
+                        "no3n": None,
+                        "humus": None,
+                        "bulk_density": None,
+                    },
+                    "selected_ledger_id": None,
+                    "status": "pending",
+                }
+            ],
+            "total_rows": 1,
+        }
+        session.save()
+
+        row_url = reverse(
+            "soil:chemical_association_field_row", kwargs={"row_index": 0}
+        )
+        response = self.client.post(row_url, {"land_ledger": self.ledger.id})
+
+        self.assertRedirects(response, row_url)
+        updated_session = self.client.session["chemical_import_session"]["rows"][0]
+        self.assertEqual(updated_session["status"], "pending")
+        self.assertIsNone(updated_session["selected_ledger_id"])
 
     def test_save_all_redirects_to_success(self):
         session = self.client.session

--- a/soil_analysis/tests/test_chemical_import_service.py
+++ b/soil_analysis/tests/test_chemical_import_service.py
@@ -199,6 +199,53 @@ class ChemicalImportServiceTest(TestCase):
 
         self.assertEqual(ledgers, [expected_ledger])
 
+    def test_get_suggested_ledgers_uses_first_unused_period_for_first_round(self):
+        """
+        シナリオ:
+        - 入力: 3圃場に2026年播種時と2027年播種時の未使用帳簿を用意する。
+        - 処理: 1ラウンド目の候補帳簿を圃場名から取得する。
+        - 期待値: 最初の未使用LandPeriodである2026年播種時の3帳簿だけが返ること。
+        """
+        company = Company.objects.create(
+            name="Round Test Company", category=self.company.category
+        )
+        first_period = LandPeriod.objects.create(name="播種時", year=2026)
+        next_period = LandPeriod.objects.create(name="播種時", year=2027)
+        expected_ledgers = []
+        for number in range(1, 4):
+            land = Land.objects.create(
+                name=f"FIELD00{number}（点検用圃場）",
+                company=company,
+                jma_city=self.city,
+                cultivation_type=self.cultivation_type,
+                owner=self.user,
+                center="36.0,140.0",
+            )
+            expected_ledgers.append(
+                LandLedger.objects.create(
+                    land=land,
+                    land_period=first_period,
+                    sampling_date=date(2026, 3, 3),
+                    analytical_agency=company,
+                    crop=self.crop,
+                    sampling_method=self.sampling_method,
+                    sampling_staff=self.user,
+                )
+            )
+            LandLedger.objects.create(
+                land=land,
+                land_period=next_period,
+                sampling_date=date(2027, 3, 3),
+                analytical_agency=company,
+                crop=self.crop,
+                sampling_method=self.sampling_method,
+                sampling_staff=self.user,
+            )
+
+        ledgers = ChemicalImportService.get_suggested_ledgers("FIELD001（点検用圃場）")
+
+        self.assertEqual(ledgers, expected_ledgers)
+
     def test_save_import_data(self):
         """データの保存ができること"""
         row = KawadaRow(

--- a/soil_analysis/tests/test_chemical_import_service.py
+++ b/soil_analysis/tests/test_chemical_import_service.py
@@ -80,8 +80,8 @@ class ChemicalImportServiceTest(TestCase):
         ledgers = ChemicalImportService.get_suggested_ledgers("圃場")
         self.assertIn(self.ledger, ledgers)
 
-    def test_get_suggested_ledgers_with_base_ledger_priority(self):
-        """base_ledgerと同じ期間の帳簿が優先されること"""
+    def test_get_suggested_ledgers_with_base_ledger_year(self):
+        """base_ledgerと同じ年度の未使用帳簿が候補になること"""
         period2 = LandPeriod.objects.create(name="2024年秋", year=2024)
         ledger2 = LandLedger.objects.create(
             land=self.land,
@@ -97,12 +97,12 @@ class ChemicalImportServiceTest(TestCase):
         ledgers = ChemicalImportService.get_suggested_ledgers(
             "圃場A", base_ledger_id=self.ledger.id
         )
-        self.assertEqual(ledgers[0].id, self.ledger.id)
+        self.assertEqual(ledgers, [self.ledger, ledger2])
 
         ledgers2 = ChemicalImportService.get_suggested_ledgers(
             "圃場A", base_ledger_id=ledger2.id
         )
-        self.assertEqual(ledgers2[0].id, ledger2.id)
+        self.assertEqual(ledgers2, [self.ledger, ledger2])
 
     def test_get_suggested_ledgers_excludes_used_ledger(self):
         """
@@ -133,12 +133,12 @@ class ChemicalImportServiceTest(TestCase):
         self.assertNotIn(self.ledger, ledgers)
         self.assertIn(unused_ledger, ledgers)
 
-    def test_get_suggested_ledgers_keeps_used_period_name_for_next_round(self):
+    def test_get_suggested_ledgers_keeps_used_year_until_exhausted(self):
         """
         シナリオ:
         - 入力: 2026年播種時を使用済みにし、同一圃場に2026年収穫時・2027年播種時・2027年収穫時を用意する。
         - 処理: 2ラウンド目の候補帳簿を圃場名から取得する。
-        - 期待値: 使用済み帳簿と異なる時期名の帳簿は候補にならず、未使用の2027年播種時だけが返ること。
+        - 期待値: 2026年に未使用の収穫時が残っているため、2027年ではなく2026年収穫時だけが返ること。
         """
         land = Land.objects.create(
             name="FIELD001（点検用圃場）",
@@ -161,7 +161,7 @@ class ChemicalImportServiceTest(TestCase):
             sampling_method=self.sampling_method,
             sampling_staff=self.user,
         )
-        LandLedger.objects.create(
+        expected_ledger = LandLedger.objects.create(
             land=land,
             land_period=harvest_period,
             sampling_date=date(2026, 9, 3),
@@ -170,7 +170,7 @@ class ChemicalImportServiceTest(TestCase):
             sampling_method=self.sampling_method,
             sampling_staff=self.user,
         )
-        expected_ledger = LandLedger.objects.create(
+        LandLedger.objects.create(
             land=land,
             land_period=next_sowing_period,
             sampling_date=date(2027, 3, 3),
@@ -199,17 +199,18 @@ class ChemicalImportServiceTest(TestCase):
 
         self.assertEqual(ledgers, [expected_ledger])
 
-    def test_get_suggested_ledgers_uses_first_unused_period_for_first_round(self):
+    def test_get_suggested_ledgers_uses_first_unused_year_for_first_round(self):
         """
         シナリオ:
-        - 入力: 3圃場に2026年播種時と2027年播種時の未使用帳簿を用意する。
+        - 入力: 3圃場に2026年播種時・2026年収穫時・2027年播種時の未使用帳簿を用意する。
         - 処理: 1ラウンド目の候補帳簿を圃場名から取得する。
-        - 期待値: 最初の未使用LandPeriodである2026年播種時の3帳簿だけが返ること。
+        - 期待値: Excel行の圃場名に一致する2026年の未使用帳簿だけが返り、2027年は返らないこと。
         """
         company = Company.objects.create(
             name="Round Test Company", category=self.company.category
         )
         first_period = LandPeriod.objects.create(name="播種時", year=2026)
+        harvest_period = LandPeriod.objects.create(name="収穫時", year=2026)
         next_period = LandPeriod.objects.create(name="播種時", year=2027)
         expected_ledgers = []
         for number in range(1, 4):
@@ -221,17 +222,27 @@ class ChemicalImportServiceTest(TestCase):
                 owner=self.user,
                 center="36.0,140.0",
             )
-            expected_ledgers.append(
-                LandLedger.objects.create(
-                    land=land,
-                    land_period=first_period,
-                    sampling_date=date(2026, 3, 3),
-                    analytical_agency=company,
-                    crop=self.crop,
-                    sampling_method=self.sampling_method,
-                    sampling_staff=self.user,
-                )
+            sowing_ledger = LandLedger.objects.create(
+                land=land,
+                land_period=first_period,
+                sampling_date=date(2026, 3, 3),
+                analytical_agency=company,
+                crop=self.crop,
+                sampling_method=self.sampling_method,
+                sampling_staff=self.user,
             )
+            harvest_ledger = LandLedger.objects.create(
+                land=land,
+                land_period=harvest_period,
+                sampling_date=date(2026, 9, 3),
+                analytical_agency=company,
+                crop=self.crop,
+                sampling_method=self.sampling_method,
+                sampling_staff=self.user,
+            )
+            if number == 1:
+                expected_ledgers.append(sowing_ledger)
+                expected_ledgers.append(harvest_ledger)
             LandLedger.objects.create(
                 land=land,
                 land_period=next_period,

--- a/soil_analysis/tests/test_chemical_import_service.py
+++ b/soil_analysis/tests/test_chemical_import_service.py
@@ -21,6 +21,7 @@ from soil_analysis.models import (
     Crop,
     SamplingMethod,
     LandBlock,
+    SoilChemicalMeasurement,
 )
 
 
@@ -102,6 +103,35 @@ class ChemicalImportServiceTest(TestCase):
             "圃場A", base_ledger_id=ledger2.id
         )
         self.assertEqual(ledgers2[0].id, ledger2.id)
+
+    def test_get_suggested_ledgers_excludes_used_ledger(self):
+        """
+        シナリオ:
+        - 入力: 同一圃場に使用済み帳簿と未使用帳簿を用意する。
+        - 処理: 圃場名から化学分析用の候補帳簿を取得する。
+        - 期待値: 化学分析データに紐付け済みの帳簿は候補から除外されること。
+        """
+        unused_period = LandPeriod.objects.create(name="2024年秋", year=2024)
+        unused_ledger = LandLedger.objects.create(
+            land=self.land,
+            land_period=unused_period,
+            sampling_date=date(2024, 10, 1),
+            analytical_agency=self.company,
+            crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        SoilChemicalMeasurement.objects.create(
+            land_ledger=self.ledger,
+            ph=6.5,
+            ec=0.1,
+            source_file="used.xlsx",
+        )
+
+        ledgers = ChemicalImportService.get_suggested_ledgers("圃場A")
+
+        self.assertNotIn(self.ledger, ledgers)
+        self.assertIn(unused_ledger, ledgers)
 
     def test_save_import_data(self):
         """データの保存ができること"""

--- a/soil_analysis/tests/test_chemical_import_service.py
+++ b/soil_analysis/tests/test_chemical_import_service.py
@@ -111,11 +111,11 @@ class ChemicalImportServiceTest(TestCase):
         - 処理: 圃場名から化学分析用の候補帳簿を取得する。
         - 期待値: 化学分析データに紐付け済みの帳簿は候補から除外されること。
         """
-        unused_period = LandPeriod.objects.create(name="2024年秋", year=2024)
+        unused_period = LandPeriod.objects.create(name="2024年春", year=2025)
         unused_ledger = LandLedger.objects.create(
             land=self.land,
             land_period=unused_period,
-            sampling_date=date(2024, 10, 1),
+            sampling_date=date(2025, 4, 1),
             analytical_agency=self.company,
             crop=self.crop,
             sampling_method=self.sampling_method,
@@ -132,6 +132,72 @@ class ChemicalImportServiceTest(TestCase):
 
         self.assertNotIn(self.ledger, ledgers)
         self.assertIn(unused_ledger, ledgers)
+
+    def test_get_suggested_ledgers_keeps_used_period_name_for_next_round(self):
+        """
+        シナリオ:
+        - 入力: 2026年播種時を使用済みにし、同一圃場に2026年収穫時・2027年播種時・2027年収穫時を用意する。
+        - 処理: 2ラウンド目の候補帳簿を圃場名から取得する。
+        - 期待値: 使用済み帳簿と異なる時期名の帳簿は候補にならず、未使用の2027年播種時だけが返ること。
+        """
+        land = Land.objects.create(
+            name="FIELD001（点検用圃場）",
+            company=self.company,
+            jma_city=self.city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="36.0,140.0",
+        )
+        used_period = LandPeriod.objects.create(name="播種時", year=2026)
+        harvest_period = LandPeriod.objects.create(name="収穫時", year=2026)
+        next_sowing_period = LandPeriod.objects.create(name="播種時", year=2027)
+        next_harvest_period = LandPeriod.objects.create(name="収穫時", year=2027)
+        used_ledger = LandLedger.objects.create(
+            land=land,
+            land_period=used_period,
+            sampling_date=date(2026, 3, 3),
+            analytical_agency=self.company,
+            crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        LandLedger.objects.create(
+            land=land,
+            land_period=harvest_period,
+            sampling_date=date(2026, 9, 3),
+            analytical_agency=self.company,
+            crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        expected_ledger = LandLedger.objects.create(
+            land=land,
+            land_period=next_sowing_period,
+            sampling_date=date(2027, 3, 3),
+            analytical_agency=self.company,
+            crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        LandLedger.objects.create(
+            land=land,
+            land_period=next_harvest_period,
+            sampling_date=date(2027, 9, 3),
+            analytical_agency=self.company,
+            crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        SoilChemicalMeasurement.objects.create(
+            land_ledger=used_ledger,
+            ph=6.5,
+            ec=0.1,
+            source_file="stage01.xlsx",
+        )
+
+        ledgers = ChemicalImportService.get_suggested_ledgers("FIELD001（点検用圃場）")
+
+        self.assertEqual(ledgers, [expected_ledger])
 
     def test_save_import_data(self):
         """データの保存ができること"""

--- a/soil_analysis/tests/test_land_detail_views.py
+++ b/soil_analysis/tests/test_land_detail_views.py
@@ -1,0 +1,166 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from soil_analysis.models import (
+    Company,
+    CompanyCategory,
+    Crop,
+    CultivationType,
+    Device,
+    JmaArea,
+    JmaCity,
+    JmaPrefecture,
+    JmaRegion,
+    Land,
+    LandBlock,
+    LandLedger,
+    LandPeriod,
+    SamplingMethod,
+    SoilChemicalMeasurement,
+    SoilHardnessMeasurement,
+)
+
+
+class LandDetailViewTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="testuser")
+
+        category = CompanyCategory.objects.create(name="テストカテゴリ")
+        self.company = Company.objects.create(name="テスト法人", category=category)
+
+        area = JmaArea.objects.create(code="01", name="テストエリア")
+        pref = JmaPrefecture.objects.create(code="0101", name="テスト県", jma_area=area)
+        region = JmaRegion.objects.create(
+            code="010101", name="テスト地域", jma_prefecture=pref
+        )
+        city = JmaCity.objects.create(
+            code="0101011", name="テスト市", jma_region=region
+        )
+
+        self.cultivation_type = CultivationType.objects.create(name="露地")
+        self.crop = Crop.objects.create(name="キャベツ")
+        self.sampling_method = SamplingMethod.objects.create(name="5点法", times=5)
+        self.land = Land.objects.create(
+            name="FIELD001",
+            company=self.company,
+            jma_city=city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="36.0,140.0",
+        )
+
+    def create_ledger(self, *, period_name, year, sampling_date):
+        period = LandPeriod.objects.create(name=period_name, year=year)
+        return LandLedger.objects.create(
+            land=self.land,
+            land_period=period,
+            sampling_date=sampling_date,
+            analytical_agency=self.company,
+            crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+
+    def detail_url(self):
+        return reverse(
+            "soil:land_detail",
+            kwargs={"company_id": self.company.id, "pk": self.land.id},
+        )
+
+    def report_url(self, ledger):
+        return reverse(
+            "soil:standard_report",
+            kwargs={"company_id": self.company.id, "land_ledger_id": ledger.id},
+        )
+
+    def test_land_detail_orders_ledgers_by_year_ascending(self):
+        """
+        シナリオ:
+        - 入力: 2027年、2026年の順に作成された通知表台帳。
+        - 処理: 圃場詳細画面を表示する。
+        - 期待値: 通知表台帳が年度昇順で 2026年、2027年の順に表示されること。
+        """
+        self.create_ledger(
+            period_name="播種時", year=2027, sampling_date=date(2027, 3, 3)
+        )
+        self.create_ledger(
+            period_name="播種時", year=2026, sampling_date=date(2026, 3, 3)
+        )
+
+        response = self.client.get(self.detail_url())
+
+        self.assertEqual(response.status_code, 200)
+        ledgers = response.context["object"].ledgers
+        self.assertEqual([ledger.land_period.year for ledger in ledgers], [2026, 2027])
+
+    def test_land_detail_disables_report_button_without_measurements(self):
+        """
+        シナリオ:
+        - 入力: 化学データも硬度データも紐づいていない通知表台帳。
+        - 処理: 圃場詳細画面を表示する。
+        - 期待値: 通知表表示のリンクは出ず、disabled の操作ボタンが表示されること。
+        """
+        ledger = self.create_ledger(
+            period_name="播種時", year=2026, sampling_date=date(2026, 3, 3)
+        )
+
+        response = self.client.get(self.detail_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, f'href="{self.report_url(ledger)}"')
+        self.assertContains(
+            response, "化学データまたは硬度データが登録されると表示できます"
+        )
+        self.assertContains(response, "disabled")
+
+    def test_land_detail_enables_report_button_with_chemical_measurement(self):
+        """
+        シナリオ:
+        - 入力: 化学データが紐づいた通知表台帳。
+        - 処理: 圃場詳細画面を表示する。
+        - 期待値: 通知表表示リンクが有効な操作として表示されること。
+        """
+        ledger = self.create_ledger(
+            period_name="播種時", year=2026, sampling_date=date(2026, 3, 3)
+        )
+        SoilChemicalMeasurement.objects.create(land_ledger=ledger, ph=6.5, ec=0.1)
+
+        response = self.client.get(self.detail_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'href="{self.report_url(ledger)}"')
+
+    def test_land_detail_enables_report_button_with_hardness_measurement(self):
+        """
+        シナリオ:
+        - 入力: 硬度データだけが紐づいた通知表台帳。
+        - 処理: 圃場詳細画面を表示する。
+        - 期待値: 化学データがなくても通知表表示リンクが有効な操作として表示されること。
+        """
+        ledger = self.create_ledger(
+            period_name="播種時", year=2026, sampling_date=date(2026, 3, 3)
+        )
+        device = Device.objects.create(name="硬度計")
+        block = LandBlock.objects.create(name="A1")
+        SoilHardnessMeasurement.objects.create(
+            set_memory=1,
+            set_datetime=timezone.now(),
+            set_depth=60,
+            set_spring=1,
+            set_cone=1,
+            depth=10,
+            pressure=100,
+            folder="FIELD001",
+            set_device=device,
+            land_block=block,
+            land_ledger=ledger,
+        )
+
+        response = self.client.get(self.detail_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'href="{self.report_url(ledger)}"')

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -764,6 +764,7 @@ class ChemicalSuccessView(TemplateView):
                         {
                             "company_name": ledger.land.company.name,
                             "land_name": ledger.land.name,
+                            "period_year": ledger.land_period.year,
                             "period_name": ledger.land_period.name,
                             "total": count_by_ledger.get(ledger.id, 0),
                         }

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -754,6 +754,9 @@ class ChemicalSuccessView(TemplateView):
                         )
                     )
                     .filter(id__in=ledger_ids)
+                    .order_by(
+                        "land__name", "land_period__year", "land_period__name", "id"
+                    )
                 )
 
                 for ledger in ledgers:

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -222,7 +222,14 @@ class LandDetailView(DetailView):
         )
         land_ledger_prefetch = Prefetch(
             "landledger_set",
-            queryset=LandLedger.objects.select_related("land_period", "crop"),
+            queryset=LandLedger.objects.select_related("land_period", "crop")
+            .annotate(
+                chemical_measurement_count=Count("soil_chemical_measurement"),
+                hardness_measurement_count=Count(
+                    "soilhardnessmeasurement", distinct=True
+                ),
+            )
+            .order_by("land_period__year", "sampling_date", "land_period__name", "id"),
             to_attr="ledgers",
         )
         return (

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -661,9 +661,11 @@ class ChemicalAssociationRowView(TemplateView):
         suggested_ledgers = ChemicalImportService.get_suggested_ledgers(
             land_name, base_ledger_id=import_session.get("base_ledger_id")
         )
-        all_ledgers = LandLedger.objects.select_related(
-            "land", "land__company", "land_period"
-        ).order_by("-id")[:200]
+        all_ledgers = (
+            LandLedger.objects.select_related("land", "land__company", "land_period")
+            .exclude(id__in=ChemicalImportService.get_used_ledger_ids())
+            .order_by("-id")[:200]
+        )
         suggested_ids = {ledger.id for ledger in suggested_ledgers}
         fallback_ledgers = [
             ledger for ledger in all_ledgers if ledger.id not in suggested_ids
@@ -690,6 +692,16 @@ class ChemicalAssociationRowView(TemplateView):
 
         ledger_id = request.POST.get("land_ledger")
         if ledger_id:
+            if SoilChemicalMeasurement.objects.filter(
+                land_ledger_id=ledger_id
+            ).exists():
+                messages.error(
+                    request, "選択した帳簿はすでに化学分析データに紐付いています。"
+                )
+                return redirect(
+                    "soil:chemical_association_field_row", row_index=row_index
+                )
+
             import_session["rows"][row_index]["selected_ledger_id"] = int(ledger_id)
             import_session["rows"][row_index]["status"] = "confirmed"
             request.session.modified = True


### PR DESCRIPTION
## Summary
土壌分析の化学性分析 帳簿関連付け画面で、帳簿選択肢に年度と採土日を表示し、すでに化学分析データへ紐付け済みの帳簿を選択肢から除外するようにしました。

- 候補帳簿と全帳簿の `<option>` 表示に `land_period.year` と `sampling_date` を追加
- `SoilChemicalMeasurement` に紐付け済みの帳簿を、候補帳簿と全帳簿の両方から除外
- 候補帳簿は `land_name` に一致する圃場の未使用帳簿から算出するように統一
- 候補年度は、その圃場に未使用帳簿が残っている最古年度にする
- 2026年内に未使用時期が残っている間は2026年を候補にし、2027年へ進まない
- 例: 2026年播種時が使用済みでも2026年収穫時が未使用なら、ROUND2のFIELD001候補は2026年収穫時になる
- 一覧画面の候補数を、行別画面の候補帳簿と同じロジックで算出するよう統一
- 一覧画面の `行番号 (Excel)` 表示を `Excel行` に変更し、圃場数ではなくExcel上の行位置であることを明確化
- 一覧画面の関連付け済み帳簿に、年度・時期・採土日を表示
- 関連付け完了画面の集計テーブルの `時期` に年度を表示
- POST 直打ちで使用済み帳簿IDが送られた場合も確定せず、同じ行の関連付け画面に戻す
- 関連付け完了画面の集計を圃場名昇順で表示するよう修正
- 圃場詳細の土壌分析データ（通知表）一覧を年度昇順で表示するよう修正
- 圃場詳細の通知表操作は、化学データも硬度データもない帳簿では disabled 表示に変更

## 目検による動作確認手順
- [x] `/soil_analysis/chemical/association` を表示し、`Excel行: 4` がExcel上の行番号として表示されることを確認する
- [x] `/soil_analysis/chemical/association` の関連付け済み帳簿に、`2026 播種時` と `採土日: 2026-03-03` のように年度と採土日が表示されることを確認する
- [x] ROUND1では、Excel行の圃場名に一致する最古未使用年度の帳簿が候補になることを確認する
- [x] ROUND2では、2026年播種時が処理済みでも2026年収穫時が未使用なら、2027年播種時ではなく2026年収穫時が候補になることを確認する
- [x] 化学分析データに紐付け済みの帳簿が、候補帳簿にも全帳簿にも表示されないことを確認する
- [x] 使用済み帳簿IDをPOSTしても確定済みにならず、行別関連付け画面へ戻ることを確認する
- [x] `/soil_analysis/chemical/association/success` の関連付けデータ集計が `FIELD001`, `FIELD002`, `FIELD003` のように圃場名昇順で表示されることを確認する
- [x] `/soil_analysis/chemical/association/success` の `時期` 列に `2026 播種時` のように年度付きで表示されることを確認する
- [x] `/soil_analysis/company/1/land/1/detail` の土壌分析データ（通知表）が年度昇順で表示されることを確認する
- [x] `/soil_analysis/company/1/land/1/detail` で、化学データも硬度データもない通知表の操作が disabled 表示になることを確認する
- [x] `/soil_analysis/company/1/land/1/detail` で、化学データまたは硬度データがある通知表の操作リンクが有効であることを確認する

## 自動テストでカバーできた範囲
- `soil_analysis.tests.test_chemical_association_views`
  - 行別帳簿関連付け画面で、同一圃場・同じ時期名・別年度の帳簿候補に年度と採土日が表示されることを検証
  - 使用済み帳簿が候補帳簿・全帳簿から除外されることを検証
  - 一覧画面の候補数が、Excel行の圃場名に一致する最古未使用年度の帳簿数になることを検証
  - 一覧画面でExcel行番号として表示され、関連付け済み帳簿に年度と採土日が表示されることを検証
  - 使用済み帳簿IDのPOSTが拒否されることを検証
  - 完了画面の集計が圃場名昇順になることを検証
  - 完了画面の時期列に年度が表示されることを検証
- `soil_analysis.tests.test_chemical_import_service`
  - 化学分析候補帳簿の取得時に、使用済み帳簿が除外されることを検証
  - ROUND1で最古未使用年度の帳簿だけが候補になることを検証
  - ROUND2で同年度内に未使用時期が残っている場合、次年度ではなく同年度の未使用帳簿が候補になることを検証
- `soil_analysis.tests.test_land_detail_views`
  - 圃場詳細の通知表台帳が年度昇順で表示されることを検証
  - 化学データも硬度データもない通知表台帳では操作リンクが出ず、disabled ボタンになることを検証
  - 化学データがある通知表台帳では操作リンクが有効になることを検証
  - 硬度データだけがある通知表台帳でも操作リンクが有効になることを検証
- `python manage.py test`
  - 全体 293 件のテストが成功

## 関連Issue
https://github.com/duri0214/portfolio/issues/724
