### PR TITLE
#746 LLM Chat 六戸町会議録の管理者向け操作を非管理者にも無効表示する

### DIFF
--- a/llm_chat/templates/llm_chat/index.html
+++ b/llm_chat/templates/llm_chat/index.html
@@ -28,8 +28,7 @@
 
                 <div class="d-flex justify-content-end mb-3 gap-2 align-items-center">
                     {% if is_superuser %}
-                        <a href="{% url 'llm:rokunohe_minutes' %}" class="btn btn-outline-info btn-sm">六戸町会議録QA
-                            (管理)</a>
+                        <a href="{% url 'llm:rokunohe_minutes' %}" class="btn btn-outline-info btn-sm">六戸町会議録QA</a>
                     {% else %}
                         <a href="{% url 'llm:rokunohe_minutes' %}"
                            class="btn btn-outline-info btn-sm">六戸町会議録QA</a>

--- a/llm_chat/templates/llm_chat/rokunohe_minutes.html
+++ b/llm_chat/templates/llm_chat/rokunohe_minutes.html
@@ -39,11 +39,18 @@
                     {% if is_superuser %}
                         <form method="post" action="{% url 'llm:rokunohe_pdf_download' %}" class="me-auto">
                             {% csrf_token %}
-                            <button type="submit" class="btn btn-outline-success btn-sm">会議録PDF保存</button>
+                            <button type="submit" class="btn btn-outline-success btn-sm">会議録PDF取得・ベクトル化</button>
                         </form>
+                    {% else %}
+                        <button type="button" class="btn btn-outline-secondary btn-sm me-auto" disabled>
+                            会議録PDF取得・ベクトル化
+                        </button>
                     {% endif %}
                     <button id="clearChatLogsBtn" class="btn btn-danger btn-sm">チャット履歴を削除</button>
                 </div>
+                {% if not is_superuser %}
+                    <p class="small text-muted mt-2 mb-3">管理者権限が必要なボタンは無効化されています</p>
+                {% endif %}
 
                 {% for chat_log in chat_history %}
                     <div class="card shadow-sm border-0 mb-3">

--- a/llm_chat/tests/test_rokunohe_rag.py
+++ b/llm_chat/tests/test_rokunohe_rag.py
@@ -145,7 +145,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         """
         シナリオ:
         - 入力: superuserでログインした状態。
-        - 処理: 六戸町会議録PDF保存ボタンのPOST先へリクエストする。
+        - 処理: 六戸町会議録PDF取得・ベクトル化ボタンのPOST先へリクエストする。
         - 期待値: 管理コマンドが呼び出され、六戸町会議録QAページへリダイレクトされること。
         """
         user = User.objects.create_superuser(
@@ -169,7 +169,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         """
         シナリオ:
         - 入力: 一般ユーザーでログインした状態。
-        - 処理: 六戸町会議録PDF保存ボタンのPOST先へリクエストする。
+        - 処理: 六戸町会議録PDF取得・ベクトル化ボタンのPOST先へリクエストする。
         - 期待値: 403が返り、管理コマンドは呼び出されないこと。
         """
         user = User.objects.create_user(
@@ -192,7 +192,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         """
         シナリオ:
         - 入力: superuserでログインし、PDF保存処理が既に実行中の状態。
-        - 処理: 六戸町会議録PDF保存ボタンのPOST先へリクエストする。
+        - 処理: 六戸町会議録PDF取得・ベクトル化ボタンのPOST先へリクエストする。
         - 期待値: 例外で500にせず、六戸町会議録QAページへリダイレクトされること。
         """
         user = User.objects.create_superuser(
@@ -219,7 +219,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         シナリオ:
         - 入力: superuserでログインした状態。
         - 処理: 六戸町会議録QAページを表示する。
-        - 期待値: 会議録PDF保存ボタンが表示されること。
+        - 期待値: 会議録PDF取得・ベクトル化ボタンが有効な状態で表示されること。
         """
         user = User.objects.create_superuser(
             username="admin3",
@@ -230,14 +230,15 @@ class RokunohePdfDownloadViewTest(TestCase):
 
         response = self.client.get(reverse("llm:rokunohe_minutes"))
 
-        self.assertContains(response, "会議録PDF保存")
+        self.assertContains(response, "会議録PDF取得・ベクトル化")
+        self.assertContains(response, 'class="btn btn-outline-success btn-sm"')
 
-    def test_non_superuser_does_not_see_pdf_download_button(self):
+    def test_non_superuser_sees_disabled_pdf_download_button(self):
         """
         シナリオ:
         - 入力: 一般ユーザーでログインした状態。
         - 処理: 六戸町会議録QAページを表示する。
-        - 期待値: 会議録PDF保存ボタンが表示されないこと。
+        - 期待値: 会議録PDF取得・ベクトル化ボタンが無効な状態で表示されること。
         """
         user = User.objects.create_user(
             username="user2",
@@ -248,7 +249,9 @@ class RokunohePdfDownloadViewTest(TestCase):
 
         response = self.client.get(reverse("llm:rokunohe_minutes"))
 
-        self.assertNotContains(response, "会議録PDF保存")
+        self.assertContains(response, "会議録PDF取得・ベクトル化")
+        self.assertContains(response, "管理者権限が必要なボタンは無効化されています")
+        self.assertContains(response, "disabled")
 
 
 class RokunoheMinutesPdfImportServiceTest(TestCase):

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -130,9 +130,7 @@ class RokunohePdfDownloadView(UserPassesTestMixin, View):
 
     raise_exception = True
     command_name = "rokunohe_pdf_download"
-    success_message = (
-        "六戸町会議録PDFを media/llm_chat/rokunohe_pdf_back_numbers に保存しました。"
-    )
+    success_message = "六戸町会議録PDFの取得・ベクトル化処理を実行しました。"
 
     def test_func(self):
         return self.request.user.is_superuser


### PR DESCRIPTION
## Summary
六戸町会議録RAG画面の管理者向け操作を、非管理者にも disabled 状態で見えるようにしました。

- 非管理者にも「会議録PDF取得・ベクトル化」ボタンを disabled 表示
- shopping 画面と同じ「管理者権限が必要なボタンは無効化されています」文言を追加
- ボタン文言と完了メッセージを、PDF保存だけでなくベクトル化まで行う実態に合わせて更新
- 既存テストを、非管理者ではボタンが非表示ではなく disabled 表示される仕様へ更新

## 目検による動作確認手順
- [x] 非管理者で `/llm_chat/rokunohe-minutes/` を開いたとき、「会議録PDF取得・ベクトル化」ボタンが disabled で表示されること
- [x] 非管理者で「管理者権限が必要なボタンは無効化されています」が表示されること
- [x] 管理者で同ページを開いたとき、「会議録PDF取得・ベクトル化」ボタンが有効な状態で表示されること

## 自動テストでカバーできた範囲
`black llm_chat\views.py llm_chat\tests\test_rokunohe_rag.py`

- 変更した Python ファイルのフォーマット確認

`python manage.py check`

- Django 構成チェック

`python manage.py test llm_chat.tests.test_rokunohe_rag`

- 六戸町会議録RAG画面とPDF取得・ベクトル化処理まわりの既存テスト20件が成功
- 管理者ではボタンが有効表示されること
- 非管理者ではボタンが disabled 表示され、管理者権限メッセージが表示されること

## 関連Issue
Closes #746
https://github.com/duri0214/portfolio/issues/746
