### PR TITLE
#752 六戸町会議録RAGでPDF取込後に自動サマリーを提示する

### DIFF
--- a/llm_chat/domain/repository/completion/rokunohe_minutes.py
+++ b/llm_chat/domain/repository/completion/rokunohe_minutes.py
@@ -35,5 +35,18 @@ class RokunoheMinutesRagRepository:
     def upsert_documents(self, documents: list[RokunoheMinutesDocument]) -> None:
         self._rag_service.upsert_documents(documents)
 
+    def delete_pdf_documents(self, pdf: RokunoheMinutesPdf) -> None:
+        existing = self._rag_service._collection.get(where={"source": pdf.source_name})
+        if existing and existing["ids"]:
+            self._rag_service._collection.delete(ids=existing["ids"])
+
+    def reset_collection(self) -> int:
+        existing = self._rag_service._collection.get()
+        if not existing or not existing["ids"]:
+            return 0
+
+        self._rag_service._collection.delete(ids=existing["ids"])
+        return len(existing["ids"])
+
     def retrieve_answer(self, message: Message) -> RagResponse:
         return self._rag_service.retrieve_answer(message)

--- a/llm_chat/domain/service/completion/rokunohe_minutes.py
+++ b/llm_chat/domain/service/completion/rokunohe_minutes.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+from django.contrib.auth.models import User
+from lib.llm.valueobject.completion import RoleType
 from pypdf import PdfReader
 
 from lib.llm.valueobject.config import OpenAIGptConfig, ModelName
@@ -59,15 +61,15 @@ class RokunoheMinutesPdfImportService:
         if self.repository.exists(pdf):
             return RokunoheMinutesImportStatus.SKIPPED_EXISTING
 
-        document = self._create_document(pdf)
-        if document is None:
+        documents = self._create_documents(pdf)
+        if not documents:
             return RokunoheMinutesImportStatus.SKIPPED_EMPTY_TEXT
 
-        self.repository.upsert_documents([document])
+        self.repository.upsert_documents(documents)
         return RokunoheMinutesImportStatus.IMPORTED
 
     @staticmethod
-    def _create_document(pdf: RokunoheMinutesPdf) -> RokunoheMinutesDocument | None:
+    def _create_documents(pdf: RokunoheMinutesPdf) -> list[RokunoheMinutesDocument]:
         """
         PDF本文とメタデータからRAG登録用ドキュメントを作成します。
 
@@ -75,29 +77,33 @@ class RokunoheMinutesPdfImportService:
             pdf: 本文抽出対象の六戸町会議録PDF。
 
         Returns:
-            RokunoheMinutesDocument | None:
-                抽出本文とsource/idメタデータを持つドキュメント。
-                PDFから空文字しか得られない場合はNoneを返します。
+            list[RokunoheMinutesDocument]:
+                ページ単位の抽出本文とsource/page/dateメタデータを持つドキュメント。
+                PDFから空文字しか得られない場合は空リストを返します。
 
         Side Effects:
             PDFファイルを読み取り、各ページからテキストを抽出します。
         """
         reader = PdfReader(pdf.path)
-        text_parts = []
-        for page in reader.pages:
+        documents = []
+        for page_index, page in enumerate(reader.pages, start=1):
             text = page.extract_text()
-            if text:
-                text_parts.append(text)
+            if not text or not text.strip():
+                continue
 
-        full_text = "\n".join(text_parts).strip()
-        if not full_text:
-            return None
+            metadata = RokunoheMinutesMetadata.from_pdf(
+                pdf,
+                page=page_index,
+                chunk_index=page_index - 1,
+            )
+            documents.append(
+                RokunoheMinutesDocument(
+                    page_content=text.strip(),
+                    metadata=metadata.to_dict(),
+                )
+            )
 
-        metadata = RokunoheMinutesMetadata.from_pdf(pdf)
-        return RokunoheMinutesDocument(
-            page_content=full_text,
-            metadata=metadata.to_dict(),
-        )
+        return documents
 
 
 class RokunoheMinutesRagService(BaseChatService):
@@ -112,6 +118,11 @@ class RokunoheMinutesRagService(BaseChatService):
     """
 
     model_name = ModelName.GPT_5_MINI
+    initial_summary_prompt = (
+        "取り込み済みの六戸町会議録を横断して、分析の入口になる初回サマリーを作成してください。"
+        "主要テーマ、直近の傾向、深掘りに向く質問例を日本語で簡潔に箇条書きしてください。"
+        "根拠にした会議録の出典も分かる範囲で添えてください。"
+    )
 
     def __init__(self, repository: RokunoheMinutesRagRepository | None = None):
         """
@@ -154,3 +165,22 @@ class RokunoheMinutesRagService(BaseChatService):
             content=response.answer,
             use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
         )
+
+    def generate_initial_summary(self, user: User) -> MessageDTO:
+        """
+        PDF取り込み直後に表示する分析入口用サマリーを生成します。
+
+        Args:
+            user: サマリーを保存する対象ユーザー。
+
+        Returns:
+            MessageDTO: チャット履歴へ保存するassistantメッセージ。
+        """
+        user_message = MessageDTO(
+            user=user,
+            role=RoleType.USER,
+            content=self.initial_summary_prompt,
+            model_name=self.model_name,
+            use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+        )
+        return self.generate(user_message)

--- a/llm_chat/domain/service/completion/rokunohe_minutes.py
+++ b/llm_chat/domain/service/completion/rokunohe_minutes.py
@@ -65,6 +65,7 @@ class RokunoheMinutesPdfImportService:
         if not documents:
             return RokunoheMinutesImportStatus.SKIPPED_EMPTY_TEXT
 
+        self.repository.delete_pdf_documents(pdf)
         self.repository.upsert_documents(documents)
         return RokunoheMinutesImportStatus.IMPORTED
 

--- a/llm_chat/domain/valueobject/completion/rokunohe_minutes.py
+++ b/llm_chat/domain/valueobject/completion/rokunohe_minutes.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+import re
 
 
 ROKUNOHE_MINUTES_COLLECTION_NAME = "rokunohe_minutes"
@@ -41,6 +42,11 @@ class RokunoheMinutesPdf:
     def document_id(self) -> str:
         return f"rokunohe_{self.path.stem}"
 
+    @property
+    def source_date(self) -> str:
+        match = re.match(r"^(?P<date>\d{8})_", self.path.name)
+        return match.group("date") if match else ""
+
 
 @dataclass(frozen=True)
 class RokunoheMinutesMetadata:
@@ -50,20 +56,49 @@ class RokunoheMinutesMetadata:
     Attributes:
         source: 出典として表示・重複判定に使うPDFファイル名。
         document_id: Chroma DBへ登録するドキュメントIDの基礎値。
+        source_date: PDFファイル名先頭から取得したYYYYMMDD形式の日付。
+        page: PDF内のページ番号。
+        chunk_index: RAG登録時のチャンク番号。
     """
 
     source: str
     document_id: str
+    source_date: str = ""
+    page: int | None = None
+    chunk_index: int | None = None
 
     @classmethod
-    def from_pdf(cls, pdf: RokunoheMinutesPdf) -> "RokunoheMinutesMetadata":
-        return cls(source=pdf.source_name, document_id=pdf.document_id)
+    def from_pdf(
+        cls,
+        pdf: RokunoheMinutesPdf,
+        *,
+        page: int | None = None,
+        chunk_index: int | None = None,
+    ) -> "RokunoheMinutesMetadata":
+        return cls(
+            source=pdf.source_name,
+            document_id=pdf.document_id,
+            source_date=pdf.source_date,
+            page=page,
+            chunk_index=chunk_index,
+        )
 
-    def to_dict(self) -> dict[str, str]:
-        return {
+    def to_dict(self) -> dict[str, str | int]:
+        document_id = self.document_id
+        if self.page is not None:
+            document_id = f"{document_id}_page_{self.page}"
+
+        metadata: dict[str, str | int] = {
             "source": self.source,
-            "id": self.document_id,
+            "id": document_id,
         }
+        if self.source_date:
+            metadata["source_date"] = self.source_date
+        if self.page is not None:
+            metadata["page"] = self.page
+        if self.chunk_index is not None:
+            metadata["chunk_index"] = self.chunk_index
+        return metadata
 
 
 @dataclass(frozen=True)
@@ -77,4 +112,4 @@ class RokunoheMinutesDocument:
     """
 
     page_content: str
-    metadata: dict[str, str]
+    metadata: dict[str, str | int]

--- a/llm_chat/templates/llm_chat/rokunohe_minutes.html
+++ b/llm_chat/templates/llm_chat/rokunohe_minutes.html
@@ -37,8 +37,9 @@
 
                 <div class="d-flex justify-content-end mb-3 gap-2">
                     {% if is_superuser %}
-                        <form method="post" action="{% url 'llm:rokunohe_pdf_download' %}" class="me-auto">
+                        <form id="pdfDownloadForm" method="post" action="{% url 'llm:rokunohe_pdf_download' %}" class="me-auto">
                             {% csrf_token %}
+                            <input type="hidden" name="reset_consent" value="1">
                             <button type="submit" class="btn btn-outline-success btn-sm">会議録PDF取得・ベクトル化</button>
                         </form>
                     {% else %}
@@ -110,6 +111,7 @@
             const userInput = document.getElementById("id_question");
             const loadingIndicator = document.getElementById("loading-indicator");
             const clearBtn = document.getElementById("clearChatLogsBtn");
+            const pdfDownloadForm = document.getElementById("pdfDownloadForm");
             let isLoading = false;
 
             function startLoading() {
@@ -182,6 +184,15 @@
                                 location.reload();
                             }
                         });
+                });
+            }
+
+            if (pdfDownloadForm) {
+                pdfDownloadForm.addEventListener("submit", function (event) {
+                    const confirmed = confirm("会議録PDF取得・ベクトル化を実行する前に、六戸町会議録QAの会話履歴をリセットします。実行しますか？");
+                    if (!confirmed) {
+                        event.preventDefault();
+                    }
                 });
             }
 

--- a/llm_chat/templates/llm_chat/rokunohe_minutes.html
+++ b/llm_chat/templates/llm_chat/rokunohe_minutes.html
@@ -42,6 +42,11 @@
                             <input type="hidden" name="reset_consent" value="1">
                             <button type="submit" class="btn btn-outline-success btn-sm">会議録PDF取得・ベクトル化</button>
                         </form>
+                        <form id="vectorDbResetForm" method="post" action="{% url 'llm:rokunohe_vector_db_reset' %}">
+                            {% csrf_token %}
+                            <input type="hidden" name="reset_collection_consent" value="1">
+                            <button type="submit" class="btn btn-outline-danger btn-sm">コレクションリセット</button>
+                        </form>
                     {% else %}
                         <button type="button" class="btn btn-outline-secondary btn-sm me-auto" disabled>
                             会議録PDF取得・ベクトル化
@@ -112,6 +117,7 @@
             const loadingIndicator = document.getElementById("loading-indicator");
             const clearBtn = document.getElementById("clearChatLogsBtn");
             const pdfDownloadForm = document.getElementById("pdfDownloadForm");
+            const vectorDbResetForm = document.getElementById("vectorDbResetForm");
             let isLoading = false;
 
             function startLoading() {
@@ -190,6 +196,15 @@
             if (pdfDownloadForm) {
                 pdfDownloadForm.addEventListener("submit", function (event) {
                     const confirmed = confirm("会議録PDF取得・ベクトル化を実行する前に、六戸町会議録QAの会話履歴をリセットします。実行しますか？");
+                    if (!confirmed) {
+                        event.preventDefault();
+                    }
+                });
+            }
+
+            if (vectorDbResetForm) {
+                vectorDbResetForm.addEventListener("submit", function (event) {
+                    const confirmed = confirm("六戸町会議録RAGのVector DBコレクションをすべて削除し、会話履歴もリセットします。PDFを再取得・ベクトル化するまで資料検索は使えません。実行しますか？");
                     if (!confirmed) {
                         event.preventDefault();
                     }

--- a/llm_chat/templates/llm_chat/rokunohe_minutes.html
+++ b/llm_chat/templates/llm_chat/rokunohe_minutes.html
@@ -51,6 +51,9 @@
                         <button type="button" class="btn btn-outline-secondary btn-sm me-auto" disabled>
                             会議録PDF取得・ベクトル化
                         </button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                            コレクションリセット
+                        </button>
                     {% endif %}
                     <button id="clearChatLogsBtn" class="btn btn-danger btn-sm">チャット履歴を削除</button>
                 </div>

--- a/llm_chat/tests/test_rokunohe_rag.py
+++ b/llm_chat/tests/test_rokunohe_rag.py
@@ -295,6 +295,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         response = self.client.get(reverse("llm:rokunohe_minutes"))
 
         self.assertContains(response, "会議録PDF取得・ベクトル化")
+        self.assertContains(response, "コレクションリセット")
         self.assertContains(response, 'class="btn btn-outline-success btn-sm"')
 
     def test_non_superuser_sees_disabled_pdf_download_button(self):
@@ -316,6 +317,94 @@ class RokunohePdfDownloadViewTest(TestCase):
         self.assertContains(response, "会議録PDF取得・ベクトル化")
         self.assertContains(response, "管理者権限が必要なボタンは無効化されています")
         self.assertContains(response, "disabled")
+        self.assertNotContains(response, "コレクションリセット")
+
+    @patch("llm_chat.views.RokunoheMinutesRagRepository")
+    def test_superuser_can_reset_vector_db_collection(self, mock_repository):
+        """
+        シナリオ:
+        - 入力: superuserでログインし、六戸町会議録RAG履歴がある状態。
+        - 処理: Vector DBコレクションリセットのPOST先へ同意値付きでリクエストする。
+        - 期待値: コレクションがリセットされ、六戸町会議録RAG履歴も削除されること。
+        """
+        user = User.objects.create_superuser(
+            username="admin-reset",
+            email="admin-reset@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+        ChatLogs.objects.create(
+            user=user,
+            role=RoleType.USER.value,
+            content="古い質問",
+            use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+        )
+        mock_repository.return_value.reset_collection.return_value = 3
+
+        response = self.client.post(
+            reverse("llm:rokunohe_vector_db_reset"),
+            {"reset_collection_consent": "1"},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("llm:rokunohe_minutes"),
+            fetch_redirect_response=False,
+        )
+        mock_repository.return_value.reset_collection.assert_called_once_with()
+        self.assertFalse(
+            ChatLogs.objects.filter(
+                user=user,
+                use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+            ).exists()
+        )
+
+    @patch("llm_chat.views.RokunoheMinutesRagRepository")
+    def test_superuser_must_consent_to_reset_vector_db_collection(
+        self, mock_repository
+    ):
+        """
+        シナリオ:
+        - 入力: superuserだが同意値なしでPOSTする。
+        - 処理: Vector DBコレクションリセットのPOST先へリクエストする。
+        - 期待値: コレクションリセットを呼び出さず、六戸町会議録QAページへリダイレクトされること。
+        """
+        user = User.objects.create_superuser(
+            username="admin-reset-consent",
+            email="admin-reset-consent@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        response = self.client.post(reverse("llm:rokunohe_vector_db_reset"))
+
+        self.assertRedirects(
+            response,
+            reverse("llm:rokunohe_minutes"),
+            fetch_redirect_response=False,
+        )
+        mock_repository.assert_not_called()
+
+    def test_non_superuser_cannot_reset_vector_db_collection(self):
+        """
+        シナリオ:
+        - 入力: 一般ユーザーでログインした状態。
+        - 処理: Vector DBコレクションリセットのPOST先へリクエストする。
+        - 期待値: 403が返ること。
+        """
+        user = User.objects.create_user(
+            username="user-reset",
+            email="user-reset@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        response = self.client.post(
+            reverse("llm:rokunohe_vector_db_reset"),
+            {"reset_collection_consent": "1"},
+        )
+
+        self.assertEqual(403, response.status_code)
 
 
 class RokunoheMinutesPdfImportServiceTest(TestCase):
@@ -337,6 +426,7 @@ class RokunoheMinutesPdfImportServiceTest(TestCase):
         status = service.import_pdf(Path("会議録.pdf"))
 
         self.assertEqual(status, RokunoheMinutesImportStatus.IMPORTED)
+        repository.delete_pdf_documents.assert_called_once()
         repository.upsert_documents.assert_called_once()
         docs = repository.upsert_documents.call_args[0][0]
         self.assertEqual(len(docs), 1)
@@ -383,6 +473,7 @@ class RokunoheMinutesPdfImportServiceTest(TestCase):
 
         self.assertEqual(status, RokunoheMinutesImportStatus.SKIPPED_EXISTING)
         mock_pdf_reader.assert_not_called()
+        repository.delete_pdf_documents.assert_not_called()
         repository.upsert_documents.assert_not_called()
 
     @patch("llm_chat.domain.service.completion.rokunohe_minutes.PdfReader")
@@ -403,6 +494,7 @@ class RokunoheMinutesPdfImportServiceTest(TestCase):
         status = service.import_pdf(Path("空.pdf"))
 
         self.assertEqual(status, RokunoheMinutesImportStatus.SKIPPED_EMPTY_TEXT)
+        repository.delete_pdf_documents.assert_not_called()
         repository.upsert_documents.assert_not_called()
 
 
@@ -471,6 +563,45 @@ class RokunoheMinutesRagRepositoryTest(TestCase):
             where={"source": "会議録.pdf"},
             limit=1,
         )
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_delete_pdf_documents_removes_existing_source_documents(
+        self, mock_rag_service
+    ):
+        """
+        シナリオ:
+        - 入力: Chroma DB上に同じsource名のドキュメントIDが存在するPDF。
+        - 処理: RepositoryでPDF単位の削除を行う。
+        - 期待値: source条件で取得したIDだけが削除されること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.get.return_value = {"ids": ["doc_1", "doc_2"]}
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        repository.delete_pdf_documents(RokunoheMinutesPdf(path=Path("会議録.pdf")))
+
+        rag_instance._collection.get.assert_called_once_with(
+            where={"source": "会議録.pdf"}
+        )
+        rag_instance._collection.delete.assert_called_once_with(ids=["doc_1", "doc_2"])
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_reset_collection_removes_all_documents(self, mock_rag_service):
+        """
+        シナリオ:
+        - 入力: Chroma DB collectionにドキュメントIDが存在する状態。
+        - 処理: Repositoryでcollectionリセットを行う。
+        - 期待値: collection内の全IDが削除され、削除件数が返ること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.get.return_value = {"ids": ["doc_1", "doc_2"]}
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        deleted_count = repository.reset_collection()
+
+        rag_instance._collection.get.assert_called_once_with()
+        rag_instance._collection.delete.assert_called_once_with(ids=["doc_1", "doc_2"])
+        self.assertEqual(deleted_count, 2)
 
 
 class RokunohePdfDownloadCommandTest(TestCase):

--- a/llm_chat/tests/test_rokunohe_rag.py
+++ b/llm_chat/tests/test_rokunohe_rag.py
@@ -24,6 +24,7 @@ from llm_chat.domain.valueobject.completion.rokunohe_minutes import (
     RokunoheMinutesPdf,
 )
 from llm_chat.domain.valueobject.completion.use_case import UseCaseType
+from llm_chat.models import ChatLogs
 
 
 class RokunoheMinutesRagViewTest(TestCase):
@@ -155,8 +156,28 @@ class RokunohePdfDownloadViewTest(TestCase):
         )
         self.client.force_login(user)
 
-        with patch("llm_chat.views.call_command") as call_command_mock:
-            response = self.client.post(reverse("llm:rokunohe_pdf_download"))
+        summary_message = MessageDTO(
+            user=user,
+            role=RoleType.ASSISTANT,
+            content="取り込み後の初回サマリーです。",
+            use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+        )
+        ChatLogs.objects.create(
+            user=user,
+            role=RoleType.USER.value,
+            content="古い質問",
+            use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+        )
+        with patch("llm_chat.views.call_command") as call_command_mock, patch(
+            "llm_chat.views.RokunoheMinutesRagService"
+        ) as rag_service_mock:
+            rag_service_mock.return_value.generate_initial_summary.return_value = (
+                summary_message
+            )
+            response = self.client.post(
+                reverse("llm:rokunohe_pdf_download"),
+                {"reset_consent": "1"},
+            )
 
         self.assertRedirects(
             response,
@@ -164,6 +185,45 @@ class RokunohePdfDownloadViewTest(TestCase):
             fetch_redirect_response=False,
         )
         call_command_mock.assert_called_once_with("rokunohe_pdf_download")
+        rag_service_mock.return_value.generate_initial_summary.assert_called_once_with(
+            user
+        )
+        self.assertEqual(
+            list(
+                ChatLogs.objects.filter(
+                    user=user,
+                    use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+                ).values_list("content", flat=True)
+            ),
+            ["取り込み後の初回サマリーです。"],
+        )
+
+    def test_superuser_must_consent_to_reset_before_pdf_download(self):
+        """
+        シナリオ:
+        - 入力: superuserだが会話リセット同意値なしでPOSTする。
+        - 処理: 六戸町会議録PDF取得・ベクトル化ボタンのPOST先へリクエストする。
+        - 期待値: 管理コマンドを呼び出さず、六戸町会議録QAページへリダイレクトされること。
+        """
+        user = User.objects.create_superuser(
+            username="admin-consent",
+            email="admin-consent@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        with patch("llm_chat.views.call_command") as call_command_mock, patch(
+            "llm_chat.views.RokunoheMinutesRagService"
+        ) as rag_service_mock:
+            response = self.client.post(reverse("llm:rokunohe_pdf_download"))
+
+        self.assertRedirects(
+            response,
+            reverse("llm:rokunohe_minutes"),
+            fetch_redirect_response=False,
+        )
+        call_command_mock.assert_not_called()
+        rag_service_mock.assert_not_called()
 
     def test_non_superuser_cannot_start_pdf_download(self):
         """
@@ -205,14 +265,18 @@ class RokunohePdfDownloadViewTest(TestCase):
         with patch(
             "llm_chat.views.call_command",
             side_effect=CommandError("六戸町PDFダウンロードは既に実行中です。"),
-        ):
-            response = self.client.post(reverse("llm:rokunohe_pdf_download"))
+        ), patch("llm_chat.views.RokunoheMinutesRagService") as rag_service_mock:
+            response = self.client.post(
+                reverse("llm:rokunohe_pdf_download"),
+                {"reset_consent": "1"},
+            )
 
         self.assertRedirects(
             response,
             reverse("llm:rokunohe_minutes"),
             fetch_redirect_response=False,
         )
+        rag_service_mock.assert_not_called()
 
     def test_superuser_sees_pdf_download_button(self):
         """
@@ -278,7 +342,30 @@ class RokunoheMinutesPdfImportServiceTest(TestCase):
         self.assertEqual(len(docs), 1)
         self.assertEqual(docs[0].page_content, "六戸町会議録の内容です。")
         self.assertEqual(docs[0].metadata["source"], "会議録.pdf")
-        self.assertEqual(docs[0].metadata["id"], "rokunohe_会議録")
+        self.assertEqual(docs[0].metadata["id"], "rokunohe_会議録_page_1")
+        self.assertEqual(docs[0].metadata["page"], 1)
+        self.assertEqual(docs[0].metadata["chunk_index"], 0)
+
+    @patch("llm_chat.domain.service.completion.rokunohe_minutes.PdfReader")
+    def test_imports_pdf_text_with_source_date_metadata(self, mock_pdf_reader):
+        """
+        シナリオ:
+        - 入力: ファイル名先頭に日付を持つPDF。
+        - 処理: PDFインポートサービスを実行する。
+        - 期待値: ファイル名の日付がメタデータへ登録されること。
+        """
+        repository = Mock()
+        repository.exists.return_value = False
+        mock_page = Mock()
+        mock_page.extract_text.return_value = "日付付き会議録の内容です。"
+        mock_pdf_reader.return_value.pages = [mock_page]
+
+        service = RokunoheMinutesPdfImportService(repository=repository)
+        status = service.import_pdf(Path("20260225_会議録.pdf"))
+
+        self.assertEqual(status, RokunoheMinutesImportStatus.IMPORTED)
+        docs = repository.upsert_documents.call_args[0][0]
+        self.assertEqual(docs[0].metadata["source_date"], "20260225")
 
     @patch("llm_chat.domain.service.completion.rokunohe_minutes.PdfReader")
     def test_skips_existing_pdf_before_reading(self, mock_pdf_reader):

--- a/llm_chat/tests/test_rokunohe_rag.py
+++ b/llm_chat/tests/test_rokunohe_rag.py
@@ -298,12 +298,12 @@ class RokunohePdfDownloadViewTest(TestCase):
         self.assertContains(response, "コレクションリセット")
         self.assertContains(response, 'class="btn btn-outline-success btn-sm"')
 
-    def test_non_superuser_sees_disabled_pdf_download_button(self):
+    def test_non_superuser_sees_disabled_admin_buttons(self):
         """
         シナリオ:
         - 入力: 一般ユーザーでログインした状態。
         - 処理: 六戸町会議録QAページを表示する。
-        - 期待値: 会議録PDF取得・ベクトル化ボタンが無効な状態で表示されること。
+        - 期待値: 管理者向け操作ボタンが無効な状態で表示されること。
         """
         user = User.objects.create_user(
             username="user2",
@@ -317,7 +317,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         self.assertContains(response, "会議録PDF取得・ベクトル化")
         self.assertContains(response, "管理者権限が必要なボタンは無効化されています")
         self.assertContains(response, "disabled")
-        self.assertNotContains(response, "コレクションリセット")
+        self.assertContains(response, "コレクションリセット")
 
     @patch("llm_chat.views.RokunoheMinutesRagRepository")
     def test_superuser_can_reset_vector_db_collection(self, mock_repository):

--- a/llm_chat/urls.py
+++ b/llm_chat/urls.py
@@ -11,6 +11,7 @@ from .views import (
     RiddleCSVUploadView,
     RiddleSampleCSVView,
     RokunohePdfDownloadView,
+    RokunoheVectorDbResetView,
 )
 
 app_name = "llm"
@@ -42,5 +43,10 @@ urlpatterns = [
         "rokunohe-pdf-download/",
         RokunohePdfDownloadView.as_view(),
         name="rokunohe_pdf_download",
+    ),
+    path(
+        "rokunohe-vector-db-reset/",
+        RokunoheVectorDbResetView.as_view(),
+        name="rokunohe_vector_db_reset",
     ),
 ]

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -23,6 +23,9 @@ from lib.llm.valueobject.completion import StreamResponse
 from lib.llm.valueobject.config import OpenAIGptConfig, ModelName
 from llm_chat.domain.factory.completion.use_case import UseCaseFactory
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
+from llm_chat.domain.repository.completion.rokunohe_minutes import (
+    RokunoheMinutesRagRepository,
+)
 from llm_chat.domain.service.chat import ChatDisplayService
 from llm_chat.domain.service.completion.rokunohe_minutes import (
     RokunoheMinutesRagService,
@@ -165,6 +168,39 @@ class RokunohePdfDownloadView(UserPassesTestMixin, View):
         service = RokunoheMinutesRagService()
         summary = service.generate_initial_summary(user)
         ChatLogRepository.insert(summary)
+
+
+class RokunoheVectorDbResetView(UserPassesTestMixin, View):
+    """
+    六戸町会議録RAGのChroma DB collectionをリセットする管理者用ビュー。
+    """
+
+    raise_exception = True
+    reset_consent_value = "1"
+    success_message = "六戸町会議録RAGのVector DBコレクションをリセットしました。"
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def post(self, request, *args, **kwargs):
+        if request.POST.get("reset_collection_consent") != self.reset_consent_value:
+            messages.warning(
+                request,
+                "Vector DBコレクションのリセットに同意してから実行してください。",
+            )
+            return redirect("llm:rokunohe_minutes")
+
+        login_user = _get_login_user(request)
+        repository = RokunoheMinutesRagRepository(
+            api_key=os.getenv("OPENAI_API_KEY") or ""
+        )
+        deleted_count = repository.reset_collection()
+        ChatLogRepository.clear_history(
+            user=login_user,
+            use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+        )
+        messages.success(request, f"{self.success_message} 削除件数: {deleted_count}件")
+        return redirect("llm:rokunohe_minutes")
 
 
 class SyncResponseView(View):

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -24,6 +24,9 @@ from lib.llm.valueobject.config import OpenAIGptConfig, ModelName
 from llm_chat.domain.factory.completion.use_case import UseCaseFactory
 from llm_chat.domain.repository.completion.chat import ChatLogRepository
 from llm_chat.domain.service.chat import ChatDisplayService
+from llm_chat.domain.service.completion.rokunohe_minutes import (
+    RokunoheMinutesRagService,
+)
 from llm_chat.domain.use_case.completion.chat import (
     OpenAIGptStreamingUseCase,
 )
@@ -131,17 +134,37 @@ class RokunohePdfDownloadView(UserPassesTestMixin, View):
     raise_exception = True
     command_name = "rokunohe_pdf_download"
     success_message = "六戸町会議録PDFの取得・ベクトル化処理を実行しました。"
+    reset_consent_value = "1"
 
     def test_func(self):
         return self.request.user.is_superuser
 
     def post(self, request, *args, **kwargs):
+        if request.POST.get("reset_consent") != self.reset_consent_value:
+            messages.warning(
+                request,
+                "会話履歴のリセットに同意してから実行してください。",
+            )
+            return redirect("llm:rokunohe_minutes")
+
+        login_user = _get_login_user(request)
+        ChatLogRepository.clear_history(
+            user=login_user,
+            use_case_type=UseCaseType.ROKUNOHE_MINUTES_RAG,
+        )
         try:
             call_command(self.command_name)
+            self._save_initial_summary(login_user)
             messages.success(request, self.success_message)
         except CommandError as e:
             messages.warning(request, str(e))
         return redirect("llm:rokunohe_minutes")
+
+    @staticmethod
+    def _save_initial_summary(user: User) -> None:
+        service = RokunoheMinutesRagService()
+        summary = service.generate_initial_summary(user)
+        ChatLogRepository.insert(summary)
 
 
 class SyncResponseView(View):


### PR DESCRIPTION
## Summary
六戸町会議録RAGのPDF取得・ベクトル化後に、会話履歴をリセットしたうえで初回サマリーを提示するようにしました。

- PDF取得・ベクトル化ボタン押下時に会話リセット同意を確認し、同意値がないPOSTは実行しない
- 同意後に六戸町会議録RAGの履歴を削除し、取り込み完了後に初回サマリーをassistant履歴として保存
- PDF本文をページ単位でRAG登録し、source date / page / chunk index をメタデータへ追加
- 処理対象PDFは同一sourceの既存ベクトルを削除してからupsertし、スキップ文書はVector DBから削除しない
- 管理者向けにVector DBコレクション全体をリセットするボタンを追加
- 非管理者にも管理者向け操作ボタンをdisabled状態で表示する

## 目検による動作確認手順
- [x] 管理者で `/llm_chat/rokunohe-minutes/` を開き、「会議録PDF取得・ベクトル化」を押すと会話リセット確認が表示されること
- [x] 確認をキャンセルするとPDF取得・ベクトル化が実行されないこと
- [x] 確認に同意して実行すると、既存の六戸町会議録QA履歴が消え、取り込み後の初回サマリーが表示されること
- [x] 管理者で「コレクションリセット」を押すと、Vector DB削除と会話履歴削除の確認が表示されること
- [x] 非管理者では「会議録PDF取得・ベクトル化」と「コレクションリセット」がdisabled状態で表示されること

## 自動テストでカバーできた範囲
- `black llm_chat\domain\service\completion\rokunohe_minutes.py llm_chat\domain\valueobject\completion\rokunohe_minutes.py llm_chat\views.py llm_chat\tests\test_rokunohe_rag.py`
  - 変更したPythonファイルのフォーマット確認
- `black llm_chat\domain\repository\completion\rokunohe_minutes.py llm_chat\domain\service\completion\rokunohe_minutes.py llm_chat\views.py llm_chat\urls.py llm_chat\tests\test_rokunohe_rag.py`
  - 追加変更したPythonファイルのフォーマット確認
- `black llm_chat\tests\test_rokunohe_rag.py`
  - 非管理者向けdisabled表示テスト更新後のフォーマット確認
- `python manage.py check`
  - Django構成チェック
- `python manage.py test llm_chat.tests.test_rokunohe_rag`
  - 六戸町会議録RAGまわりの27件が成功
- `python manage.py test llm_chat`
  - llm_chatアプリ全体72件が成功

## 関連Issue
Closes #752
https://github.com/duri0214/portfolio/issues/752
