### PR TITLE
#754 六戸町会議録RAGのコレクションビューアを追加する

### DIFF
--- a/llm_chat/domain/repository/completion/rokunohe_minutes.py
+++ b/llm_chat/domain/repository/completion/rokunohe_minutes.py
@@ -3,9 +3,12 @@ from lib.llm.valueobject.completion import Message, RagResponse
 from lib.llm.valueobject.config import ModelName
 from llm_chat.domain.valueobject.completion.rokunohe_minutes import (
     ROKUNOHE_MINUTES_COLLECTION_NAME,
+    RokunoheMinutesCollectionItem,
     RokunoheMinutesDocument,
     RokunoheMinutesPdf,
 )
+
+CollectionGetResult = dict[str, list]
 
 
 class RokunoheMinutesRagRepository:
@@ -47,6 +50,83 @@ class RokunoheMinutesRagRepository:
 
         self._rag_service._collection.delete(ids=existing["ids"])
         return len(existing["ids"])
+
+    def count_collection_items(self, *, source_date_from: int | None = None) -> int:
+        if source_date_from is not None:
+            existing = self._rag_service._collection.get(
+                include=["documents", "metadatas"],
+            )
+            return len(self._build_collection_items(existing, source_date_from))
+
+        return self._rag_service._collection.count()
+
+    def list_collection_items(
+        self, *, limit: int, offset: int = 0, source_date_from: int | None = None
+    ) -> list[RokunoheMinutesCollectionItem]:
+        if source_date_from is not None:
+            existing = self._rag_service._collection.get(
+                include=["documents", "metadatas"],
+            )
+            items = self._build_collection_items(existing, source_date_from)
+            items.sort(
+                key=lambda item: self._get_item_source_date_int(item), reverse=True
+            )
+            return items[offset : offset + limit]
+
+        existing = self._rag_service._collection.get(
+            limit=limit,
+            offset=offset,
+            include=["documents", "metadatas"],
+        )
+        return self._build_collection_items(existing)
+
+    def _build_collection_items(
+        self,
+        existing: CollectionGetResult,
+        source_date_from: int | None = None,
+    ) -> list[RokunoheMinutesCollectionItem]:
+        if not existing or not existing["ids"]:
+            return []
+
+        ids = existing["ids"]
+        documents = existing.get("documents") or []
+        metadatas = existing.get("metadatas") or []
+        items: list[RokunoheMinutesCollectionItem] = []
+
+        for index, chroma_id in enumerate(ids):
+            document = documents[index] if index < len(documents) else ""
+            metadata = metadatas[index] if index < len(metadatas) else {}
+            source_date_int = self._get_source_date_int(metadata)
+            if source_date_from is not None and source_date_int < source_date_from:
+                continue
+            preview = document.replace("\n", " ")[:200]
+            items.append(
+                RokunoheMinutesCollectionItem(
+                    chroma_id=chroma_id,
+                    source=str(metadata.get("source", "")),
+                    source_date=str(metadata.get("source_date", "")),
+                    page=metadata.get("page"),
+                    chunk_index=metadata.get("chunk_index"),
+                    preview=preview,
+                )
+            )
+
+        return items
+
+    @staticmethod
+    def _get_source_date_int(metadata: dict) -> int:
+        source_date = metadata.get("source_date_ymd") or metadata.get("source_date")
+        try:
+            return int(source_date)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _get_item_source_date_int(item: RokunoheMinutesCollectionItem) -> int:
+        try:
+            return int(item.source_date)
+        except ValueError:
+            return 0
 
     def retrieve_answer(self, message: Message) -> RagResponse:
         return self._rag_service.retrieve_answer(message)

--- a/llm_chat/domain/valueobject/completion/rokunohe_minutes.py
+++ b/llm_chat/domain/valueobject/completion/rokunohe_minutes.py
@@ -94,6 +94,7 @@ class RokunoheMinutesMetadata:
         }
         if self.source_date:
             metadata["source_date"] = self.source_date
+            metadata["source_date_ymd"] = int(self.source_date)
         if self.page is not None:
             metadata["page"] = self.page
         if self.chunk_index is not None:
@@ -113,3 +114,25 @@ class RokunoheMinutesDocument:
 
     page_content: str
     metadata: dict[str, str | int]
+
+
+@dataclass(frozen=True)
+class RokunoheMinutesCollectionItem:
+    """
+    Chroma DBに登録済みの六戸町会議録RAGドキュメント1件分の表示用データ。
+
+    Attributes:
+        chroma_id: Chroma DB上のドキュメントID。
+        source: 出典PDFファイル名。
+        source_date: 出典PDFファイル名から取得したYYYYMMDD形式の日付。
+        page: PDF内のページ番号。
+        chunk_index: RAG登録時のチャンク番号。
+        preview: 管理画面で確認する本文プレビュー。
+    """
+
+    chroma_id: str
+    source: str
+    source_date: str
+    page: int | None
+    chunk_index: int | None
+    preview: str

--- a/llm_chat/templates/llm_chat/rokunohe_collection_viewer.html
+++ b/llm_chat/templates/llm_chat/rokunohe_collection_viewer.html
@@ -1,0 +1,100 @@
+{% extends 'llm_chat/base.html' %}
+
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'llm:index' %}">LLM Chat</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'llm:rokunohe_minutes' %}">六戸町会議録 RAG</a></li>
+                <li class="breadcrumb-item active" aria-current="page">コレクションビューア</li>
+            </ol>
+        </nav>
+
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <div>
+                <h1 class="h3 mb-1">六戸町会議録 コレクションビューア</h1>
+                <p class="text-muted mb-0">
+                    {{ query_type_label }}: 全 {{ total_count }} 件中 {{ page_start }}-{{ page_end }} 件を表示しています。
+                </p>
+            </div>
+            <a href="{% url 'llm:rokunohe_minutes' %}" class="btn btn-outline-secondary btn-sm">QAへ戻る</a>
+        </div>
+
+        <div class="d-flex align-items-center justify-content-end flex-wrap gap-3 mb-3">
+            <div class="d-flex align-items-center gap-2">
+                <span class="small text-muted">クエリタイプ</span>
+                <a href="?page=1&per_page={{ per_page }}"
+                   class="btn btn-sm {% if query_type == '' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">
+                    全件
+                </a>
+                <a href="?query_type=recent_year&page=1&per_page={{ per_page }}"
+                   class="btn btn-sm {% if query_type == 'recent_year' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">
+                    直近1年
+                </a>
+            </div>
+            <form method="get" class="d-flex align-items-center gap-2">
+                <label for="perPageSelect" class="form-label mb-0 small text-muted">最大</label>
+                <select id="perPageSelect" name="per_page" class="form-select form-select-sm w-auto"
+                        onchange="this.form.submit()">
+                    {% for option in per_page_options %}
+                        <option value="{{ option }}" {% if option == per_page %}selected{% endif %}>{{ option }}件</option>
+                    {% endfor %}
+                </select>
+                <input type="hidden" name="page" value="1">
+                {% if query_type %}
+                    <input type="hidden" name="query_type" value="{{ query_type }}">
+                {% endif %}
+            </form>
+        </div>
+
+        {% if collection_items %}
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle">
+                    <thead>
+                    <tr>
+                        <th scope="col">Chroma ID</th>
+                        <th scope="col">source</th>
+                        <th scope="col">source_date</th>
+                        <th scope="col">page</th>
+                        <th scope="col">chunk_index</th>
+                        <th scope="col">本文プレビュー</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in collection_items %}
+                        <tr>
+                            <td class="font-monospace small">{{ item.chroma_id }}</td>
+                            <td>{{ item.source|default_if_none:"-" }}</td>
+                            <td>{{ item.source_date|default_if_none:"-" }}</td>
+                            <td>{{ item.page|default_if_none:"-" }}</td>
+                            <td>{{ item.chunk_index|default_if_none:"-" }}</td>
+                            <td class="small">{{ item.preview|default_if_none:"-" }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <nav aria-label="collection pagination">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item {% if not has_previous_page %}disabled{% endif %}">
+                        <a class="page-link"
+                           href="?page={{ previous_page }}&per_page={{ per_page }}{% if query_type %}&query_type={{ query_type }}{% endif %}"
+                           aria-label="Previous">前へ</a>
+                    </li>
+                    <li class="page-item disabled">
+                        <span class="page-link">{{ current_page }} / {{ total_pages }}</span>
+                    </li>
+                    <li class="page-item {% if not has_next_page %}disabled{% endif %}">
+                        <a class="page-link"
+                           href="?page={{ next_page }}&per_page={{ per_page }}{% if query_type %}&query_type={{ query_type }}{% endif %}"
+                           aria-label="Next">次へ</a>
+                    </li>
+                </ul>
+            </nav>
+        {% else %}
+            <div class="alert alert-info" role="alert">
+                rokunohe_minutes collection に表示できる登録内容はありません。
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/llm_chat/templates/llm_chat/rokunohe_minutes.html
+++ b/llm_chat/templates/llm_chat/rokunohe_minutes.html
@@ -47,12 +47,18 @@
                             <input type="hidden" name="reset_collection_consent" value="1">
                             <button type="submit" class="btn btn-outline-danger btn-sm">コレクションリセット</button>
                         </form>
+                        <a href="{% url 'llm:rokunohe_collection_viewer' %}" class="btn btn-outline-info btn-sm">
+                            コレクションビューア
+                        </a>
                     {% else %}
                         <button type="button" class="btn btn-outline-secondary btn-sm me-auto" disabled>
                             会議録PDF取得・ベクトル化
                         </button>
                         <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
                             コレクションリセット
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" disabled>
+                            コレクションビューア
                         </button>
                     {% endif %}
                     <button id="clearChatLogsBtn" class="btn btn-danger btn-sm">チャット履歴を削除</button>

--- a/llm_chat/tests/test_rokunohe_rag.py
+++ b/llm_chat/tests/test_rokunohe_rag.py
@@ -1,3 +1,4 @@
+from datetime import date
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -20,6 +21,7 @@ from llm_chat.domain.service.completion.rokunohe_minutes import (
 from llm_chat.domain.valueobject.completion.chat import MessageDTO
 from llm_chat.domain.valueobject.completion.rokunohe_minutes import (
     ROKUNOHE_MINUTES_COLLECTION_NAME,
+    RokunoheMinutesCollectionItem,
     RokunoheMinutesImportStatus,
     RokunoheMinutesPdf,
 )
@@ -296,6 +298,7 @@ class RokunohePdfDownloadViewTest(TestCase):
 
         self.assertContains(response, "会議録PDF取得・ベクトル化")
         self.assertContains(response, "コレクションリセット")
+        self.assertContains(response, "コレクションビューア")
         self.assertContains(response, 'class="btn btn-outline-success btn-sm"')
 
     def test_non_superuser_sees_disabled_admin_buttons(self):
@@ -318,6 +321,7 @@ class RokunohePdfDownloadViewTest(TestCase):
         self.assertContains(response, "管理者権限が必要なボタンは無効化されています")
         self.assertContains(response, "disabled")
         self.assertContains(response, "コレクションリセット")
+        self.assertContains(response, "コレクションビューア")
 
     @patch("llm_chat.views.RokunoheMinutesRagRepository")
     def test_superuser_can_reset_vector_db_collection(self, mock_repository):
@@ -406,6 +410,156 @@ class RokunohePdfDownloadViewTest(TestCase):
 
         self.assertEqual(403, response.status_code)
 
+    @patch("llm_chat.views.RokunoheMinutesRagRepository")
+    def test_superuser_can_view_vector_db_collection(self, mock_repository):
+        """
+        シナリオ:
+        - 入力: superuserでログインし、Repositoryがコレクション表示用データを返す状態。
+        - 処理: コレクションビューア画面へGETリクエストする。
+        - 期待値: 管理者専用画面にChroma ID、メタデータ、本文プレビューが表示されること。
+        """
+        user = User.objects.create_superuser(
+            username="admin-viewer",
+            email="admin-viewer@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+        mock_repository.return_value.count_collection_items.return_value = 1
+        mock_repository.return_value.list_collection_items.return_value = [
+            RokunoheMinutesCollectionItem(
+                chroma_id="doc_1",
+                source="20260225_会議録.pdf",
+                source_date="20260225",
+                page=1,
+                chunk_index=0,
+                preview="本文プレビューです。",
+            )
+        ]
+
+        response = self.client.get(reverse("llm:rokunohe_collection_viewer"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "llm_chat/rokunohe_collection_viewer.html")
+        mock_repository.return_value.count_collection_items.assert_called_once_with(
+            source_date_from=None
+        )
+        mock_repository.return_value.list_collection_items.assert_called_once_with(
+            limit=100,
+            offset=0,
+            source_date_from=None,
+        )
+        self.assertContains(response, "doc_1")
+        self.assertContains(response, "20260225_会議録.pdf")
+        self.assertContains(response, "20260225")
+        self.assertContains(response, "本文プレビューです。")
+        self.assertContains(response, "全 1 件中 1-1 件")
+
+    @patch("llm_chat.views.RokunoheMinutesRagRepository")
+    def test_collection_viewer_uses_page_and_per_page(self, mock_repository):
+        """
+        シナリオ:
+        - 入力: superuserでログインし、2ページ目と50件表示を指定する。
+        - 処理: コレクションビューア画面へGETリクエストする。
+        - 期待値: Repositoryへlimit=50、offset=50が渡され、ページ情報が表示されること。
+        """
+        user = User.objects.create_superuser(
+            username="admin-viewer-page",
+            email="admin-viewer-page@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+        mock_repository.return_value.count_collection_items.return_value = 120
+        mock_repository.return_value.list_collection_items.return_value = [
+            RokunoheMinutesCollectionItem(
+                chroma_id="doc_51",
+                source="20260225_会議録.pdf",
+                source_date="20260225",
+                page=3,
+                chunk_index=2,
+                preview="51件目です。",
+            )
+        ]
+
+        response = self.client.get(
+            reverse("llm:rokunohe_collection_viewer"),
+            {"page": "2", "per_page": "50"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_repository.return_value.list_collection_items.assert_called_once_with(
+            limit=50,
+            offset=50,
+            source_date_from=None,
+        )
+        self.assertContains(response, "全 120 件中 51-51 件")
+        self.assertContains(response, "2 / 3")
+        self.assertContains(response, "doc_51")
+
+    @patch("llm_chat.views.timezone.localdate")
+    @patch("llm_chat.views.RokunoheMinutesRagRepository")
+    def test_collection_viewer_uses_recent_year_query_type(
+        self, mock_repository, mock_localdate
+    ):
+        """
+        シナリオ:
+        - 入力: superuserでログインし、クエリタイプに直近1年を指定する。
+        - 処理: コレクションビューア画面へGETリクエストする。
+        - 期待値: 1年前の日付を下限としてRepositoryへ渡し、直近1年表示になること。
+        """
+        mock_localdate.return_value = date(2026, 6, 12)
+        user = User.objects.create_superuser(
+            username="admin-viewer-recent",
+            email="admin-viewer-recent@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+        mock_repository.return_value.count_collection_items.return_value = 1
+        mock_repository.return_value.list_collection_items.return_value = [
+            RokunoheMinutesCollectionItem(
+                chroma_id="doc_recent",
+                source="20260225_会議録.pdf",
+                source_date="20260225",
+                page=1,
+                chunk_index=0,
+                preview="直近1年の本文です。",
+            )
+        ]
+
+        response = self.client.get(
+            reverse("llm:rokunohe_collection_viewer"),
+            {"query_type": "recent_year", "per_page": "50"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_repository.return_value.count_collection_items.assert_called_once_with(
+            source_date_from=20250612
+        )
+        mock_repository.return_value.list_collection_items.assert_called_once_with(
+            limit=50,
+            offset=0,
+            source_date_from=20250612,
+        )
+        self.assertContains(response, "直近1年: 全 1 件中 1-1 件")
+        self.assertContains(response, "doc_recent")
+
+    def test_non_superuser_cannot_view_vector_db_collection(self):
+        """
+        シナリオ:
+        - 入力: 一般ユーザーでログインした状態。
+        - 処理: コレクションビューア画面へGETリクエストする。
+        - 期待値: 403が返ること。
+        """
+        user = User.objects.create_user(
+            username="user-viewer",
+            email="user-viewer@example.com",
+            password="password",
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("llm:rokunohe_collection_viewer"))
+
+        self.assertEqual(403, response.status_code)
+
 
 class RokunoheMinutesPdfImportServiceTest(TestCase):
     @patch("llm_chat.domain.service.completion.rokunohe_minutes.PdfReader")
@@ -456,6 +610,7 @@ class RokunoheMinutesPdfImportServiceTest(TestCase):
         self.assertEqual(status, RokunoheMinutesImportStatus.IMPORTED)
         docs = repository.upsert_documents.call_args[0][0]
         self.assertEqual(docs[0].metadata["source_date"], "20260225")
+        self.assertEqual(docs[0].metadata["source_date_ymd"], 20260225)
 
     @patch("llm_chat.domain.service.completion.rokunohe_minutes.PdfReader")
     def test_skips_existing_pdf_before_reading(self, mock_pdf_reader):
@@ -602,6 +757,135 @@ class RokunoheMinutesRagRepositoryTest(TestCase):
         rag_instance._collection.get.assert_called_once_with()
         rag_instance._collection.delete.assert_called_once_with(ids=["doc_1", "doc_2"])
         self.assertEqual(deleted_count, 2)
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_list_collection_items_returns_viewer_rows(self, mock_rag_service):
+        """
+        シナリオ:
+        - 入力: Chroma DB collectionがids、documents、metadatasを返す状態。
+        - 処理: Repositoryで表示用一覧を取得する。
+        - 期待値: Chroma ID、メタデータ、改行除去済み本文プレビューを持つ表示用データが返ること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.get.return_value = {
+            "ids": ["doc_1"],
+            "documents": ["本文1行目\n本文2行目"],
+            "metadatas": [
+                {
+                    "source": "20260225_会議録.pdf",
+                    "source_date": "20260225",
+                    "page": 1,
+                    "chunk_index": 0,
+                }
+            ],
+        }
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        items = repository.list_collection_items(limit=100)
+
+        rag_instance._collection.get.assert_called_once_with(
+            limit=100,
+            offset=0,
+            include=["documents", "metadatas"],
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].chroma_id, "doc_1")
+        self.assertEqual(items[0].source, "20260225_会議録.pdf")
+        self.assertEqual(items[0].source_date, "20260225")
+        self.assertEqual(items[0].page, 1)
+        self.assertEqual(items[0].chunk_index, 0)
+        self.assertEqual(items[0].preview, "本文1行目 本文2行目")
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_count_collection_items_returns_chroma_count(self, mock_rag_service):
+        """
+        シナリオ:
+        - 入力: Chroma DB collectionが件数を返す状態。
+        - 処理: Repositoryで登録件数を取得する。
+        - 期待値: collection.count() の値が返ること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.count.return_value = 120
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        count = repository.count_collection_items()
+
+        self.assertEqual(count, 120)
+        rag_instance._collection.count.assert_called_once_with()
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_list_collection_items_filters_by_source_date_from(self, mock_rag_service):
+        """
+        シナリオ:
+        - 入力: Chroma DB collectionに直近1年内外のsource_dateを持つデータが存在する状態。
+        - 処理: Repositoryで日付下限を指定して表示用一覧を取得する。
+        - 期待値: source_dateが下限以降のデータだけ日付降順で返ること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.get.return_value = {
+            "ids": ["old_doc", "recent_old_doc", "recent_new_doc"],
+            "documents": ["古い本文", "直近の古い本文", "直近の新しい本文"],
+            "metadatas": [
+                {"source": "20240101_会議録.pdf", "source_date": "20240101"},
+                {"source": "20260225_会議録.pdf", "source_date": "20260225"},
+                {"source": "20260301_会議録.pdf", "source_date": "20260301"},
+            ],
+        }
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        items = repository.list_collection_items(
+            limit=100,
+            offset=0,
+            source_date_from=20250612,
+        )
+
+        rag_instance._collection.get.assert_called_once_with(
+            include=["documents", "metadatas"],
+        )
+        self.assertEqual(
+            [item.chroma_id for item in items], ["recent_new_doc", "recent_old_doc"]
+        )
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_count_collection_items_filters_by_source_date_from(self, mock_rag_service):
+        """
+        シナリオ:
+        - 入力: Chroma DB collectionに直近1年内外のsource_date_ymdを持つデータが存在する状態。
+        - 処理: Repositoryで日付下限を指定して件数を取得する。
+        - 期待値: source_date_ymdが下限以降の件数が返ること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.get.return_value = {
+            "ids": ["old_doc", "recent_doc"],
+            "documents": ["古い本文", "直近の本文"],
+            "metadatas": [
+                {"source": "20240101_会議録.pdf", "source_date_ymd": 20240101},
+                {"source": "20260225_会議録.pdf", "source_date_ymd": 20260225},
+            ],
+        }
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        count = repository.count_collection_items(source_date_from=20250612)
+
+        self.assertEqual(count, 1)
+
+    @patch("llm_chat.domain.repository.completion.rokunohe_minutes.OpenAILlmRagService")
+    def test_list_collection_items_returns_empty_when_collection_is_empty(
+        self, mock_rag_service
+    ):
+        """
+        シナリオ:
+        - 入力: Chroma DB collectionにドキュメントIDが存在しない状態。
+        - 処理: Repositoryで表示用一覧を取得する。
+        - 期待値: 空リストが返ること。
+        """
+        rag_instance = mock_rag_service.return_value
+        rag_instance._collection.get.return_value = {"ids": []}
+        repository = RokunoheMinutesRagRepository(api_key="dummy")
+
+        items = repository.list_collection_items(limit=100)
+
+        self.assertEqual(items, [])
 
 
 class RokunohePdfDownloadCommandTest(TestCase):

--- a/llm_chat/urls.py
+++ b/llm_chat/urls.py
@@ -12,6 +12,7 @@ from .views import (
     RiddleSampleCSVView,
     RokunohePdfDownloadView,
     RokunoheVectorDbResetView,
+    RokunoheCollectionViewerView,
 )
 
 app_name = "llm"
@@ -48,5 +49,10 @@ urlpatterns = [
         "rokunohe-vector-db-reset/",
         RokunoheVectorDbResetView.as_view(),
         name="rokunohe_vector_db_reset",
+    ),
+    path(
+        "rokunohe-collection-viewer/",
+        RokunoheCollectionViewerView.as_view(),
+        name="rokunohe_collection_viewer",
     ),
 ]

--- a/llm_chat/views.py
+++ b/llm_chat/views.py
@@ -2,8 +2,10 @@ import csv
 import io
 import json
 import logging
+import math
 import os
 import traceback
+from datetime import timedelta
 from typing import Generator
 
 from django.contrib import messages
@@ -15,6 +17,7 @@ from django.db import transaction
 from django.http import StreamingHttpResponse, JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
+from django.utils import timezone
 from django.views import View
 from django.views.generic import FormView
 from dotenv import load_dotenv
@@ -201,6 +204,97 @@ class RokunoheVectorDbResetView(UserPassesTestMixin, View):
         )
         messages.success(request, f"{self.success_message} 削除件数: {deleted_count}件")
         return redirect("llm:rokunohe_minutes")
+
+
+class RokunoheCollectionViewerView(UserPassesTestMixin, View):
+    """
+    六戸町会議録RAGのChroma DB collection内容を確認する管理者用ビュー。
+    """
+
+    raise_exception = True
+    default_per_page = 100
+    per_page_options = (50, 100, 200, 500)
+    recent_year_query_type = "recent_year"
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get(self, request, *args, **kwargs):
+        per_page = self._get_per_page(request)
+        current_page = self._get_current_page(request)
+        query_type = self._get_query_type(request)
+        source_date_from = self._get_source_date_from(query_type)
+        offset = (current_page - 1) * per_page
+        repository = RokunoheMinutesRagRepository(
+            api_key=os.getenv("OPENAI_API_KEY") or ""
+        )
+        total_count = repository.count_collection_items(
+            source_date_from=source_date_from
+        )
+        total_pages = max(math.ceil(total_count / per_page), 1)
+        if current_page > total_pages:
+            current_page = total_pages
+            offset = (current_page - 1) * per_page
+
+        collection_items = repository.list_collection_items(
+            limit=per_page,
+            offset=offset,
+            source_date_from=source_date_from,
+        )
+        context = {
+            "collection_items": collection_items,
+            "current_page": current_page,
+            "has_next_page": current_page < total_pages,
+            "has_previous_page": current_page > 1,
+            "next_page": current_page + 1,
+            "page_start": offset + 1 if total_count else 0,
+            "page_end": offset + len(collection_items),
+            "per_page": per_page,
+            "per_page_options": self.per_page_options,
+            "previous_page": current_page - 1,
+            "query_type": query_type,
+            "query_type_label": self._get_query_type_label(query_type),
+            "total_count": total_count,
+            "total_pages": total_pages,
+        }
+        return render(request, "llm_chat/rokunohe_collection_viewer.html", context)
+
+    def _get_per_page(self, request) -> int:
+        try:
+            per_page = int(request.GET.get("per_page", self.default_per_page))
+        except (TypeError, ValueError):
+            return self.default_per_page
+
+        if per_page not in self.per_page_options:
+            return self.default_per_page
+        return per_page
+
+    @staticmethod
+    def _get_current_page(request) -> int:
+        try:
+            page = int(request.GET.get("page", 1))
+        except (TypeError, ValueError):
+            return 1
+
+        return max(page, 1)
+
+    def _get_source_date_from(self, query_type: str) -> int | None:
+        if query_type != self.recent_year_query_type:
+            return None
+
+        recent_year_start = timezone.localdate() - timedelta(days=365)
+        return int(recent_year_start.strftime("%Y%m%d"))
+
+    def _get_query_type(self, request) -> str:
+        query_type = request.GET.get("query_type", "")
+        if query_type == self.recent_year_query_type:
+            return query_type
+        return ""
+
+    def _get_query_type_label(self, query_type: str) -> str:
+        if query_type == self.recent_year_query_type:
+            return "直近1年"
+        return "全件"
 
 
 class SyncResponseView(View):


### PR DESCRIPTION
## Summary
六戸町会議録RAGの管理者向けに、Chroma DB の `rokunohe_minutes` collection 登録内容を確認できるビューアを追加しました。

- QA画面の管理者操作エリアにコレクションビューア導線を追加
- 管理者専用のコレクションビューア画面を追加し、Chroma ID / source / source_date / page / chunk_index / 本文プレビューを一覧表示
- 表示件数を 50 / 100 / 200 / 500 件から選べるドロップダウンとページングを追加し、登録データを全件確認できるように対応
- クエリタイプリンクとして「全件」「直近1年」を追加し、source_date をもとに直近1年分へ絞り込み、日付降順で表示
- 今後の登録分で日付比較しやすいよう `source_date_ymd` もメタデータへ追加し、既存の文字列 `source_date` でも直近1年判定できるように対応
- superuserのみアクセス可能であること、表示データ整形、ページング指定、直近1年絞り込みと降順ソート、空コレクションをテストで確認

## 目検による動作確認手順
- [x] superuserで六戸町会議録QA画面を開き、「コレクションビューア」ボタンが表示されること
- [x] コレクションビューア画面でChroma ID、source、source_date、page、chunk_index、本文プレビューが一覧表示されること
- [x] 表示件数ドロップダウンで 50 / 100 / 200 / 500 件を切り替えられること
- [x] 「前へ」「次へ」でページ移動し、登録データを最後まで確認できること
- [x] クエリタイプの「直近1年」を押すと、source_date が直近1年内のデータだけ日付降順で表示されること
- [x] 一般ユーザーでコレクションビューアURLへアクセスすると403になること

## 自動テストでカバーできた範囲
- `python -m black llm_chat\domain\repository\completion\rokunohe_minutes.py llm_chat\tests\test_rokunohe_rag.py`
- `python manage.py test llm_chat.tests.test_rokunohe_rag`

関連機能である六戸町会議録RAGのビュー、PDF取得、コレクションリセット、Repository処理、管理者権限チェック、コレクションビューアのページング、直近1年絞り込みと降順ソートを実行しました。

## 関連Issue
Closes #754
https://github.com/duri0214/portfolio/issues/754
