### PR TITLE
731 [機能追加] 六戸町バックナンバー会議録PDFの一括ダウンロード対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ db.sqlite3
 .env
 venv
 scripts/.my.cnf
-rokunohe_pdf_backnumbers/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ db.sqlite3
 .env
 venv
 scripts/.my.cnf
+rokunohe_pdf_backnumbers/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ db.sqlite3
 .env
 venv
 scripts/.my.cnf
-rokunohe_pdf_back*/
+rokunohe_pdf_backnumbers/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ db.sqlite3
 .env
 venv
 scripts/.my.cnf
-rokunohe_pdf_backnumbers/
+rokunohe_pdf_back*/

--- a/jp_stocks/management/commands/rokunohe_pdf_download.py
+++ b/jp_stocks/management/commands/rokunohe_pdf_download.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import time
 from pathlib import Path
@@ -8,6 +9,8 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+logger = logging.getLogger(__name__)
+
 
 class Command(BaseCommand):
     help = "六戸町の会議録PDFを一括ダウンロードします"
@@ -16,7 +19,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--save-dir",
             default=None,
-            help="PDFの保存先ディレクトリ。未指定時は media/jp_stocks/rokunohe_pdf_backnumbers に保存します。",
+            help="PDFの保存先ディレクトリ。未指定時は media/jp_stocks/rokunohe_pdf_back_numbers に保存します。",
         )
         parser.add_argument(
             "--delay",
@@ -36,7 +39,7 @@ class Command(BaseCommand):
         save_dir = self._get_save_dir(options["save_dir"])
         if not save_dir.exists():
             save_dir.mkdir(parents=True)
-            self.stdout.write(f"ディレクトリを作成しました: {save_dir}")
+            self._write_info(f"ディレクトリを作成しました: {save_dir}")
 
         lock_path = save_dir / ".rokunohe_pdf_download.lock"
         self._create_lock(lock_path)
@@ -44,9 +47,12 @@ class Command(BaseCommand):
         try:
             downloaded_filenames = set()
             request_count = 0
+            self._write_info(
+                f"六戸町PDFダウンロード開始: 保存先={save_dir}, リクエスト間隔={options['delay']}秒"
+            )
 
             for target_url in target_urls:
-                self.stdout.write(f"処理中: {target_url}")
+                self._write_info(f"HTML取得中: {target_url}")
                 try:
                     response, request_count = self._get_with_delay(
                         url=target_url,
@@ -59,87 +65,85 @@ class Command(BaseCommand):
 
                     soup = BeautifulSoup(response.text, "html.parser")
 
-                    # PDFへのリンクを探す
                     # 六戸町のサイトでは [PDF：...KB] というテキストが含まれるリンクが多い
                     links = soup.find_all("a")
+                    pdf_links = self._find_pdf_links(
+                        links=links,
+                        target_url=target_url,
+                    )
+                    self._write_info(
+                        f"PDFリンク検出: {target_url} から {len(pdf_links)} 件"
+                    )
 
-                    pdf_count = 0
-                    for link in links:
-                        href = link.get("href")
-                        if not href:
+                    downloaded_count = 0
+                    skipped_count = 0
+                    for index, pdf_link in enumerate(pdf_links, start=1):
+                        filename = pdf_link["filename"]
+                        if filename in downloaded_filenames:
+                            filename = self._get_unique_filename(
+                                filename=filename,
+                                downloaded_filenames=downloaded_filenames,
+                            )
+
+                        save_path = save_dir / filename
+                        if save_path.exists():
+                            skipped_count += 1
+                            downloaded_filenames.add(filename)
+                            self._write_info(
+                                f"進捗 {index}/{len(pdf_links)}: スキップ (保存済み): {save_path}"
+                            )
                             continue
 
-                        # URLに .pdf が含まれるか、リンクテキストに [PDF という文字列が含まれる場合
-                        text = link.get_text()
-                        if ".pdf" in href.lower() or "[pdf" in text.lower():
-                            pdf_url = urljoin(self._get_base_url(target_url), href)
+                        self._write_info(
+                            f"進捗 {index}/{len(pdf_links)}: ダウンロード中: {pdf_link['url']}"
+                        )
+                        pdf_response, request_count = self._get_with_delay(
+                            url=pdf_link["url"],
+                            delay_seconds=options["delay"],
+                            request_count=request_count,
+                        )
+                        pdf_response.raise_for_status()
 
-                            # ファイル名を取得
-                            filename = self._get_filename(text=text, href=href)
-                            if not filename.lower().endswith(".pdf"):
-                                filename += ".pdf"
+                        with open(save_path, "wb") as f:
+                            f.write(pdf_response.content)
 
-                            if filename in downloaded_filenames:
-                                filename = self._get_unique_filename(
-                                    filename=filename,
-                                    downloaded_filenames=downloaded_filenames,
-                                )
+                        downloaded_filenames.add(filename)
+                        downloaded_count += 1
+                        self._write_success(f"保存完了: {save_path}")
 
-                            # 保存パス
-                            save_path = save_dir / filename
-                            if save_path.exists():
-                                downloaded_filenames.add(filename)
-                                self.stdout.write(f"スキップ (保存済み): {save_path}")
-                                continue
-
-                            # ダウンロード
-                            self.stdout.write(f"ダウンロード中: {pdf_url}")
-                            pdf_response, request_count = self._get_with_delay(
-                                url=pdf_url,
-                                delay_seconds=options["delay"],
-                                request_count=request_count,
-                            )
-                            pdf_response.raise_for_status()
-
-                            with open(save_path, "wb") as f:
-                                f.write(pdf_response.content)
-
-                            downloaded_filenames.add(filename)
-                            pdf_count += 1
-                            self.stdout.write(
-                                self.style.SUCCESS(f"保存完了: {save_path}")
-                            )
-
-                    self.stdout.write(f"合計 {pdf_count} 件のPDFを処理しました。")
+                    self._write_info(
+                        f"処理完了: ダウンロード {downloaded_count} 件, スキップ {skipped_count} 件"
+                    )
 
                 except Exception as e:
-                    self.stdout.write(
-                        self.style.ERROR(f"エラーが発生しました ({target_url}): {e}")
-                    )
+                    self._write_error(f"エラーが発生しました ({target_url}): {e}")
+            self._write_info("六戸町PDFダウンロード終了")
         finally:
             lock_path.unlink(missing_ok=True)
 
-    def _get_save_dir(self, save_dir: str | None) -> Path:
+    @staticmethod
+    def _get_save_dir(save_dir: str | None) -> Path:
         if save_dir:
             return Path(save_dir)
-        return Path(settings.MEDIA_ROOT) / "jp_stocks" / "rokunohe_pdf_backnumbers"
+        return Path(settings.MEDIA_ROOT) / "jp_stocks" / "rokunohe_pdf_back_numbers"
 
-    def _get_base_url(self, target_url: str) -> str:
+    @staticmethod
+    def _get_base_url(target_url: str) -> str:
         if target_url.endswith("/") or target_url.endswith(".html"):
             return target_url
         return f"{target_url}/"
 
-    def _get_filename(self, text: str, href: str) -> str:
-        filename = re.sub(r"\[pdf.*?\]", "", text, flags=re.IGNORECASE).strip()
+    @staticmethod
+    def _get_filename(text: str, href: str) -> str:
+        filename = re.sub(r"\[pdf.*?]", "", text, flags=re.IGNORECASE).strip()
         filename = re.sub(r'[\\/:*?"<>|]', "_", filename)
         filename = re.sub(r"\s+", "_", filename)
         if filename:
             return filename
         return Path(href).name
 
-    def _get_unique_filename(
-        self, filename: str, downloaded_filenames: set[str]
-    ) -> str:
+    @staticmethod
+    def _get_unique_filename(filename: str, downloaded_filenames: set[str]) -> str:
         path = Path(filename)
         stem = path.stem
         suffix = path.suffix
@@ -150,16 +154,54 @@ class Command(BaseCommand):
             unique_filename = f"{stem}_{number}{suffix}"
         return unique_filename
 
+    @staticmethod
     def _get_with_delay(
-        self, url: str, delay_seconds: float, request_count: int
+        url: str, delay_seconds: float, request_count: int
     ) -> tuple[requests.Response, int]:
         if request_count > 0 and delay_seconds > 0:
             time.sleep(delay_seconds)
         return requests.get(url, timeout=30), request_count + 1
 
-    def _create_lock(self, lock_path: Path) -> None:
+    @staticmethod
+    def _create_lock(lock_path: Path) -> None:
         try:
             with open(lock_path, "x", encoding="utf-8") as f:
                 f.write("running")
         except FileExistsError as e:
             raise CommandError("六戸町PDFダウンロードは既に実行中です。") from e
+
+    @staticmethod
+    def _find_pdf_links(links, target_url: str) -> list[dict[str, str]]:
+        pdf_links = []
+        for link in links:
+            href = link.get("href")
+            if not href:
+                continue
+
+            text = link.get_text()
+            if ".pdf" not in href.lower() and "[pdf" not in text.lower():
+                continue
+
+            filename = Command._get_filename(text=text, href=href)
+            if not filename.lower().endswith(".pdf"):
+                filename += ".pdf"
+
+            pdf_links.append(
+                {
+                    "filename": filename,
+                    "url": urljoin(Command._get_base_url(target_url), href),
+                }
+            )
+        return pdf_links
+
+    def _write_info(self, message: str) -> None:
+        logger.info(message)
+        self.stdout.write(message)
+
+    def _write_success(self, message: str) -> None:
+        logger.info(message)
+        self.stdout.write(self.style.SUCCESS(message))
+
+    def _write_error(self, message: str) -> None:
+        logger.error(message)
+        self.stdout.write(self.style.ERROR(message))

--- a/jp_stocks/management/commands/rokunohe_pdf_download.py
+++ b/jp_stocks/management/commands/rokunohe_pdf_download.py
@@ -1,0 +1,99 @@
+import os
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "六戸町の会議録PDFを一括ダウンロードします"
+
+    def handle(self, *args, **options):
+        # 現行ページとバックナンバーページのURL
+        target_urls = [
+            "https://www.town.rokunohe.aomori.jp/docs/2023051900005",
+        ]
+
+        # 保存先ディレクトリ
+        save_dir = "rokunohe_pdf_backnumbers"
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+            self.stdout.write(f"ディレクトリを作成しました: {save_dir}")
+
+        downloaded_filenames = set()
+
+        for target_url in target_urls:
+            self.stdout.write(f"処理中: {target_url}")
+            try:
+                response = requests.get(target_url)
+                response.raise_for_status()
+                # エンコーディングを自動検出（Shift_JISなどの場合があるため）
+                response.encoding = response.apparent_encoding
+
+                soup = BeautifulSoup(response.text, "html.parser")
+
+                # PDFへのリンクを探す
+                # 六戸町のサイトでは [PDF：...KB] というテキストが含まれるリンクが多い
+                links = soup.find_all("a")
+
+                pdf_count = 0
+                for link in links:
+                    href = link.get("href")
+                    if not href:
+                        continue
+
+                    # URLが .pdf で終わるか、リンクテキストに [PDF という文字列が含まれる場合
+                    text = link.get_text()
+                    if href.lower().endswith(".pdf") or "[PDF" in text:
+                        pdf_url = urljoin(target_url, href)
+
+                        # 404対策: リンクが相対パスで /docs/2023051900005 からの相対ではなく
+                        # /docs/ からの相対である可能性があるため、調整を試みる
+                        # web_searchの結果では file_contents/071209.pdf となっていた
+                        # 実際のURLが https://www.town.rokunohe.aomori.jp/docs/file_contents/071209.pdf なら 404
+                        # おそらく https://www.town.rokunohe.aomori.jp/file_contents/071209.pdf か
+                        # https://www.town.rokunohe.aomori.jp/docs/2023051900005/file_contents/071209.pdf
+                        # web_searchの1番目の結果のURLは https://www.town.rokunohe.aomori.jp/docs/2023051900005
+                        # そこでのリンクが file_contents/071209.pdf なら、
+                        # 通常は https://www.town.rokunohe.aomori.jp/docs/file_contents/071209.pdf になる
+                        # しかし、もし /docs/2023051900005/ (末尾スラッシュあり) なら
+                        # https://www.town.rokunohe.aomori.jp/docs/2023051900005/file_contents/071209.pdf になる
+
+                        if not target_url.endswith("/"):
+                            # スラッシュがない場合、urljoinは最後のコンポーネントをファイルとみなして置き換える
+                            # そのため https://www.town.rokunohe.aomori.jp/docs/file_contents/071209.pdf になっていた
+                            # 期待されるのは https://www.town.rokunohe.aomori.jp/docs/2023051900005/file_contents/071209.pdf
+                            # またはドメイン直下
+                            pdf_url = urljoin(target_url + "/", href)
+
+                        # ファイル名を取得
+                        filename = os.path.basename(href)
+                        if not filename.lower().endswith(".pdf"):
+                            filename += ".pdf"
+
+                        if filename in downloaded_filenames:
+                            self.stdout.write(f"スキップ (重複): {filename}")
+                            continue
+
+                        # 保存パス
+                        save_path = os.path.join(save_dir, filename)
+
+                        # ダウンロード
+                        self.stdout.write(f"ダウンロード中: {pdf_url}")
+                        pdf_response = requests.get(pdf_url)
+                        pdf_response.raise_for_status()
+
+                        with open(save_path, "wb") as f:
+                            f.write(pdf_response.content)
+
+                        downloaded_filenames.add(filename)
+                        pdf_count += 1
+                        self.stdout.write(self.style.SUCCESS(f"保存完了: {save_path}"))
+
+                self.stdout.write(f"合計 {pdf_count} 件のPDFを処理しました。")
+
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(f"エラーが発生しました ({target_url}): {e}")
+                )

--- a/jp_stocks/management/commands/rokunohe_pdf_download.py
+++ b/jp_stocks/management/commands/rokunohe_pdf_download.py
@@ -1,6 +1,6 @@
-import logging
 import re
 import time
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -8,8 +8,6 @@ import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-
-logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -85,12 +83,15 @@ class Command(BaseCommand):
                                 downloaded_filenames=downloaded_filenames,
                             )
 
-                        save_path = save_dir / filename
-                        if save_path.exists():
+                        existing_dated_path = self._get_existing_dated_path(
+                            save_dir=save_dir,
+                            filename=filename,
+                        )
+                        if existing_dated_path:
                             skipped_count += 1
                             downloaded_filenames.add(filename)
                             self._write_info(
-                                f"進捗 {index}/{len(pdf_links)}: スキップ (保存済み): {save_path}"
+                                f"進捗 {index}/{len(pdf_links)}: スキップ (保存済み): {existing_dated_path}"
                             )
                             continue
 
@@ -103,6 +104,19 @@ class Command(BaseCommand):
                             request_count=request_count,
                         )
                         pdf_response.raise_for_status()
+
+                        filename = self._prepend_last_modified_date(
+                            filename=filename,
+                            response=pdf_response,
+                        )
+                        save_path = save_dir / filename
+                        if save_path.exists():
+                            skipped_count += 1
+                            downloaded_filenames.add(filename)
+                            self._write_info(
+                                f"進捗 {index}/{len(pdf_links)}: スキップ (保存済み): {save_path}"
+                            )
+                            continue
 
                         with open(save_path, "wb") as f:
                             f.write(pdf_response.content)
@@ -171,6 +185,29 @@ class Command(BaseCommand):
             raise CommandError("六戸町PDFダウンロードは既に実行中です。") from e
 
     @staticmethod
+    def _prepend_last_modified_date(filename: str, response: requests.Response) -> str:
+        last_modified = response.headers.get("Last-Modified")
+        if not last_modified:
+            return filename
+
+        try:
+            updated_date = parsedate_to_datetime(last_modified).strftime("%Y%m%d")
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return filename
+
+        if filename.startswith(f"{updated_date}_"):
+            return filename
+        return f"{updated_date}_{filename}"
+
+    @staticmethod
+    def _get_existing_dated_path(save_dir: Path, filename: str) -> Path | None:
+        dated_filename_pattern = re.compile(rf"^\d{{8}}_{re.escape(filename)}$")
+        for path in save_dir.glob(f"*_{filename}"):
+            if dated_filename_pattern.match(path.name):
+                return path
+        return None
+
+    @staticmethod
     def _find_pdf_links(links, target_url: str) -> list[dict[str, str]]:
         pdf_links = []
         for link in links:
@@ -195,13 +232,10 @@ class Command(BaseCommand):
         return pdf_links
 
     def _write_info(self, message: str) -> None:
-        logger.info(message)
         self.stdout.write(message)
 
     def _write_success(self, message: str) -> None:
-        logger.info(message)
         self.stdout.write(self.style.SUCCESS(message))
 
     def _write_error(self, message: str) -> None:
-        logger.error(message)
         self.stdout.write(self.style.ERROR(message))

--- a/jp_stocks/management/commands/rokunohe_pdf_download.py
+++ b/jp_stocks/management/commands/rokunohe_pdf_download.py
@@ -1,11 +1,12 @@
 import re
+import time
 from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -16,6 +17,12 @@ class Command(BaseCommand):
             "--save-dir",
             default=None,
             help="PDFの保存先ディレクトリ。未指定時は media/jp_stocks/rokunohe_pdf_backnumbers に保存します。",
+        )
+        parser.add_argument(
+            "--delay",
+            default=2.0,
+            type=float,
+            help="外部サイトへのリクエスト間隔秒数。未指定時は2秒待機します。",
         )
 
     def handle(self, *args, **options):
@@ -31,65 +38,86 @@ class Command(BaseCommand):
             save_dir.mkdir(parents=True)
             self.stdout.write(f"ディレクトリを作成しました: {save_dir}")
 
-        downloaded_filenames = set()
+        lock_path = save_dir / ".rokunohe_pdf_download.lock"
+        self._create_lock(lock_path)
 
-        for target_url in target_urls:
-            self.stdout.write(f"処理中: {target_url}")
-            try:
-                response = requests.get(target_url, timeout=30)
-                response.raise_for_status()
-                # エンコーディングを自動検出（Shift_JISなどの場合があるため）
-                response.encoding = response.apparent_encoding
+        try:
+            downloaded_filenames = set()
+            request_count = 0
 
-                soup = BeautifulSoup(response.text, "html.parser")
+            for target_url in target_urls:
+                self.stdout.write(f"処理中: {target_url}")
+                try:
+                    response, request_count = self._get_with_delay(
+                        url=target_url,
+                        delay_seconds=options["delay"],
+                        request_count=request_count,
+                    )
+                    response.raise_for_status()
+                    # エンコーディングを自動検出（Shift_JISなどの場合があるため）
+                    response.encoding = response.apparent_encoding
 
-                # PDFへのリンクを探す
-                # 六戸町のサイトでは [PDF：...KB] というテキストが含まれるリンクが多い
-                links = soup.find_all("a")
+                    soup = BeautifulSoup(response.text, "html.parser")
 
-                pdf_count = 0
-                for link in links:
-                    href = link.get("href")
-                    if not href:
-                        continue
+                    # PDFへのリンクを探す
+                    # 六戸町のサイトでは [PDF：...KB] というテキストが含まれるリンクが多い
+                    links = soup.find_all("a")
 
-                    # URLに .pdf が含まれるか、リンクテキストに [PDF という文字列が含まれる場合
-                    text = link.get_text()
-                    if ".pdf" in href.lower() or "[pdf" in text.lower():
-                        pdf_url = urljoin(self._get_base_url(target_url), href)
+                    pdf_count = 0
+                    for link in links:
+                        href = link.get("href")
+                        if not href:
+                            continue
 
-                        # ファイル名を取得
-                        filename = self._get_filename(text=text, href=href)
-                        if not filename.lower().endswith(".pdf"):
-                            filename += ".pdf"
+                        # URLに .pdf が含まれるか、リンクテキストに [PDF という文字列が含まれる場合
+                        text = link.get_text()
+                        if ".pdf" in href.lower() or "[pdf" in text.lower():
+                            pdf_url = urljoin(self._get_base_url(target_url), href)
 
-                        if filename in downloaded_filenames:
-                            filename = self._get_unique_filename(
-                                filename=filename,
-                                downloaded_filenames=downloaded_filenames,
+                            # ファイル名を取得
+                            filename = self._get_filename(text=text, href=href)
+                            if not filename.lower().endswith(".pdf"):
+                                filename += ".pdf"
+
+                            if filename in downloaded_filenames:
+                                filename = self._get_unique_filename(
+                                    filename=filename,
+                                    downloaded_filenames=downloaded_filenames,
+                                )
+
+                            # 保存パス
+                            save_path = save_dir / filename
+                            if save_path.exists():
+                                downloaded_filenames.add(filename)
+                                self.stdout.write(f"スキップ (保存済み): {save_path}")
+                                continue
+
+                            # ダウンロード
+                            self.stdout.write(f"ダウンロード中: {pdf_url}")
+                            pdf_response, request_count = self._get_with_delay(
+                                url=pdf_url,
+                                delay_seconds=options["delay"],
+                                request_count=request_count,
+                            )
+                            pdf_response.raise_for_status()
+
+                            with open(save_path, "wb") as f:
+                                f.write(pdf_response.content)
+
+                            downloaded_filenames.add(filename)
+                            pdf_count += 1
+                            self.stdout.write(
+                                self.style.SUCCESS(f"保存完了: {save_path}")
                             )
 
-                        # 保存パス
-                        save_path = save_dir / filename
+                    self.stdout.write(f"合計 {pdf_count} 件のPDFを処理しました。")
 
-                        # ダウンロード
-                        self.stdout.write(f"ダウンロード中: {pdf_url}")
-                        pdf_response = requests.get(pdf_url, timeout=30)
-                        pdf_response.raise_for_status()
-
-                        with open(save_path, "wb") as f:
-                            f.write(pdf_response.content)
-
-                        downloaded_filenames.add(filename)
-                        pdf_count += 1
-                        self.stdout.write(self.style.SUCCESS(f"保存完了: {save_path}"))
-
-                self.stdout.write(f"合計 {pdf_count} 件のPDFを処理しました。")
-
-            except Exception as e:
-                self.stdout.write(
-                    self.style.ERROR(f"エラーが発生しました ({target_url}): {e}")
-                )
+                except Exception as e:
+                    self.stdout.write(
+                        self.style.ERROR(f"エラーが発生しました ({target_url}): {e}")
+                    )
+        finally:
+            lock_path.unlink(missing_ok=True)
 
     def _get_save_dir(self, save_dir: str | None) -> Path:
         if save_dir:
@@ -121,3 +149,17 @@ class Command(BaseCommand):
             number += 1
             unique_filename = f"{stem}_{number}{suffix}"
         return unique_filename
+
+    def _get_with_delay(
+        self, url: str, delay_seconds: float, request_count: int
+    ) -> tuple[requests.Response, int]:
+        if request_count > 0 and delay_seconds > 0:
+            time.sleep(delay_seconds)
+        return requests.get(url, timeout=30), request_count + 1
+
+    def _create_lock(self, lock_path: Path) -> None:
+        try:
+            with open(lock_path, "x", encoding="utf-8") as f:
+                f.write("running")
+        except FileExistsError as e:
+            raise CommandError("六戸町PDFダウンロードは既に実行中です。") from e

--- a/jp_stocks/management/commands/rokunohe_pdf_download.py
+++ b/jp_stocks/management/commands/rokunohe_pdf_download.py
@@ -1,24 +1,34 @@
-import os
+import re
+from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
     help = "六戸町の会議録PDFを一括ダウンロードします"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--save-dir",
+            default=None,
+            help="PDFの保存先ディレクトリ。未指定時は media/jp_stocks/rokunohe_pdf_backnumbers に保存します。",
+        )
+
     def handle(self, *args, **options):
         # 現行ページとバックナンバーページのURL
         target_urls = [
-            "https://www.town.rokunohe.aomori.jp/docs/2023051900005",
+            "https://www.town.rokunohe.aomori.jp/docs/2023051900005/",
+            "https://www.town.rokunohe.aomori.jp/docs/2023051900005/chousei_cyougikai_kaigiroku_kako.html",
         ]
 
         # 保存先ディレクトリ
-        save_dir = "rokunohe_pdf_backnumbers"
-        if not os.path.exists(save_dir):
-            os.makedirs(save_dir)
+        save_dir = self._get_save_dir(options["save_dir"])
+        if not save_dir.exists():
+            save_dir.mkdir(parents=True)
             self.stdout.write(f"ディレクトリを作成しました: {save_dir}")
 
         downloaded_filenames = set()
@@ -26,7 +36,7 @@ class Command(BaseCommand):
         for target_url in target_urls:
             self.stdout.write(f"処理中: {target_url}")
             try:
-                response = requests.get(target_url)
+                response = requests.get(target_url, timeout=30)
                 response.raise_for_status()
                 # エンコーディングを自動検出（Shift_JISなどの場合があるため）
                 response.encoding = response.apparent_encoding
@@ -43,45 +53,28 @@ class Command(BaseCommand):
                     if not href:
                         continue
 
-                    # URLが .pdf で終わるか、リンクテキストに [PDF という文字列が含まれる場合
+                    # URLに .pdf が含まれるか、リンクテキストに [PDF という文字列が含まれる場合
                     text = link.get_text()
-                    if href.lower().endswith(".pdf") or "[PDF" in text:
-                        pdf_url = urljoin(target_url, href)
-
-                        # 404対策: リンクが相対パスで /docs/2023051900005 からの相対ではなく
-                        # /docs/ からの相対である可能性があるため、調整を試みる
-                        # web_searchの結果では file_contents/071209.pdf となっていた
-                        # 実際のURLが https://www.town.rokunohe.aomori.jp/docs/file_contents/071209.pdf なら 404
-                        # おそらく https://www.town.rokunohe.aomori.jp/file_contents/071209.pdf か
-                        # https://www.town.rokunohe.aomori.jp/docs/2023051900005/file_contents/071209.pdf
-                        # web_searchの1番目の結果のURLは https://www.town.rokunohe.aomori.jp/docs/2023051900005
-                        # そこでのリンクが file_contents/071209.pdf なら、
-                        # 通常は https://www.town.rokunohe.aomori.jp/docs/file_contents/071209.pdf になる
-                        # しかし、もし /docs/2023051900005/ (末尾スラッシュあり) なら
-                        # https://www.town.rokunohe.aomori.jp/docs/2023051900005/file_contents/071209.pdf になる
-
-                        if not target_url.endswith("/"):
-                            # スラッシュがない場合、urljoinは最後のコンポーネントをファイルとみなして置き換える
-                            # そのため https://www.town.rokunohe.aomori.jp/docs/file_contents/071209.pdf になっていた
-                            # 期待されるのは https://www.town.rokunohe.aomori.jp/docs/2023051900005/file_contents/071209.pdf
-                            # またはドメイン直下
-                            pdf_url = urljoin(target_url + "/", href)
+                    if ".pdf" in href.lower() or "[pdf" in text.lower():
+                        pdf_url = urljoin(self._get_base_url(target_url), href)
 
                         # ファイル名を取得
-                        filename = os.path.basename(href)
+                        filename = self._get_filename(text=text, href=href)
                         if not filename.lower().endswith(".pdf"):
                             filename += ".pdf"
 
                         if filename in downloaded_filenames:
-                            self.stdout.write(f"スキップ (重複): {filename}")
-                            continue
+                            filename = self._get_unique_filename(
+                                filename=filename,
+                                downloaded_filenames=downloaded_filenames,
+                            )
 
                         # 保存パス
-                        save_path = os.path.join(save_dir, filename)
+                        save_path = save_dir / filename
 
                         # ダウンロード
                         self.stdout.write(f"ダウンロード中: {pdf_url}")
-                        pdf_response = requests.get(pdf_url)
+                        pdf_response = requests.get(pdf_url, timeout=30)
                         pdf_response.raise_for_status()
 
                         with open(save_path, "wb") as f:
@@ -97,3 +90,34 @@ class Command(BaseCommand):
                 self.stdout.write(
                     self.style.ERROR(f"エラーが発生しました ({target_url}): {e}")
                 )
+
+    def _get_save_dir(self, save_dir: str | None) -> Path:
+        if save_dir:
+            return Path(save_dir)
+        return Path(settings.MEDIA_ROOT) / "jp_stocks" / "rokunohe_pdf_backnumbers"
+
+    def _get_base_url(self, target_url: str) -> str:
+        if target_url.endswith("/") or target_url.endswith(".html"):
+            return target_url
+        return f"{target_url}/"
+
+    def _get_filename(self, text: str, href: str) -> str:
+        filename = re.sub(r"\[pdf.*?\]", "", text, flags=re.IGNORECASE).strip()
+        filename = re.sub(r'[\\/:*?"<>|]', "_", filename)
+        filename = re.sub(r"\s+", "_", filename)
+        if filename:
+            return filename
+        return Path(href).name
+
+    def _get_unique_filename(
+        self, filename: str, downloaded_filenames: set[str]
+    ) -> str:
+        path = Path(filename)
+        stem = path.stem
+        suffix = path.suffix
+        number = 2
+        unique_filename = f"{stem}_{number}{suffix}"
+        while unique_filename in downloaded_filenames:
+            number += 1
+            unique_filename = f"{stem}_{number}{suffix}"
+        return unique_filename

--- a/jp_stocks/templates/jp_stocks/index.html
+++ b/jp_stocks/templates/jp_stocks/index.html
@@ -10,6 +10,12 @@
             </ol>
         </nav>
 
+        {% if messages %}
+            {% for message in messages %}
+                <div class="alert alert-info">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+
         <div class="row g-4">
             <!-- Hero -->
             <div class="col-12">
@@ -20,7 +26,18 @@
                     <div class="d-flex flex-wrap gap-2">
                         <a href="{% url 'jpn:create_order' %}" class="btn btn-outline-primary">注文を作成</a>
                         <a href="{% url 'jpn:order_book' %}" class="btn btn-outline-secondary">板情報を見る</a>
+                        {% if user.is_superuser %}
+                            <form method="post" action="{% url 'jpn:rokunohe_pdf_download' %}">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-outline-success">六戸町会議録PDF保存</button>
+                            </form>
+                        {% else %}
+                            <button class="btn btn-outline-secondary disabled">六戸町会議録PDF保存</button>
+                        {% endif %}
                     </div>
+                    {% if not user.is_superuser %}
+                        <p class="small text-muted mt-2 mb-0">管理者権限が必要なボタンは無効化されています</p>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/jp_stocks/tests.py
+++ b/jp_stocks/tests.py
@@ -214,11 +214,16 @@ class RokunohePdfDownloadCommandTest(TestCase):
                 ],
             ), patch(
                 "jp_stocks.management.commands.rokunohe_pdf_download.time.sleep"
-            ) as sleep_mock:
+            ) as sleep_mock, self.assertLogs(
+                "jp_stocks.management.commands.rokunohe_pdf_download",
+                level="INFO",
+            ) as logs:
                 call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0.1)
 
         self.assertGreaterEqual(sleep_mock.call_count, 2)
         sleep_mock.assert_any_call(0.1)
+        self.assertIn("進捗 1/2: ダウンロード中", "\n".join(logs.output))
+        self.assertIn("進捗 2/2: ダウンロード中", "\n".join(logs.output))
 
     def test_skips_existing_pdf_file(self):
         """

--- a/jp_stocks/tests.py
+++ b/jp_stocks/tests.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
@@ -206,7 +207,11 @@ class RokunohePdfDownloadCommandTest(TestCase):
         first_page_response = self._create_response(
             '<a href="file1.pdf">会議録1 [PDF]</a><a href="file2.pdf">会議録2 [PDF]</a>'
         )
-        pdf_response = self._create_response("", content=b"%PDF")
+        pdf_response = self._create_response(
+            "",
+            content=b"%PDF",
+            headers={"Last-Modified": "Wed, 25 Feb 2026 01:55:27 GMT"},
+        )
         second_page_response = self._create_response("")
 
         with TemporaryDirectory() as temp_dir:
@@ -220,16 +225,19 @@ class RokunohePdfDownloadCommandTest(TestCase):
                 ],
             ), patch(
                 "jp_stocks.management.commands.rokunohe_pdf_download.time.sleep"
-            ) as sleep_mock, self.assertLogs(
-                "jp_stocks.management.commands.rokunohe_pdf_download",
-                level="INFO",
-            ) as logs:
-                call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0.1)
+            ) as sleep_mock:
+                stdout = StringIO()
+                call_command(
+                    "rokunohe_pdf_download",
+                    save_dir=temp_dir,
+                    delay=0.1,
+                    stdout=stdout,
+                )
 
         self.assertGreaterEqual(sleep_mock.call_count, 2)
         sleep_mock.assert_any_call(0.1)
-        self.assertIn("進捗 1/2: ダウンロード中", "\n".join(logs.output))
-        self.assertIn("進捗 2/2: ダウンロード中", "\n".join(logs.output))
+        self.assertIn("進捗 1/2: ダウンロード中", stdout.getvalue())
+        self.assertIn("進捗 2/2: ダウンロード中", stdout.getvalue())
 
     def test_skips_existing_pdf_file(self):
         """
@@ -244,7 +252,7 @@ class RokunohePdfDownloadCommandTest(TestCase):
         second_page_response = self._create_response("")
 
         with TemporaryDirectory() as temp_dir:
-            existing_pdf_path = Path(temp_dir) / "保存済み.pdf"
+            existing_pdf_path = Path(temp_dir) / "20260225_保存済み.pdf"
             existing_pdf_path.write_bytes(b"%PDF")
 
             with patch(
@@ -254,6 +262,32 @@ class RokunohePdfDownloadCommandTest(TestCase):
                 call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0)
 
         self.assertEqual(2, get_mock.call_count)
+
+    def test_prepends_last_modified_date_to_pdf_filename(self):
+        """
+        シナリオ:
+        - 入力: Last-Modifiedヘッダを持つPDFレスポンス。
+        - 処理: 六戸町会議録PDFダウンロードコマンドを実行する。
+        - 期待値: PDFがYYYYMMDD_ファイル名.pdf形式で保存されること。
+        """
+        first_page_response = self._create_response(
+            '<a href="dated.pdf">会議録 [PDF]</a>'
+        )
+        pdf_response = self._create_response(
+            "",
+            content=b"%PDF",
+            headers={"Last-Modified": "Wed, 25 Feb 2026 01:55:27 GMT"},
+        )
+        second_page_response = self._create_response("")
+
+        with TemporaryDirectory() as temp_dir:
+            with patch(
+                "jp_stocks.management.commands.rokunohe_pdf_download.requests.get",
+                side_effect=[first_page_response, pdf_response, second_page_response],
+            ):
+                call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0)
+
+            self.assertTrue((Path(temp_dir) / "20260225_会議録.pdf").exists())
 
     def test_rejects_parallel_execution_with_lock_file(self):
         """
@@ -270,10 +304,13 @@ class RokunohePdfDownloadCommandTest(TestCase):
                 call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0)
 
     @staticmethod
-    def _create_response(text: str, content: bytes = b"") -> Mock:
+    def _create_response(
+        text: str, content: bytes = b"", headers: dict[str, str] | None = None
+    ) -> Mock:
         response = Mock()
         response.text = text
         response.content = content
+        response.headers = headers or {}
         response.apparent_encoding = "utf-8"
         response.raise_for_status = Mock()
         return response

--- a/jp_stocks/tests.py
+++ b/jp_stocks/tests.py
@@ -1,4 +1,8 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
 from jp_stocks.domain.service.order import OrderBookService
 from jp_stocks.domain.valueobject.order import OrderPair
@@ -94,3 +98,65 @@ class OrderBookServiceTest(TestCase):
             OrderPair(price=105, sell_quantity=10, buy_quantity=0),
         ]
         self.assertEqual(result, expected_result)
+
+
+class RokunohePdfDownloadViewTest(TestCase):
+    def test_superuser_can_start_pdf_download(self):
+        """
+        シナリオ:
+        - 入力: superuserでログインした状態。
+        - 処理: 六戸町会議録PDF保存ボタンのPOST先へリクエストする。
+        - 期待値: 管理コマンドが呼び出され、トップページへリダイレクトされること。
+        """
+        user = User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        with patch("jp_stocks.views.call_command") as call_command_mock:
+            response = self.client.post(reverse("jpn:rokunohe_pdf_download"))
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(reverse("jpn:index"), response.url)
+        call_command_mock.assert_called_once_with("rokunohe_pdf_download")
+
+    def test_non_superuser_cannot_start_pdf_download(self):
+        """
+        シナリオ:
+        - 入力: 一般ユーザーでログインした状態。
+        - 処理: 六戸町会議録PDF保存ボタンのPOST先へリクエストする。
+        - 期待値: 403が返り、管理コマンドは呼び出されないこと。
+        """
+        user = User.objects.create_user(
+            username="user",
+            email="user@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        with patch("jp_stocks.views.call_command") as call_command_mock:
+            response = self.client.post(reverse("jpn:rokunohe_pdf_download"))
+
+        self.assertEqual(403, response.status_code)
+        call_command_mock.assert_not_called()
+
+    def test_non_superuser_sees_disabled_pdf_download_button(self):
+        """
+        シナリオ:
+        - 入力: 一般ユーザーでログインした状態。
+        - 処理: jp_stocksトップページを表示する。
+        - 期待値: 六戸町会議録PDF保存ボタンがdisabledとして表示されること。
+        """
+        user = User.objects.create_user(
+            username="user",
+            email="user@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("jpn:index"))
+
+        self.assertContains(response, "六戸町会議録PDF保存")
+        self.assertContains(response, "disabled")

--- a/jp_stocks/tests.py
+++ b/jp_stocks/tests.py
@@ -263,7 +263,8 @@ class RokunohePdfDownloadCommandTest(TestCase):
             with self.assertRaises(CommandError):
                 call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0)
 
-    def _create_response(self, text: str, content: bytes = b"") -> Mock:
+    @staticmethod
+    def _create_response(text: str, content: bytes = b"") -> Mock:
         response = Mock()
         response.text = text
         response.content = content

--- a/jp_stocks/tests.py
+++ b/jp_stocks/tests.py
@@ -1,6 +1,10 @@
-from unittest.mock import patch
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 from django.urls import reverse
 
@@ -142,6 +146,29 @@ class RokunohePdfDownloadViewTest(TestCase):
         self.assertEqual(403, response.status_code)
         call_command_mock.assert_not_called()
 
+    def test_superuser_redirects_when_pdf_download_is_already_running(self):
+        """
+        シナリオ:
+        - 入力: superuserでログインし、PDF保存処理が既に実行中の状態。
+        - 処理: 六戸町会議録PDF保存ボタンのPOST先へリクエストする。
+        - 期待値: 例外で500にせず、トップページへリダイレクトされること。
+        """
+        user = User.objects.create_superuser(
+            username="admin2",
+            email="admin2@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        with patch(
+            "jp_stocks.views.call_command",
+            side_effect=CommandError("六戸町PDFダウンロードは既に実行中です。"),
+        ):
+            response = self.client.post(reverse("jpn:rokunohe_pdf_download"))
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(reverse("jpn:index"), response.url)
+
     def test_non_superuser_sees_disabled_pdf_download_button(self):
         """
         シナリオ:
@@ -160,3 +187,81 @@ class RokunohePdfDownloadViewTest(TestCase):
 
         self.assertContains(response, "六戸町会議録PDF保存")
         self.assertContains(response, "disabled")
+
+
+class RokunohePdfDownloadCommandTest(TestCase):
+    def test_waits_between_external_requests(self):
+        """
+        シナリオ:
+        - 入力: PDFリンクを2件含むHTMLレスポンスと、リクエスト間隔0.1秒。
+        - 処理: 六戸町会議録PDFダウンロードコマンドを実行する。
+        - 期待値: 2件目以降の外部リクエスト前に待機処理が呼び出されること。
+        """
+        first_page_response = self._create_response(
+            '<a href="file1.pdf">会議録1 [PDF]</a><a href="file2.pdf">会議録2 [PDF]</a>'
+        )
+        pdf_response = self._create_response("", content=b"%PDF")
+        second_page_response = self._create_response("")
+
+        with TemporaryDirectory() as temp_dir:
+            with patch(
+                "jp_stocks.management.commands.rokunohe_pdf_download.requests.get",
+                side_effect=[
+                    first_page_response,
+                    pdf_response,
+                    pdf_response,
+                    second_page_response,
+                ],
+            ), patch(
+                "jp_stocks.management.commands.rokunohe_pdf_download.time.sleep"
+            ) as sleep_mock:
+                call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0.1)
+
+        self.assertGreaterEqual(sleep_mock.call_count, 2)
+        sleep_mock.assert_any_call(0.1)
+
+    def test_skips_existing_pdf_file(self):
+        """
+        シナリオ:
+        - 入力: 保存済みPDFと同じファイル名になるPDFリンクを含むHTMLレスポンス。
+        - 処理: 六戸町会議録PDFダウンロードコマンドを実行する。
+        - 期待値: 保存済みPDFは再ダウンロードされず、HTML取得のみ実行されること。
+        """
+        first_page_response = self._create_response(
+            '<a href="exists.pdf">保存済み [PDF]</a>'
+        )
+        second_page_response = self._create_response("")
+
+        with TemporaryDirectory() as temp_dir:
+            existing_pdf_path = Path(temp_dir) / "保存済み.pdf"
+            existing_pdf_path.write_bytes(b"%PDF")
+
+            with patch(
+                "jp_stocks.management.commands.rokunohe_pdf_download.requests.get",
+                side_effect=[first_page_response, second_page_response],
+            ) as get_mock:
+                call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0)
+
+        self.assertEqual(2, get_mock.call_count)
+
+    def test_rejects_parallel_execution_with_lock_file(self):
+        """
+        シナリオ:
+        - 入力: 保存先に実行中を示すロックファイルが存在する状態。
+        - 処理: 六戸町会議録PDFダウンロードコマンドを実行する。
+        - 期待値: CommandErrorが発生し、並行実行が拒否されること。
+        """
+        with TemporaryDirectory() as temp_dir:
+            lock_path = Path(temp_dir) / ".rokunohe_pdf_download.lock"
+            lock_path.write_text("running", encoding="utf-8")
+
+            with self.assertRaises(CommandError):
+                call_command("rokunohe_pdf_download", save_dir=temp_dir, delay=0)
+
+    def _create_response(self, text: str, content: bytes = b"") -> Mock:
+        response = Mock()
+        response.text = text
+        response.content = content
+        response.apparent_encoding = "utf-8"
+        response.raise_for_status = Mock()
+        return response

--- a/jp_stocks/tests.py
+++ b/jp_stocks/tests.py
@@ -122,8 +122,11 @@ class RokunohePdfDownloadViewTest(TestCase):
         with patch("jp_stocks.views.call_command") as call_command_mock:
             response = self.client.post(reverse("jpn:rokunohe_pdf_download"))
 
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(reverse("jpn:index"), response.url)
+        self.assertRedirects(
+            response,
+            reverse("jpn:index"),
+            fetch_redirect_response=False,
+        )
         call_command_mock.assert_called_once_with("rokunohe_pdf_download")
 
     def test_non_superuser_cannot_start_pdf_download(self):
@@ -166,8 +169,11 @@ class RokunohePdfDownloadViewTest(TestCase):
         ):
             response = self.client.post(reverse("jpn:rokunohe_pdf_download"))
 
-        self.assertEqual(302, response.status_code)
-        self.assertEqual(reverse("jpn:index"), response.url)
+        self.assertRedirects(
+            response,
+            reverse("jpn:index"),
+            fetch_redirect_response=False,
+        )
 
     def test_non_superuser_sees_disabled_pdf_download_button(self):
         """

--- a/jp_stocks/urls.py
+++ b/jp_stocks/urls.py
@@ -1,10 +1,20 @@
 from django.urls import path
 
-from jp_stocks.views import IndexView, OrderBookListView, CreateOrderView
+from jp_stocks.views import (
+    IndexView,
+    OrderBookListView,
+    CreateOrderView,
+    RokunohePdfDownloadView,
+)
 
 app_name = "jpn"
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),
+    path(
+        "rokunohe-pdf-download/",
+        RokunohePdfDownloadView.as_view(),
+        name="rokunohe_pdf_download",
+    ),
     path("create-order/", CreateOrderView.as_view(), name="create_order"),
     path("order-book/", OrderBookListView.as_view(), name="order_book"),
 ]

--- a/jp_stocks/views.py
+++ b/jp_stocks/views.py
@@ -27,7 +27,7 @@ class RokunohePdfDownloadView(UserPassesTestMixin, View):
             call_command("rokunohe_pdf_download")
             messages.success(
                 request,
-                "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_backnumbers に保存しました。",
+                "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_back_numbers に保存しました。",
             )
         except CommandError as e:
             messages.warning(request, str(e))

--- a/jp_stocks/views.py
+++ b/jp_stocks/views.py
@@ -1,4 +1,9 @@
+from django.contrib import messages
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.core.management import call_command
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
+from django.views import View
 from django.views.generic import TemplateView, CreateView, ListView
 
 from jp_stocks.domain.repository.order import OrderRepository
@@ -8,6 +13,21 @@ from jp_stocks.models import Order
 
 class IndexView(TemplateView):
     template_name = "jp_stocks/index.html"
+
+
+class RokunohePdfDownloadView(UserPassesTestMixin, View):
+    raise_exception = True
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def post(self, request, *args, **kwargs):
+        call_command("rokunohe_pdf_download")
+        messages.success(
+            request,
+            "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_backnumbers に保存しました。",
+        )
+        return redirect("jpn:index")
 
 
 class OrderBookListView(ListView):

--- a/jp_stocks/views.py
+++ b/jp_stocks/views.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views import View
@@ -22,11 +23,14 @@ class RokunohePdfDownloadView(UserPassesTestMixin, View):
         return self.request.user.is_superuser
 
     def post(self, request, *args, **kwargs):
-        call_command("rokunohe_pdf_download")
-        messages.success(
-            request,
-            "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_backnumbers に保存しました。",
-        )
+        try:
+            call_command("rokunohe_pdf_download")
+            messages.success(
+                request,
+                "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_backnumbers に保存しました。",
+            )
+        except CommandError as e:
+            messages.warning(request, str(e))
         return redirect("jpn:index")
 
 

--- a/jp_stocks/views.py
+++ b/jp_stocks/views.py
@@ -18,17 +18,18 @@ class IndexView(TemplateView):
 
 class RokunohePdfDownloadView(UserPassesTestMixin, View):
     raise_exception = True
+    command_name = "rokunohe_pdf_download"
+    success_message = (
+        "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_back_numbers に保存しました。"
+    )
 
     def test_func(self):
         return self.request.user.is_superuser
 
     def post(self, request, *args, **kwargs):
         try:
-            call_command("rokunohe_pdf_download")
-            messages.success(
-                request,
-                "六戸町会議録PDFを media/jp_stocks/rokunohe_pdf_back_numbers に保存しました。",
-            )
+            call_command(self.command_name)
+            messages.success(request, self.success_message)
         except CommandError as e:
             messages.warning(request, str(e))
         return redirect("jpn:index")

--- a/media/jp_stocks/rokunohe_pdf_back_numbers/.gitignore
+++ b/media/jp_stocks/rokunohe_pdf_back_numbers/.gitignore
@@ -1,0 +1,5 @@
+
+# Ignore everything in this directory except control files
+*
+!.gitignore
+!.gitkeep


### PR DESCRIPTION
## Summary
Issue 731 の六戸町会議録PDF一括ダウンロードを、jp_stocks トップページから実行できるようにしました。

- jp_stocks トップページに superuser 限定の「六戸町会議録PDF保存」ボタンを追加
- ボタン押下時に既存の `rokunohe_pdf_download` 管理コマンドを実行し、PDFを `media/jp_stocks/rokunohe_pdf_backnumbers` に保存
- 管理コマンドの保存先を media 配下の app 別フォルダへ修正し、現行ページとバックナンバーページの両方を処理対象化
- 非superuserは画面上でボタンを無効化し、POST先も403で実行不可にするテストを追加

## 目検による動作確認手順
- [x] superuser で `http://127.0.0.1:8000/jp_stocks/` を開くと「六戸町会議録PDF保存」ボタンがクリック可能で表示されること
- [x] ボタンをクリックすると `media/jp_stocks/rokunohe_pdf_backnumbers` にPDFが保存され、完了メッセージが表示されること
- [x] 一般ユーザーで `http://127.0.0.1:8000/jp_stocks/` を開くと同ボタンが disabled で表示されること
- [x] 一般ユーザーでPOST先へ直接アクセスしてもPDF保存処理が実行されないこと

## 自動テストでカバーできた範囲
- `python manage.py test jp_stocks --keepdb`
  - superuser のPOSTで管理コマンドが呼ばれること
  - 非superuser のPOSTが403になること
  - 非superuser のトップページで disabled ボタンが表示されること
  - 既存の板情報サービス計算テスト
- `python manage.py check`
  - Django構成チェック
- `python manage.py test --noinput`
  - 全体テスト301件

## 関連Issue
https://github.com/duri0214/portfolio/issues/731
