### PR TITLE
#773 soil_analysis｜配車候補キューを都道府県間の一人称商圏として再設計する

### DIFF
--- a/.codex/rules/portfolio.md
+++ b/.codex/rules/portfolio.md
@@ -7,6 +7,8 @@ apply: always
 ## Git/GitHub 操作
 - GitHub API、GitHub Contents API、MCP のファイル更新系ツールなどで、リモートブランチ上のファイルを直接作成・更新・削除しない。
 - 変更は必ずローカル作業ツリーで編集し、`git add`、`git commit`、`git push` の通常フローで反映する。
+- `git commit --amend` や `git push --force` / `git push --force-with-lease` による履歴上書きは原則禁止する。PR作成後の修正や追加対応は、新しいコミットとして履歴を残す。
+- 履歴上書きが必要な場合は、ユーザーから明示的な許可を得て、理由と影響範囲を作業報告に残す。
 - コード修正を行った場合は、必要な確認（フォーマット、関連テスト、差分確認など）を通したうえで、ユーザーが明示的に `commit不要`・`push不要`・`まだコミットしない` と指示していない限り、原則としてコミットと push まで進める。
 - ユーザーが `commit` を明示した場合の詳細な確認手順や失敗時の扱いは、`commit` スキルに従う。
 - `git add`、`git commit`、`git push`、`git checkout`、`git reset` などが失敗した場合は、API 等で迂回せず、原因を切り分けてユーザーに確認する。

--- a/soil_analysis/domain/service/prefecture_commercial_area.py
+++ b/soil_analysis/domain/service/prefecture_commercial_area.py
@@ -62,6 +62,8 @@ JAPAN_MAP_PREFECTURES = (
     (47, "沖縄県"),
 )
 
+HIGH_WEATHER_RISK_INDEX = 4.0
+
 
 class PrefectureCommercialAreaService:
     """
@@ -108,8 +110,10 @@ class PrefectureCommercialAreaService:
             )
             for japan_map_code, prefecture_name in JAPAN_MAP_PREFECTURES
         ]
-        dispatch_candidates = cls._build_dispatch_candidates(areas)
         sales_opportunity_candidates = cls._build_sales_opportunity_candidates(areas)
+        dispatch_candidates = cls._build_dispatch_candidates(
+            sales_opportunity_candidates
+        )
         return PrefectureCommercialAreaDashboardVO(
             areas=areas,
             dispatch_candidates=dispatch_candidates,
@@ -148,10 +152,10 @@ class PrefectureCommercialAreaService:
     @staticmethod
     def _build_crop_stats() -> dict[int, Counter]:
         """
-        作付台帳から都道府県別の主要作物候補を集計します。
+        作付台帳から都道府県別の登録作物を集計します。
 
         `LandLedger` の作物情報を圃場の都道府県へ寄せることで、各商圏の
-        代表的な作物名を表示できるようにします。作付台帳がない商圏は
+        登録作物名を表示できるようにします。作付台帳がない商圏は
         後続処理で「未設定」として扱います。
 
         Returns:
@@ -251,7 +255,7 @@ class PrefectureCommercialAreaService:
 
         `PrefectureCommercialAreaVO` はテンプレートでそのまま利用する表示用の値を持つため、
         ここで日本地図ライブラリ用の都道府県コード、状態判定に使うリスクスコア、
-        主要作物名までまとめて確定させます。
+        登録作物名までまとめて確定させます。
 
         Args:
             japan_map_code: japan-map-js が使う都道府県コード。
@@ -270,7 +274,8 @@ class PrefectureCommercialAreaService:
         warning_names = warning.sorted_names
         land_count = stats["land_count"]
         risk_score = cls._calculate_risk_score(land_count, warning_city_count)
-        main_crop_name = cls._get_main_crop_name(crop_stats[japan_map_code])
+        crop_names = cls._get_crop_names(crop_stats[japan_map_code])
+        main_crop_name = crop_names[0] if crop_names else "未設定"
         weather = weather_stats.get_by_japan_map_code(japan_map_code)
         weather_risk_index = cls._calculate_weather_risk_index(
             weather.code, warning_city_count
@@ -283,6 +288,7 @@ class PrefectureCommercialAreaService:
             land_count=land_count,
             company_count=len(stats["company_ids"]),
             main_crop_name=main_crop_name,
+            crop_names=crop_names,
             total_area=round(stats["total_area"], 2),
             warning_city_count=warning_city_count,
             warning_names=warning_names,
@@ -351,67 +357,61 @@ class PrefectureCommercialAreaService:
         return 0
 
     @staticmethod
-    def _get_main_crop_name(crop_counter: Counter) -> str:
+    def _get_crop_names(crop_counter: Counter) -> list[str]:
         """
-        商圏の代表作物として表示する作物名を選びます。
+        商圏の作物名を出現数順に返します。
 
-        作付台帳に紐づく作物のうち最も出現数が多いものを採用します。
-        データ未登録の商圏でも画面表示が欠けないよう、空の場合は
-        「未設定」を返します。
+        作付台帳に紐づく作物を、出現数が多い順、同数の場合は名前順で返します。
+        データ未登録の商圏は空のリストとして扱います。
 
         Args:
             crop_counter: 作物名ごとの出現回数。
 
         Returns:
-            str: 商圏テーブルや配車候補に表示する主要作物名。
+            list[str]: 商圏テーブルや配車候補判定に使う作物名一覧。
         """
         if not crop_counter:
-            return "未設定"
-        return crop_counter.most_common(1)[0][0]
+            return []
+        return [
+            crop_name
+            for crop_name, _ in sorted(
+                crop_counter.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ]
 
     @staticmethod
     def _build_dispatch_candidates(
-        areas: list[PrefectureCommercialAreaVO],
+        sales_opportunity_candidates: list[SalesOpportunityCandidateVO],
     ) -> list[DispatchCandidateVO]:
         """
-        商圏集計からトップページ用の出荷候補リストを生成します。
+        売り込み候補からトップページ用の配車候補リストを生成します。
 
-        現時点では外部の市場価格や物流APIへ接続せず、圃場登録がある商圏を
-        画面上で確認しやすくするための簡易候補を作ります。警報・注意報がある
-        商圏は「天候確認中」とし、通常商圏は出荷候補として表示します。
+        天気リスクが高い都道府県へ他都道府県が売り込む関係を、
+        配車調整で確認する一方向のキューとして扱います。商圏リスクスコアではなく、
+        売り込み先の天気リスク指数を判断軸にします。
 
         Args:
-            areas: 都道府県単位の商圏VO一覧。
+            sales_opportunity_candidates: 天気リスクが高い商圏への売り込み候補一覧。
 
         Returns:
             list[DispatchCandidateVO]: トップページの配車候補キューに表示する候補。
         """
-        active_areas = [area for area in areas if area.land_count]
-        sorted_areas = sorted(
-            active_areas,
-            key=lambda area: (area.warning_city_count == 0, area.land_count),
-            reverse=True,
-        )
-
         candidates = []
-        for index, area in enumerate(sorted_areas[:5]):
-            market_name = "首都圏市場" if index % 2 == 0 else "関西市場"
-            logistics_status = (
-                "配車候補あり" if not area.warning_city_count else "天候確認中"
+        for candidate in sales_opportunity_candidates[:5]:
+            reason = (
+                f"{candidate.target_name}の天気リスクを見て、"
+                f"{candidate.origin_name}からの代替出荷便を確認します。"
             )
-            if area.warning_city_count:
-                reason = f"{area.prefecture_name}は警報・注意報があるため、代替ルート確認を優先します。"
-            else:
-                reason = f"{area.prefecture_name}は圃場登録があり、{area.main_crop_name}の出荷候補として監視します。"
-
             candidates.append(
                 DispatchCandidateVO(
-                    origin_name=area.prefecture_name,
-                    target_market_name=market_name,
-                    main_crop_name=area.main_crop_name,
-                    logistics_status=logistics_status,
+                    origin_name=candidate.origin_name,
+                    target_prefecture_name=candidate.target_name,
+                    main_crop_name=candidate.main_crop_name,
+                    logistics_status="代替便確認中",
                     reason=reason,
-                    risk_score=area.risk_score,
+                    weather_risk_index=candidate.weather_risk_index,
+                    relation_label=candidate.relation_label,
                 )
             )
         return candidates
@@ -422,10 +422,11 @@ class PrefectureCommercialAreaService:
         areas: list[PrefectureCommercialAreaVO],
     ) -> list[SalesOpportunityCandidateVO]:
         """
-        赤信号商圏へ他都道府県から売り込む候補リストを生成します。
+        天気リスクが高い商圏へ同じ登録作物を持つ他都道府県から売り込む候補リストを生成します。
 
-        警報・注意報がある商圏を「出荷側として止まっている地域」とみなし、
-        警報・注意報がなく圃場登録のある他商圏を売り込み元候補にします。
+        雨・雪や警報・注意報で天気リスク指数が高い商圏を
+        「登録作物の出荷が止まりやすい地域」とみなし、同じ登録作物を持ち、
+        警報・注意報がない他商圏を売り込み元候補にします。
         A県→B県とB県→A県は別々の関係として扱うため、候補は一方向のVOで返します。
 
         Args:
@@ -434,34 +435,51 @@ class PrefectureCommercialAreaService:
         Returns:
             list[SalesOpportunityCandidateVO]: リスク指数つきの売り込み候補。
         """
-        target_areas = [area for area in areas if area.warning_city_count]
+        target_areas = [
+            area
+            for area in areas
+            if area.weather_risk_index >= HIGH_WEATHER_RISK_INDEX and area.crop_names
+        ]
         origin_areas = [
-            area for area in areas if area.land_count and not area.warning_city_count
+            area
+            for area in areas
+            if area.land_count and not area.warning_city_count and area.crop_names
         ]
         candidates = []
         for target_area in target_areas:
             for origin_area in origin_areas:
                 if origin_area.japan_map_code == target_area.japan_map_code:
                     continue
+                if origin_area.weather_risk_index >= target_area.weather_risk_index:
+                    continue
+                matched_crop_names = sorted(
+                    set(origin_area.crop_names) & set(target_area.crop_names)
+                )
+                if not matched_crop_names:
+                    continue
+                matched_crop_name = matched_crop_names[0]
                 candidates.append(
                     SalesOpportunityCandidateVO(
                         origin_name=origin_area.prefecture_name,
                         target_name=target_area.prefecture_name,
-                        main_crop_name=origin_area.main_crop_name,
+                        main_crop_name=matched_crop_name,
                         weather_risk_index=target_area.weather_risk_index,
                         relation_label=(
                             f"{origin_area.prefecture_name}→"
                             f"{target_area.prefecture_name}"
                         ),
                         reason=cls._build_sales_opportunity_reason(
-                            origin_area, target_area
+                            origin_area, target_area, matched_crop_name
                         ),
                     )
                 )
 
         return sorted(
             candidates,
-            key=lambda candidate: candidate.weather_risk_index,
+            key=lambda candidate: (
+                candidate.weather_risk_index,
+                candidate.main_crop_name,
+            ),
             reverse=True,
         )[:5]
 
@@ -472,7 +490,7 @@ class PrefectureCommercialAreaService:
         warning_city_count: int,
     ) -> float:
         """
-        赤信号県への売り込み判断に使う天気リスク指数を算出します。
+        売り込み判断に使う天気リスク指数を算出します。
 
         天気コードの先頭2桁を主な判断軸とし、警報・注意報件数は
         小さな補正として倍率に近い数値へ畳み込みます。
@@ -525,6 +543,7 @@ class PrefectureCommercialAreaService:
         cls,
         origin_area: PrefectureCommercialAreaVO,
         target_area: PrefectureCommercialAreaVO,
+        crop_name: str,
     ) -> str:
         """
         売り込み候補の判断理由を画面表示用に組み立てます。
@@ -532,12 +551,18 @@ class PrefectureCommercialAreaService:
         Args:
             origin_area: 売り込み元商圏。
             target_area: 売り込み先商圏。
+            crop_name: 売り込み元と売り込み先で一致した作物名。
 
         Returns:
             str: リスク指数に寄与した判断軸を含む説明文。
         """
+        target_weather_summary = target_area.weather_name
+        if target_area.warning_names:
+            target_weather_summary = (
+                f"{target_area.weather_name}、{target_area.warning_summary}"
+            )
         return (
-            f"{target_area.prefecture_name}は{target_area.warning_summary}で赤信号。"
-            f"{origin_area.prefecture_name}は警報・注意報がないため、"
+            f"{target_area.prefecture_name}は{target_weather_summary}で天気リスクが高い状態。"
+            f"{origin_area.prefecture_name}は警報・注意報がなく同じ{crop_name}を出せるため、"
             f"{target_area.prefecture_name}への売り込み候補になります。"
         )

--- a/soil_analysis/domain/valueobject/prefecture_commercial_area.py
+++ b/soil_analysis/domain/valueobject/prefecture_commercial_area.py
@@ -202,7 +202,8 @@ class PrefectureCommercialAreaVO:
         japan_map_code: japan-map-js が都道府県識別に使う1から47のコード。
         land_count: 登録済み圃場数。
         company_count: 登録済み農業法人・企業数。
-        main_crop_name: 最も多く台帳に登場する作物名。
+        main_crop_name: 最も多く台帳に登場する代表作物名。
+        crop_names: 作付台帳に登場する作物名一覧。
         total_area: 圃場面積の合計。
         warning_city_count: 警報・注意報が登録されている市区町村数。
         warning_names: 都道府県内で発表されている警報・注意報名。
@@ -220,6 +221,7 @@ class PrefectureCommercialAreaVO:
     land_count: int
     company_count: int
     main_crop_name: str
+    crop_names: list[str]
     total_area: float
     warning_city_count: int
     warning_names: list[str]
@@ -277,6 +279,18 @@ class PrefectureCommercialAreaVO:
         return "、".join(self.warning_names)
 
     @property
+    def crop_summary(self) -> str:
+        """
+        画面表示用の作物サマリを返します。
+
+        Returns:
+            str: 作物名の列記。未登録の場合は `未設定`。
+        """
+        if not self.crop_names:
+            return "未設定"
+        return "、".join(self.crop_names)
+
+    @property
     def map_payload(self) -> dict[str, int | str]:
         """
         japan-map-js に渡す都道府県別データを返します。
@@ -295,6 +309,7 @@ class PrefectureCommercialAreaVO:
             "landCount": self.land_count,
             "companyCount": self.company_count,
             "mainCropName": self.main_crop_name,
+            "cropSummary": self.crop_summary,
             "warningCount": self.warning_city_count,
             "warningSummary": self.warning_summary,
             "riskScore": self.risk_score,
@@ -309,46 +324,47 @@ class PrefectureCommercialAreaVO:
 @dataclass(frozen=True)
 class DispatchCandidateVO:
     """
-    商圏から仮想市場への出荷候補を表す読み取り専用VOです。
+    都道府県間の一人称商圏に基づく配車候補を表す読み取り専用VOです。
 
     このVOは、都道府県別商圏マップの右側に表示する配車候補キューのために使います。
-    現段階では実在の物流APIや市場価格へ接続せず、圃場登録のある商圏を
-    「どこから、どの市場へ、どの作物を出せそうか」という形で可視化する
-    PoC用の表示モデルです。
+    現段階では実在の物流APIや市場価格へ接続せず、天気リスクが高い都道府県へ
+    他都道府県が同じ登録作物を売り込む関係を配車の確認対象として可視化します。
 
     後続で市況データや配車APIに置き換える場合も、テンプレート側はこのVOを
     読むだけにしておくことで、外部連携の差し替え範囲をService側へ閉じます。
 
     Attributes:
-        origin_name: 出荷元の都道府県商圏名。
-        target_market_name: 仮想の出荷先市場名。
-        main_crop_name: 出荷候補の主要作物名。
+        origin_name: 売り込み元の都道府県名。
+        target_prefecture_name: 天気リスクが高い売り込み先の都道府県名。
+        main_crop_name: 出荷候補として一致した作物名。
         logistics_status: 配車候補の状態。
         reason: 推奨理由。
-        risk_score: 対象商圏のリスクスコア。
+        weather_risk_index: 売り込み先都道府県の天気リスク指数。
+        relation_label: A県→B県を示す一方向の商圏関係ラベル。
     """
 
     origin_name: str
-    target_market_name: str
+    target_prefecture_name: str
     main_crop_name: str
     logistics_status: str
     reason: str
-    risk_score: int
+    weather_risk_index: float
+    relation_label: str
 
 
 @dataclass(frozen=True)
 class SalesOpportunityCandidateVO:
     """
-    赤信号商圏へ他県が売り込みをかける候補関係を表す読み取り専用VOです。
+    天気リスクが高い商圏へ他県が売り込みをかける候補関係を表す読み取り専用VOです。
 
-    このVOは、赤信号県の天気と警報・注意報から算出した
+    このVOは、売り込み先の天気と警報・注意報から算出した
     出荷リスク指数を保持します。都道府県自身が自己申告する値ではなく、
     A県からB県へ売り込む一方向の商圏関係として扱います。
 
     Attributes:
         origin_name: 売り込み元の都道府県名。
-        target_name: 赤信号として売り込み先候補になる都道府県名。
-        main_crop_name: 売り込み候補の主要作物名。
+        target_name: 天気リスクが高く売り込み先候補になる都道府県名。
+        main_crop_name: 売り込み候補として一致した作物名。
         weather_risk_index: 天気と警報・注意報から算出した出荷リスク指数。
         relation_label: A県→B県を示す一方向の商圏関係ラベル。
         reason: リスク指数に寄与した主な判断材料。
@@ -377,8 +393,8 @@ class PrefectureCommercialAreaDashboardVO:
 
     Attributes:
         areas: 都道府県単位の商圏一覧。
-        dispatch_candidates: 出荷候補一覧。
-        sales_opportunity_candidates: 赤信号商圏への売り込み候補一覧。
+        dispatch_candidates: 都道府県間の配車候補一覧。
+        sales_opportunity_candidates: 天気リスクが高い商圏への売り込み候補一覧。
     """
 
     areas: list[PrefectureCommercialAreaVO]

--- a/soil_analysis/static/soil_analysis/js/home.js
+++ b/soil_analysis/static/soil_analysis/js/home.js
@@ -46,7 +46,7 @@ document.addEventListener("DOMContentLoaded", () => {
         title.textContent = `${area.name}: ${area.weatherName}`;
 
         const summary = document.createElement("span");
-        summary.textContent = `圃場 ${area.landCount}圃場 / 企業 ${area.companyCount}社 / 主要作物 ${area.mainCropName}`;
+        summary.textContent = `圃場 ${area.landCount}圃場 / 企業 ${area.companyCount}社 / 登録作物 ${area.cropSummary}`;
 
         const risk = document.createElement("span");
         risk.textContent = `予報日 ${area.weatherReportingDate || "未取得"} / 警報・注意報 ${area.warningSummary}`;

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -102,7 +102,7 @@
                             </div>
                         </div>
                         <div class="col-12 col-xl-4">
-                            <h2 class="h5 mb-2"><i class="fas fa-bullhorn me-2 text-muted"></i>赤信号県への売り込み候補</h2>
+                            <h2 class="h5 mb-2"><i class="fas fa-bullhorn me-2 text-muted"></i>天気リスク県への売り込み候補</h2>
                             {% if prefecture_area_dashboard.sales_opportunity_candidates %}
                                 <div class="sales-opportunity-list mb-4">
                                     {% for candidate in prefecture_area_dashboard.sales_opportunity_candidates %}
@@ -119,7 +119,7 @@
                             {% else %}
                                 <div class="empty-dashboard mb-4">
                                     <i class="fas fa-cloud-sun-rain text-muted mb-2"></i>
-                                    <p class="small text-muted mb-0">赤信号の都道府県が出ると売り込み候補が表示されます。</p>
+                                    <p class="small text-muted mb-0">警報・注意報のある都道府県が出ると売り込み候補が表示されます。</p>
                                 </div>
                             {% endif %}
 
@@ -129,10 +129,10 @@
                                     {% for candidate in dispatch_candidates %}
                                         <div class="dispatch-item">
                                             <div class="d-flex justify-content-between gap-2">
-                                                <strong>{{ candidate.origin_name }} → {{ candidate.target_market_name }}</strong>
+                                                <strong>{{ candidate.relation_label }}</strong>
                                                 <span class="badge bg-secondary">{{ candidate.logistics_status }}</span>
                                             </div>
-                                            <div class="small text-muted mt-1">{{ candidate.main_crop_name }} / Risk {{ candidate.risk_score }}</div>
+                                            <div class="small text-muted mt-1">{{ candidate.main_crop_name }} / 天気リスク {{ candidate.weather_risk_index }}</div>
                                             <p class="small mb-0 mt-2">{{ candidate.reason }}</p>
                                         </div>
                                     {% endfor %}
@@ -140,7 +140,7 @@
                             {% else %}
                                 <div class="empty-dashboard">
                                     <i class="fas fa-route text-muted mb-2"></i>
-                                    <p class="small text-muted mb-0">圃場が登録されると配車候補が表示されます。</p>
+                                    <p class="small text-muted mb-0">警報・注意報のある都道府県が出ると配車候補が表示されます。</p>
                                 </div>
                             {% endif %}
                         </div>
@@ -165,7 +165,7 @@
                                     <th>天気（予報日）</th>
                                     <th class="text-end">圃場数</th>
                                     <th class="text-end">企業</th>
-                                    <th>主要作物</th>
+                                    <th>登録作物</th>
                                     <th class="text-end">リスク指数</th>
                                     <th>警報・注意報</th>
                                 </tr>
@@ -192,7 +192,7 @@
                                         </td>
                                         <td class="text-end">{{ area.land_count }}圃場</td>
                                         <td class="text-end">{{ area.company_count }}</td>
-                                        <td>{{ area.main_crop_name }}</td>
+                                        <td>{{ area.crop_summary }}</td>
                                         <td class="text-end">{{ area.weather_risk_index }}</td>
                                         <td>{{ area.warning_summary }}</td>
                                     </tr>

--- a/soil_analysis/tests/management/commands/test_prefecture_representative_fixtures.py
+++ b/soil_analysis/tests/management/commands/test_prefecture_representative_fixtures.py
@@ -78,7 +78,7 @@ class PrefectureRepresentativeFixtureCommandTest(TestCase):
         シナリオ:
         - 入力: 代表作物つき圃場データを作成済みのDB状態。
         - 処理: 都道府県別商圏Serviceを実行する。
-        - 期待値: 47都道府県すべてに3圃場が入り、主要作物が未設定にならないこと。
+        - 期待値: 47都道府県すべてに3圃場が入り、登録作物が3つ集計されること。
         """
         self._create_reference_masters()
         call_command("generate_prefecture_representative_fixtures", verbosity=0)
@@ -91,6 +91,7 @@ class PrefectureRepresentativeFixtureCommandTest(TestCase):
         self.assertTrue(
             all(area.main_crop_name != "未設定" for area in dashboard.areas)
         )
+        self.assertTrue(all(len(area.crop_names) == 3 for area in dashboard.areas))
 
     def _create_reference_masters(self):
         sampling_staff = get_user_model().objects.create(

--- a/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
+++ b/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
@@ -93,7 +93,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         シナリオ:
         - 入力: 静岡県に圃場、作物台帳、JMA警報が登録されているDB状態。
         - 処理: 都道府県別商圏Serviceを実行する。
-        - 期待値: 静岡県商圏に圃場数、企業数、主要作物、警報数、天気が反映されること。
+        - 期待値: 静岡県商圏に圃場数、企業数、登録作物、警報数、天気が反映されること。
         """
         city = self._get_city("静岡県")
         land = Land.objects.create(
@@ -134,6 +134,8 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertEqual(shizuoka.land_count, 1)
         self.assertEqual(shizuoka.company_count, 1)
         self.assertEqual(shizuoka.main_crop_name, "トマト")
+        self.assertEqual(shizuoka.crop_names, ["トマト"])
+        self.assertEqual(shizuoka.crop_summary, "トマト")
         self.assertEqual(shizuoka.japan_map_code, 22)
         self.assertEqual(shizuoka.total_area, 12.5)
         self.assertEqual(shizuoka.warning_city_count, 1)
@@ -337,11 +339,12 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
     def test_build_creates_sales_opportunity_to_warning_prefecture(self):
         """
         シナリオ:
-        - 入力: 静岡県に晴れのトマト圃場、千葉県に雨と警報付きのトマト圃場があるDB状態。
+        - 入力: 静岡県に晴れのトマト圃場、岐阜県に晴れの別作物圃場、千葉県に雨と警報付きのトマト圃場があるDB状態。
         - 処理: 都道府県別商圏Serviceを実行する。
-        - 期待値: 静岡県→千葉県の一方向売り込み候補が天気と警報由来のリスク指数付きで返ること。
+        - 期待値: 同じトマトを出せる静岡県→千葉県の売り込み候補と配車候補だけが天気リスク指数付きで返ること。
         """
         shizuoka_city = self._get_city("静岡県")
+        gifu_city = self._get_city("岐阜県")
         chiba_city = self._get_city("千葉県")
         shizuoka_land = Land.objects.create(
             name="静岡トマト圃場",
@@ -350,6 +353,14 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
             cultivation_type=self.cultivation_type,
             owner=self.user,
             center="34.74424,137.64905",
+        )
+        gifu_land = Land.objects.create(
+            name="岐阜きゅうり圃場",
+            company=self.company,
+            jma_city=gifu_city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="35.423,136.761",
         )
         chiba_land = Land.objects.create(
             name="千葉トマト圃場",
@@ -365,6 +376,16 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
             sampling_date="2026-03-01",
             analytical_agency=self.company,
             crop=self.crop,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        cucumber = Crop.objects.create(name="きゅうり")
+        LandLedger.objects.create(
+            land=gifu_land,
+            land_period=self.period,
+            sampling_date="2026-03-01",
+            analytical_agency=self.company,
+            crop=cucumber,
             sampling_method=self.sampling_method,
             sampling_staff=self.user,
         )
@@ -392,21 +413,105 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         )
 
         prefecture_area_dashboard = PrefectureCommercialAreaService.build()
-        candidate = prefecture_area_dashboard.sales_opportunity_candidates[0]
+        sales_candidate = prefecture_area_dashboard.sales_opportunity_candidates[0]
+        dispatch_candidate = prefecture_area_dashboard.dispatch_candidates[0]
 
         self.assertEqual(prefecture_area_dashboard.sales_opportunity_candidate_count, 1)
-        self.assertEqual(candidate.relation_label, "静岡県→千葉県")
-        self.assertEqual(candidate.target_name, "千葉県")
-        self.assertEqual(candidate.main_crop_name, "トマト")
-        self.assertEqual(candidate.weather_risk_index, 4.2)
+        self.assertEqual(sales_candidate.relation_label, "静岡県→千葉県")
+        self.assertEqual(sales_candidate.target_name, "千葉県")
+        self.assertEqual(sales_candidate.main_crop_name, "トマト")
+        self.assertEqual(sales_candidate.weather_risk_index, 4.2)
         self.assertEqual(
-            candidate.weather_risk_index,
+            sales_candidate.weather_risk_index,
             self._find_area(
                 prefecture_area_dashboard.areas, "千葉県"
             ).weather_risk_index,
         )
-        self.assertIn("大雨警報", candidate.reason)
-        self.assertIn("警報・注意報がない", candidate.reason)
+        self.assertIn("大雨警報", sales_candidate.reason)
+        self.assertIn("同じトマトを出せる", sales_candidate.reason)
+        self.assertEqual(prefecture_area_dashboard.dispatch_candidate_count, 1)
+        self.assertEqual(dispatch_candidate.relation_label, "静岡県→千葉県")
+        self.assertEqual(dispatch_candidate.target_prefecture_name, "千葉県")
+        self.assertEqual(dispatch_candidate.weather_risk_index, 4.2)
+        self.assertEqual(dispatch_candidate.logistics_status, "代替便確認中")
+        self.assertFalse(hasattr(dispatch_candidate, "target_market_name"))
+        self.assertFalse(hasattr(dispatch_candidate, "risk_score"))
+
+    def test_build_creates_sales_opportunity_to_rainy_prefecture_by_same_crop(self):
+        """
+        シナリオ:
+        - 入力: 静岡県に晴れのなばな圃場、三重県に雨で警報なしの3作物圃場があるDB状態。
+        - 処理: 都道府県別商圏Serviceを実行する。
+        - 期待値: 三重県の3作物が表示され、同じなばなを出せる静岡県が候補になること。
+        """
+        shizuoka_city = self._get_city("静岡県")
+        mie_city = self._get_city("三重県")
+        nabana = Crop.objects.create(name="なばな")
+        tea = Crop.objects.create(name="茶")
+        rice = Crop.objects.create(name="米")
+        shizuoka_land = Land.objects.create(
+            name="静岡なばな圃場",
+            company=self.company,
+            jma_city=shizuoka_city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="34.74424,137.64905",
+        )
+        mie_lands = [
+            Land.objects.create(
+                name=f"三重{crop.name}圃場",
+                company=self.company,
+                jma_city=mie_city,
+                cultivation_type=self.cultivation_type,
+                owner=self.user,
+                center="34.730,136.508",
+            )
+            for crop in (tea, rice, nabana)
+        ]
+        LandLedger.objects.create(
+            land=shizuoka_land,
+            land_period=self.period,
+            sampling_date="2026-03-01",
+            analytical_agency=self.company,
+            crop=nabana,
+            sampling_method=self.sampling_method,
+            sampling_staff=self.user,
+        )
+        for mie_land, crop in zip(mie_lands, (tea, rice, nabana), strict=True):
+            LandLedger.objects.create(
+                land=mie_land,
+                land_period=self.period,
+                sampling_date="2026-03-01",
+                analytical_agency=self.company,
+                crop=crop,
+                sampling_method=self.sampling_method,
+                sampling_staff=self.user,
+            )
+        JmaWeather.objects.create(
+            jma_region=mie_city.jma_region,
+            reporting_date=date(2026, 6, 16),
+            jma_weather_code=self.rainy_weather_code,
+            weather_text="雨",
+            wind_text="北の風",
+            wave_text="なし",
+            avg_rain_probability=80,
+            avg_min_temperature=18,
+            avg_max_temperature=22,
+            avg_max_wind_speed=8,
+        )
+
+        prefecture_area_dashboard = PrefectureCommercialAreaService.build()
+        mie = self._find_area(prefecture_area_dashboard.areas, "三重県")
+        candidate = prefecture_area_dashboard.sales_opportunity_candidates[0]
+
+        self.assertEqual(mie.crop_names, ["なばな", "米", "茶"])
+        self.assertEqual(mie.crop_summary, "なばな、米、茶")
+        self.assertEqual(prefecture_area_dashboard.sales_opportunity_candidate_count, 1)
+        self.assertEqual(candidate.relation_label, "静岡県→三重県")
+        self.assertEqual(candidate.target_name, "三重県")
+        self.assertEqual(candidate.main_crop_name, "なばな")
+        self.assertEqual(candidate.weather_risk_index, 4.0)
+        self.assertIn("雨", candidate.reason)
 
     def test_dashboard_orders_areas_by_high_weather_risk(self):
         """
@@ -563,7 +668,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertNotContains(response, "<th>状態</th>", html=True)
         self.assertNotContains(response, "出荷信号")
         self.assertNotContains(response, "私は天気")
-        self.assertContains(response, "赤信号県への売り込み候補")
+        self.assertContains(response, "天気リスク県への売り込み候補")
         self.assertContains(response, "売り込み候補")
         self.assertContains(response, "配車候補キュー")
         self.assertContains(response, "企業別圃場一覧")


### PR DESCRIPTION
## Summary
soil_analysis の配車候補キューを、仮想市場ではなく都道府県間の一人称商圏関係として表示するように再設計しました。

- `DispatchCandidateVO` から `target_market_name` / `risk_score` 前提を外し、相手先都道府県・関係ラベル・天気リスク指数を持つVOへ更新
- `PrefectureCommercialAreaVO` に `crop_names` / `crop_summary` を追加し、3圃場3作物があれば一覧と地図詳細に複数の登録作物を表示
- 配車候補キューは天気リスク県への売り込み候補から派生させ、`静岡県→三重県` のような都道府県→都道府県の関係として表示
- 売り込み候補は、天気リスク指数が高い都道府県に対して、同じ登録作物を持ち警報・注意報がない他都道府県だけを候補化
- 雨・雪などで `weather_risk_index >= 4.0` になった都道府県は、警報・注意報がなくても配車候補の起点として扱う
- 画面上の配車候補表示を `Risk` ではなく `天気リスク` に変更し、空状態も警報・注意報のある都道府県が出たときの候補表示へ文言調整
- 旧来の「赤信号」語彙を、現在の実装に合わせて「天気リスク」「警報・注意報」へ整理

## 目検による動作確認手順
- [x] soil_analysis トップページで、全国商圏リスクランキングの登録作物が複数作物表示になること
- [x] 地図で都道府県を選択した詳細表示でも、登録作物が複数作物表示になること
- [x] 配車候補キューが都道府県→都道府県の関係として表示されること（現fixtureでは候補が出ない場合があるため、今回は画面上の確認は不問）
- [x] 配車候補キューに `首都圏市場` / `関西市場` のような仮想市場名が表示されないこと（現fixtureでは候補が出ない場合があるため、今回は画面上の確認は不問）
- [x] 配車候補キューの指標が `Risk` ではなく `天気リスク` として表示されること（現fixtureでは候補が出ない場合があるため、今回は画面上の確認は不問）
- [x] 天気リスクが高い県と同じ登録作物を持つ他県だけが売り込み・配車候補になること（現fixtureでは成立する県間ペアが不足しているため、今回は画面上の確認は不問。fixture調整は #776 で対応）

## 自動テストでカバーできた範囲
- `python -m black soil_analysis\domain\valueobject\prefecture_commercial_area.py soil_analysis\domain\service\prefecture_commercial_area.py soil_analysis\tests\test_prefecture_commercial_area_dashboard.py soil_analysis\tests\management\commands\test_prefecture_representative_fixtures.py`
- `python manage.py test soil_analysis.tests.test_prefecture_commercial_area_dashboard soil_analysis.tests.management.commands.test_prefecture_representative_fixtures`
- `python manage.py test soil_analysis`

商圏VO/Service、トップページ表示、都道府県間の売り込み候補と配車候補、複数の登録作物表示、同じ登録作物のみ候補化する条件、警報なしの雨天リスク起点、soil_analysis アプリ全体の回帰を確認しました。

## 関連Issue
Closes #773
https://github.com/duri0214/portfolio/issues/773
