### PR TITLE
#774 soil_analysis｜地図クリックで都道府県詳細ページへ遷移する

### DIFF
--- a/soil_analysis/domain/service/prefecture_commercial_area.py
+++ b/soil_analysis/domain/service/prefecture_commercial_area.py
@@ -112,7 +112,12 @@ class PrefectureCommercialAreaService:
             )
             for japan_map_code, prefecture_name in JAPAN_MAP_PREFECTURES
         ]
-        sales_opportunity_candidates = cls._build_sales_opportunity_candidates(areas)
+        all_sales_opportunity_candidates = cls._build_all_sales_opportunity_candidates(
+            areas
+        )
+        sales_opportunity_candidates = cls._select_top_sales_opportunity_candidates(
+            all_sales_opportunity_candidates
+        )
         dispatch_candidates = cls._build_dispatch_candidates(
             sales_opportunity_candidates
         )
@@ -120,6 +125,7 @@ class PrefectureCommercialAreaService:
             areas=areas,
             dispatch_candidates=dispatch_candidates,
             sales_opportunity_candidates=sales_opportunity_candidates,
+            all_sales_opportunity_candidates=all_sales_opportunity_candidates,
         )
 
     @staticmethod
@@ -454,29 +460,27 @@ class PrefectureCommercialAreaService:
         return candidates
 
     @classmethod
-    def _build_sales_opportunity_candidates(
+    def _build_all_sales_opportunity_candidates(
         cls,
         areas: list[PrefectureCommercialAreaVO],
     ) -> list[SalesOpportunityCandidateVO]:
         """
-        天気リスクが高い商圏へ同じ登録作物を持つ他都道府県から売り込む候補リストを生成します。
+        天気リスクが高い商圏へ同じ登録作物を持つ他都道府県から売り込む全候補を生成します。
 
         雨・雪や警報・注意報で天気リスク指数が高い商圏を
         「登録作物の出荷が止まりやすい地域」とみなし、同じ登録作物を持ち、
         対象より天気リスク指数が低い他商圏を売り込み元候補にします。
         隣接県が候補になる場合は、遠方県より優先します。
         ここでいう隣接県は、JMAの大きい地域が同じ都道府県として扱います。
-        候補はいったん全量生成し、売り込み先のリスク、同一JMA地域、
-        売り込み元のリスクの順に並べてから、売り込み先都道府県ごとに
-        先頭1件だけを残します。これにより、47都道府県それぞれに対して
-        もっとも強い売り込み元候補を1件ずつ選べます。
+        候補は売り込み先のリスク、同一JMA地域、売り込み元のリスクの順に
+        並べます。詳細ページでは、この全量候補を都道府県で絞り込んで表示します。
         A県→B県とB県→A県は別々の関係として扱うため、候補は一方向のVOで返します。
 
         Args:
             areas: 都道府県単位の商圏VO一覧。
 
         Returns:
-            list[SalesOpportunityCandidateVO]: リスク指数つきの売り込み候補。
+            list[SalesOpportunityCandidateVO]: リスク指数つきの売り込み全候補。
         """
         target_areas = [
             area
@@ -521,7 +525,7 @@ class PrefectureCommercialAreaService:
                     )
                 )
 
-        sorted_candidates = sorted(
+        return sorted(
             candidates,
             key=lambda candidate: (
                 -candidate.weather_risk_index,
@@ -532,9 +536,25 @@ class PrefectureCommercialAreaService:
             ),
         )
 
+    @staticmethod
+    def _select_top_sales_opportunity_candidates(
+        candidates: list[SalesOpportunityCandidateVO],
+    ) -> list[SalesOpportunityCandidateVO]:
+        """
+        全量候補から売り込み先都道府県ごとの代表候補だけを選びます。
+
+        トップページや配車候補キューでは全国俯瞰として情報量を絞るため、
+        売り込み先ごとに最も優先度の高い候補を1件だけ残します。
+
+        Args:
+            candidates: 優先順に並んだ売り込み全候補。
+
+        Returns:
+            list[SalesOpportunityCandidateVO]: 売り込み先ごとの代表候補。
+        """
         selected_candidates = []
         selected_target_names = set()
-        for candidate in sorted_candidates:
+        for candidate in candidates:
             if candidate.target_name in selected_target_names:
                 continue
             selected_candidates.append(candidate)

--- a/soil_analysis/domain/service/prefecture_commercial_area.py
+++ b/soil_analysis/domain/service/prefecture_commercial_area.py
@@ -1,4 +1,5 @@
 from collections import Counter, defaultdict
+from dataclasses import replace
 
 from soil_analysis.domain.valueobject.prefecture_commercial_area import (
     DispatchCandidateVO,
@@ -115,6 +116,16 @@ class PrefectureCommercialAreaService:
         all_sales_opportunity_candidates = cls._build_all_sales_opportunity_candidates(
             areas
         )
+        offer_counts = Counter(
+            candidate.target_name for candidate in all_sales_opportunity_candidates
+        )
+        areas = [
+            replace(
+                area,
+                sales_offer_count=offer_counts[area.prefecture_name],
+            )
+            for area in areas
+        ]
         sales_opportunity_candidates = cls._select_top_sales_opportunity_candidates(
             all_sales_opportunity_candidates
         )
@@ -337,6 +348,7 @@ class PrefectureCommercialAreaService:
             weather_icon_image=weather.icon_image,
             weather_code=weather.code,
             weather_reporting_date=weather.reporting_date,
+            sales_offer_count=0,
         )
 
     @staticmethod

--- a/soil_analysis/domain/valueobject/prefecture_commercial_area.py
+++ b/soil_analysis/domain/valueobject/prefecture_commercial_area.py
@@ -215,6 +215,7 @@ class PrefectureCommercialAreaVO:
         weather_icon_image: 一番未来の予報日の天気アイコンファイル名。
         weather_code: 一番未来の予報日の天気コード。
         weather_reporting_date: 一番未来の予報日。
+        sales_offer_count: 売り込み先として受けられるオファー候補数。
     """
 
     prefecture_id: int
@@ -235,6 +236,7 @@ class PrefectureCommercialAreaVO:
     weather_icon_image: str
     weather_code: str
     weather_reporting_date: str
+    sales_offer_count: int
 
     @property
     def status_label(self) -> str:
@@ -323,6 +325,7 @@ class PrefectureCommercialAreaVO:
             "weatherIconImage": self.weather_icon_image,
             "weatherCode": self.weather_code,
             "weatherReportingDate": self.weather_reporting_date,
+            "salesOfferCount": self.sales_offer_count,
         }
 
 

--- a/soil_analysis/domain/valueobject/prefecture_commercial_area.py
+++ b/soil_analysis/domain/valueobject/prefecture_commercial_area.py
@@ -419,12 +419,14 @@ class PrefectureCommercialAreaDashboardVO:
     Attributes:
         areas: 都道府県単位の商圏一覧。
         dispatch_candidates: 都道府県間の配車候補一覧。
-        sales_opportunity_candidates: 天気リスクが高い商圏への売り込み候補一覧。
+        sales_opportunity_candidates: 都道府県ごとの代表として選抜した売り込み候補一覧。
+        all_sales_opportunity_candidates: 全量の売り込み候補一覧。
     """
 
     areas: list[PrefectureCommercialAreaVO]
     dispatch_candidates: list[DispatchCandidateVO]
     sales_opportunity_candidates: list[SalesOpportunityCandidateVO]
+    all_sales_opportunity_candidates: list[SalesOpportunityCandidateVO]
 
     @property
     def area_count(self) -> int:

--- a/soil_analysis/static/soil_analysis/css/home.css
+++ b/soil_analysis/static/soil_analysis/css/home.css
@@ -25,6 +25,40 @@
     color: #627d98;
 }
 
+.market-kpi-text {
+    display: grid;
+    align-content: start;
+    gap: 8px;
+}
+
+.market-kpi-value {
+    display: block;
+    color: #102a43;
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}
+
+.market-kpi-meta {
+    display: block;
+    color: #627d98;
+    font-size: 0.86rem;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.market-weather-value {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.market-weather-value img {
+    flex: 0 0 auto;
+}
+
 .market-legend {
     display: flex;
     flex-wrap: wrap;

--- a/soil_analysis/static/soil_analysis/css/home.css
+++ b/soil_analysis/static/soil_analysis/css/home.css
@@ -56,6 +56,7 @@
     display: flex;
     justify-content: center;
     min-height: 420px;
+    cursor: pointer;
     overflow: hidden;
 }
 

--- a/soil_analysis/static/soil_analysis/js/home.js
+++ b/soil_analysis/static/soil_analysis/js/home.js
@@ -38,6 +38,8 @@ document.addEventListener("DOMContentLoaded", () => {
             hoverColor: palette.hoverColor,
         };
     });
+    const detailUrlTemplate = mapElement.dataset.detailUrlTemplate || "";
+    const buildDetailUrl = (area) => detailUrlTemplate.replace("999", area.code);
 
     const renderDetail = (area) => {
         detailElement.replaceChildren();
@@ -54,7 +56,12 @@ document.addEventListener("DOMContentLoaded", () => {
         const risk = document.createElement("span");
         risk.textContent = `予報日 ${area.weatherReportingDate || "未取得"} / 警報・注意報 ${area.warningSummary}`;
 
-        detailElement.append(title, jmaArea, summary, risk);
+        const detailLink = document.createElement("a");
+        detailLink.className = "btn btn-sm btn-primary justify-self-start mt-2";
+        detailLink.href = buildDetailUrl(area);
+        detailLink.textContent = "詳細ページへ";
+
+        detailElement.append(title, jmaArea, summary, risk, detailLink);
     };
 
     try {

--- a/soil_analysis/static/soil_analysis/js/home.js
+++ b/soil_analysis/static/soil_analysis/js/home.js
@@ -56,12 +56,15 @@ document.addEventListener("DOMContentLoaded", () => {
         const risk = document.createElement("span");
         risk.textContent = `予報日 ${area.weatherReportingDate || "未取得"} / 警報・注意報 ${area.warningSummary}`;
 
+        const offerCount = document.createElement("span");
+        offerCount.textContent = `オファー候補 ${area.salesOfferCount || 0}件`;
+
         const detailLink = document.createElement("a");
         detailLink.className = "btn btn-sm btn-primary justify-self-start mt-2";
         detailLink.href = buildDetailUrl(area);
         detailLink.textContent = "詳細ページへ";
 
-        detailElement.append(title, jmaArea, summary, risk, detailLink);
+        detailElement.append(title, jmaArea, summary, risk, offerCount, detailLink);
     };
 
     try {

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -21,7 +21,7 @@
                     <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-4">
                         <div>
                             <h1 class="display-6 mb-2">都道府県別商圏マップ</h1>
-                            <p class="lead mb-0">47都道府県の商圏を俯瞰し、出荷候補と物流リスクを確認します。</p>
+                            <p class="lead mb-0">47都道府県の商圏を俯瞰し、天気リスクと登録状況を確認します。</p>
                         </div>
                         <div class="d-flex flex-wrap gap-2 align-content-start">
                             <a class="btn btn-primary" href="{% url 'soil:company_create' %}">
@@ -69,15 +69,15 @@
                         </div>
                         <div class="col-6 col-lg-3">
                             <div class="market-kpi">
-                                <span class="market-kpi-label">売り込み候補</span>
-                                <strong>{{ prefecture_area_dashboard.sales_opportunity_candidate_count }}</strong>
-                                <small>件</small>
+                                <span class="market-kpi-label">注意商圏</span>
+                                <strong>{{ prefecture_area_dashboard.risk_area_count }}</strong>
+                                <small>商圏</small>
                             </div>
                         </div>
                     </div>
 
                     <div class="row g-4">
-                        <div class="col-12 col-xl-8">
+                        <div class="col-12">
                             <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
                                 <h2 class="h5 mb-0"><i class="fas fa-map me-2 text-muted"></i>日本地図商圏マップ</h2>
                                 <div class="d-flex flex-wrap align-items-center gap-3">
@@ -104,93 +104,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-12 col-xl-4">
-                            <h2 class="h5 mb-2"><i class="fas fa-bullhorn me-2 text-muted"></i>天気リスク県への売り込み候補</h2>
-                            {% if prefecture_area_dashboard.sales_opportunity_candidates %}
-                                <div class="sales-opportunity-list mb-4">
-                                    {% for candidate in prefecture_area_dashboard.sales_opportunity_candidates %}
-                                        <div class="sales-opportunity-item">
-                                            <div class="d-flex justify-content-between gap-2">
-                                                <strong class="d-flex flex-wrap align-items-center gap-1">
-                                                    <span>{{ candidate.origin_name }}</span>
-                                                    {% if candidate.origin_weather_icon_image %}
-                                                        {% with icon_path="soil_analysis/images/weather/svg/"|add:candidate.origin_weather_icon_image %}
-                                                            <img src="{% static icon_path %}"
-                                                                 alt="{{ candidate.origin_weather_name }}"
-                                                                 title="{{ candidate.origin_weather_name }}"
-                                                                 width="22"
-                                                                 height="22">
-                                                        {% endwith %}
-                                                    {% endif %}
-                                                    <span>→</span>
-                                                    <span>{{ candidate.target_name }}</span>
-                                                    {% if candidate.target_weather_icon_image %}
-                                                        {% with icon_path="soil_analysis/images/weather/svg/"|add:candidate.target_weather_icon_image %}
-                                                            <img src="{% static icon_path %}"
-                                                                 alt="{{ candidate.target_weather_name }}"
-                                                                 title="{{ candidate.target_weather_name }}"
-                                                                 width="22"
-                                                                 height="22">
-                                                        {% endwith %}
-                                                    {% endif %}
-                                                </strong>
-                                                <span class="badge bg-danger">リスク {{ candidate.weather_risk_index }}</span>
-                                            </div>
-                                            <div class="small text-muted mt-1">{{ candidate.main_crop_name }}</div>
-                                            <p class="small mb-0 mt-2">{{ candidate.reason }}</p>
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            {% else %}
-                                <div class="empty-dashboard mb-4">
-                                    <i class="fas fa-cloud-sun-rain text-muted mb-2"></i>
-                                    <p class="small text-muted mb-0">警報・注意報のある都道府県が出ると売り込み候補が表示されます。</p>
-                                </div>
-                            {% endif %}
-
-                            <h2 class="h5 mb-2"><i class="fas fa-truck-moving me-2 text-muted"></i>配車候補キュー</h2>
-                            {% if dispatch_candidates %}
-                                <div class="dispatch-queue">
-                                    {% for candidate in dispatch_candidates %}
-                                        <div class="dispatch-item">
-                                            <div class="d-flex justify-content-between gap-2">
-                                                <strong class="d-flex flex-wrap align-items-center gap-1">
-                                                    <span>{{ candidate.origin_name }}</span>
-                                                    {% if candidate.origin_weather_icon_image %}
-                                                        {% with icon_path="soil_analysis/images/weather/svg/"|add:candidate.origin_weather_icon_image %}
-                                                            <img src="{% static icon_path %}"
-                                                                 alt="{{ candidate.origin_weather_name }}"
-                                                                 title="{{ candidate.origin_weather_name }}"
-                                                                 width="22"
-                                                                 height="22">
-                                                        {% endwith %}
-                                                    {% endif %}
-                                                    <span>→</span>
-                                                    <span>{{ candidate.target_prefecture_name }}</span>
-                                                    {% if candidate.target_weather_icon_image %}
-                                                        {% with icon_path="soil_analysis/images/weather/svg/"|add:candidate.target_weather_icon_image %}
-                                                            <img src="{% static icon_path %}"
-                                                                 alt="{{ candidate.target_weather_name }}"
-                                                                 title="{{ candidate.target_weather_name }}"
-                                                                 width="22"
-                                                                 height="22">
-                                                        {% endwith %}
-                                                    {% endif %}
-                                                </strong>
-                                                <span class="badge bg-secondary">{{ candidate.logistics_status }}</span>
-                                            </div>
-                                            <div class="small text-muted mt-1">{{ candidate.main_crop_name }} / 天気リスク {{ candidate.weather_risk_index }}</div>
-                                            <p class="small mb-0 mt-2">{{ candidate.reason }}</p>
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            {% else %}
-                                <div class="empty-dashboard">
-                                    <i class="fas fa-route text-muted mb-2"></i>
-                                    <p class="small text-muted mb-0">警報・注意報のある都道府県が出ると配車候補が表示されます。</p>
-                                </div>
-                            {% endif %}
-                        </div>
                     </div>
                 </div>
             </div>
@@ -201,7 +114,7 @@
                 </div>
                 <div class="risk-note mb-3">
                     <strong>これは天気リスクを織り込んだ全国ランキングです。</strong>
-                    <span>天気コードのカテゴリと警報・注意報件数から、都道府県ごとのリスク指数を算出しています。数値が高いほど天気由来で出荷しづらい地域と読み、雨系の出荷元の代わりにどの商圏へ売り込み・配車戦略を取るかを考える材料にできます。</span>
+                    <span>天気コードのカテゴリと警報・注意報件数から、都道府県ごとのリスク指数を算出しています。数値が高いほど天気由来で出荷しづらい地域と読み、詳細ページで深掘りする商圏を選ぶ材料にできます。</span>
                 </div>
                 <div class="card border-0 shadow-sm">
                     <div class="table-responsive">
@@ -252,76 +165,6 @@
                 </div>
             </div>
 
-            <!-- 企業別圃場一覧 -->
-            <div class="col-12">
-                <div class="d-flex justify-content-between align-items-center mb-3">
-                    <h2 class="h3 mb-0"><i class="fas fa-list me-2 text-muted"></i>企業別圃場一覧</h2>
-                </div>
-
-                {% if companies %}
-                    <div class="card border-0 shadow-sm">
-                        <div class="table-responsive">
-                            <table class="table table-striped table-hover mb-0">
-                                <thead class="table-light">
-                                    <tr>
-                                        <th>企業名</th>
-                                        <th>圃場名</th>
-                                        <th class="text-end">操作</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for company in companies %}
-                                        {% if company.land_set.all %}
-                                            {% for land in company.land_set.all %}
-                                                <tr>
-                                                    {% if forloop.first %}
-                                                        <td rowspan="{{ company.land_set.all|length }}" class="align-middle">
-                                                            <a href="{% url 'soil:company_detail' company.pk %}" class="fw-semibold text-decoration-none">{{ company.name }}</a>
-                                                        </td>
-                                                    {% endif %}
-                                                    <td class="align-middle">
-                                                        <a href="{% url 'soil:land_detail' company.pk land.pk %}" class="text-decoration-none">{{ land.name }}</a>
-                                                    </td>
-                                                    {% if forloop.first %}
-                                                        <td rowspan="{{ company.land_set.all|length }}" class="align-middle text-end">
-                                                            <a class="btn btn-sm btn-outline-primary" href="{% url 'soil:land_create' company.pk %}">
-                                                                <i class="fas fa-plus me-1"></i>圃場の追加
-                                                            </a>
-                                                        </td>
-                                                    {% endif %}
-                                                </tr>
-                                            {% endfor %}
-                                        {% else %}
-                                            <tr>
-                                                <td class="align-middle">
-                                                    <a href="{% url 'soil:company_detail' company.pk %}" class="fw-semibold text-decoration-none">{{ company.name }}</a>
-                                                </td>
-                                                <td class="text-muted align-middle">（圃場なし）</td>
-                                                <td class="text-end align-middle">
-                                                    <a class="btn btn-sm btn-outline-primary" href="{% url 'soil:land_create' company.pk %}">
-                                                        <i class="fas fa-plus me-1"></i>圃場の追加
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                        {% endif %}
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="card bg-light border-0 py-5 text-center">
-                        <div class="card-body">
-                            <i class="fas fa-building fa-3x text-muted mb-3 opacity-25"></i>
-                            <h4 class="text-muted mb-3">まだ企業が登録されていません</h4>
-                            <p class="text-secondary small mb-4">上のボタンから農業法人を追加してください。</p>
-                            <a href="{% url 'soil:company_create' %}" class="btn btn-primary">
-                                <i class="fas fa-plus me-1"></i>企業を追加する
-                            </a>
-                        </div>
-                    </div>
-                {% endif %}
-            </div>
         </div>
     </div>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -127,6 +127,7 @@
                                     <th class="text-end">企業</th>
                                     <th>登録作物</th>
                                     <th class="text-end">リスク指数</th>
+                                    <th class="text-end">オファー候補</th>
                                     <th>警報・注意報</th>
                                 </tr>
                             </thead>
@@ -156,6 +157,7 @@
                                         <td class="text-end">{{ area.company_count }}</td>
                                         <td>{{ area.crop_summary }}</td>
                                         <td class="text-end">{{ area.weather_risk_index }}</td>
+                                        <td class="text-end">{{ area.sales_offer_count }}件</td>
                                         <td>{{ area.warning_summary }}</td>
                                     </tr>
                                 {% endfor %}

--- a/soil_analysis/templates/soil_analysis/home.html
+++ b/soil_analysis/templates/soil_analysis/home.html
@@ -94,7 +94,10 @@
                             </div>
                             {{ commercial_area_map_data|json_script:"commercial-area-map-data" }}
                             <div class="japan-market-map">
-                                <div id="commercial-area-map" class="commercial-area-map-canvas" aria-label="47都道府県の商圏マップ"></div>
+                                <div id="commercial-area-map"
+                                     class="commercial-area-map-canvas"
+                                     aria-label="47都道府県の商圏マップ"
+                                     data-detail-url-template="{% url 'soil:prefecture_detail' 999 %}"></div>
                                 <div class="market-map-detail" id="commercial-area-map-detail" aria-live="polite">
                                     <strong>地図から都道府県を選択</strong>
                                     <span>商圏の集計値を確認できます。</span>
@@ -217,7 +220,9 @@
                             <tbody>
                                 {% for area in prefecture_area_dashboard.areas_by_weather_risk %}
                                     <tr>
-                                        <td class="fw-semibold">{{ area.prefecture_name }}</td>
+                                        <td class="fw-semibold">
+                                            <a href="{% url 'soil:prefecture_detail' area.japan_map_code %}" class="text-decoration-none">{{ area.prefecture_name }}</a>
+                                        </td>
                                         <td>
                                             {% if area.weather_icon_image %}
                                                 {% with 'soil_analysis/images/weather/svg/'|add:area.weather_icon_image as weather_icon_path %}
@@ -330,5 +335,5 @@
         window.jpmapInternalMap = window.Map;
         window.Map = window.nativeMapBeforeJpmap;
     </script>
-    <script src="{% static 'soil_analysis/js/home.js' %}?v=770-map-fix-2"></script>
+    <script src="{% static 'soil_analysis/js/home.js' %}?v=774-prefecture-detail"></script>
 {% endblock %}

--- a/soil_analysis/templates/soil_analysis/prefecture/detail.html
+++ b/soil_analysis/templates/soil_analysis/prefecture/detail.html
@@ -1,0 +1,140 @@
+{% extends "soil_analysis/base.html" %}
+{% load static %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'soil_analysis/css/home.css' %}">
+{% endblock %}
+
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'soil:home' %}" class="text-decoration-none">土壌分析CRM</a></li>
+                <li class="breadcrumb-item active" aria-current="page">{{ area.prefecture_name }}</li>
+            </ol>
+        </nav>
+
+        <div class="row g-4">
+            <div class="col-12">
+                <div class="bg-light p-4 p-lg-5 rounded shadow-sm">
+                    <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-4">
+                        <div>
+                            <h1 class="display-6 mb-2">{{ area.prefecture_name }} 詳細</h1>
+                            <p class="lead mb-0">{{ area.jma_area_name|default:"JMAエリア未設定" }} / {{ area.weather_name }} / 天気リスク指数 {{ area.weather_risk_index }}</p>
+                        </div>
+                        <div class="align-content-start">
+                            <a class="btn btn-outline-secondary" href="{% url 'soil:home' %}">
+                                <i class="fas fa-arrow-left me-1"></i>全国商圏マップへ戻る
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="row g-3">
+                        <div class="col-6 col-lg-3">
+                            <div class="market-kpi">
+                                <span class="market-kpi-label">JMAエリア</span>
+                                <strong class="h3">{{ area.jma_area_name|default:"未設定" }}</strong>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-3">
+                            <div class="market-kpi">
+                                <span class="market-kpi-label">天気</span>
+                                {% if area.weather_icon_image %}
+                                    {% with weather_icon_path="soil_analysis/images/weather/svg/"|add:area.weather_icon_image %}
+                                        <img src="{% static weather_icon_path %}"
+                                             alt="{{ area.weather_name }}"
+                                             width="40"
+                                             height="40">
+                                    {% endwith %}
+                                {% endif %}
+                                <strong class="h3">{{ area.weather_name }}</strong>
+                                {% if area.weather_reporting_date %}
+                                    <small>{{ area.weather_reporting_date }}</small>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-3">
+                            <div class="market-kpi">
+                                <span class="market-kpi-label">警報・注意報</span>
+                                <strong class="h3">{{ area.warning_summary }}</strong>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-3">
+                            <div class="market-kpi">
+                                <span class="market-kpi-label">天気リスク指数</span>
+                                <strong>{{ area.weather_risk_index }}</strong>
+                                <small>{{ area.land_count }}圃場 / {{ area.company_count }}社</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 col-xl-5">
+                <h2 class="h4 mb-3"><i class="fas fa-bullhorn me-2 text-muted"></i>天気リスク県への売り込み候補</h2>
+                {% if sales_opportunity_candidates %}
+                    <div class="sales-opportunity-list">
+                        {% for candidate in sales_opportunity_candidates %}
+                            <div class="sales-opportunity-item">
+                                <div class="d-flex justify-content-between gap-2">
+                                    <strong>{{ candidate.relation_label }}</strong>
+                                    <span class="badge bg-danger">リスク {{ candidate.weather_risk_index }}</span>
+                                </div>
+                                <div class="small text-muted mt-1">{{ candidate.main_crop_name }}</div>
+                                <p class="small mb-0 mt-2">{{ candidate.reason }}</p>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="empty-dashboard">
+                        <i class="fas fa-cloud-sun-rain text-muted mb-2"></i>
+                        <p class="small text-muted mb-0">{{ area.prefecture_name }} に関係する売り込み候補はありません。</p>
+                    </div>
+                {% endif %}
+            </div>
+
+            <div class="col-12 col-xl-7">
+                <h2 class="h4 mb-3"><i class="fas fa-list me-2 text-muted"></i>{{ area.prefecture_name }} の企業別圃場一覧</h2>
+                {% if companies %}
+                    <div class="card border-0 shadow-sm">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>企業名</th>
+                                        <th>圃場名</th>
+                                        <th>市区町村</th>
+                                        <th class="text-end">面積</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for company in companies %}
+                                        {% for land in company.land_set.all %}
+                                            <tr>
+                                                {% if forloop.first %}
+                                                    <td rowspan="{{ company.land_set.all|length }}" class="align-middle">
+                                                        <a href="{% url 'soil:company_detail' company.pk %}" class="fw-semibold text-decoration-none">{{ company.name }}</a>
+                                                    </td>
+                                                {% endif %}
+                                                <td>
+                                                    <a href="{% url 'soil:land_detail' company.pk land.pk %}" class="text-decoration-none">{{ land.name }}</a>
+                                                </td>
+                                                <td>{{ land.jma_city.name }}</td>
+                                                <td class="text-end">{{ land.area|default:"-" }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="empty-dashboard">
+                        <i class="fas fa-seedling text-muted mb-2"></i>
+                        <p class="small text-muted mb-0">{{ area.prefecture_name }} に登録済みの圃場はありません。</p>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/soil_analysis/templates/soil_analysis/prefecture/detail.html
+++ b/soil_analysis/templates/soil_analysis/prefecture/detail.html
@@ -31,32 +31,32 @@
 
                     <div class="row g-3">
                         <div class="col-6 col-lg-3">
-                            <div class="market-kpi">
+                            <div class="market-kpi market-kpi-text">
                                 <span class="market-kpi-label">JMAエリア</span>
-                                <strong class="h3">{{ area.jma_area_name|default:"未設定" }}</strong>
+                                <span class="market-kpi-value">{{ area.jma_area_name|default:"未設定" }}</span>
                             </div>
                         </div>
                         <div class="col-6 col-lg-3">
-                            <div class="market-kpi">
+                            <div class="market-kpi market-kpi-text">
                                 <span class="market-kpi-label">天気</span>
-                                {% if area.weather_icon_image %}
-                                    {% with weather_icon_path="soil_analysis/images/weather/svg/"|add:area.weather_icon_image %}
-                                        <img src="{% static weather_icon_path %}"
-                                             alt="{{ area.weather_name }}"
-                                             width="40"
-                                             height="40">
-                                    {% endwith %}
-                                {% endif %}
-                                <strong class="h3">{{ area.weather_name }}</strong>
-                                {% if area.weather_reporting_date %}
-                                    <small>{{ area.weather_reporting_date }}</small>
-                                {% endif %}
+                                <div class="market-weather-value">
+                                    {% if area.weather_icon_image %}
+                                        {% with weather_icon_path="soil_analysis/images/weather/svg/"|add:area.weather_icon_image %}
+                                            <img src="{% static weather_icon_path %}"
+                                                 alt="{{ area.weather_name }}"
+                                                 width="32"
+                                                 height="32">
+                                        {% endwith %}
+                                    {% endif %}
+                                    <span class="market-kpi-value">{{ area.weather_name }}</span>
+                                </div>
+                                <span class="market-kpi-meta">{{ area.weather_reporting_date|default:"予報日未取得" }}</span>
                             </div>
                         </div>
                         <div class="col-6 col-lg-3">
-                            <div class="market-kpi">
+                            <div class="market-kpi market-kpi-text">
                                 <span class="market-kpi-label">警報・注意報</span>
-                                <strong class="h3">{{ area.warning_summary }}</strong>
+                                <span class="market-kpi-value">{{ area.warning_summary }}</span>
                             </div>
                         </div>
                         <div class="col-6 col-lg-3">

--- a/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
+++ b/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
@@ -748,7 +748,11 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertContains(response, "雨系の出荷元の代わり")
         self.assertContains(response, "天気（予報日）")
         self.assertContains(response, '<th class="text-end">リスク指数</th>', html=True)
-        self.assertContains(response, '<td class="fw-semibold">沖縄県</td>', html=True)
+        self.assertContains(
+            response,
+            '<td class="fw-semibold"><a href="/soil_analysis/prefecture/47/detail" class="text-decoration-none">沖縄県</a></td>',
+            html=True,
+        )
         self.assertContains(response, "圃場数")
         self.assertContains(response, "警報・注意報")
         self.assertContains(response, "なし")
@@ -761,7 +765,97 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertContains(response, "売り込み候補")
         self.assertContains(response, "配車候補キュー")
         self.assertContains(response, "企業別圃場一覧")
+        self.assertContains(response, reverse("soil:prefecture_detail", args=[22]))
         self.assertContains(response, "静岡県")
+
+    def test_prefecture_detail_view_displays_area_candidates_and_lands(self):
+        """
+        シナリオ:
+        - 入力: 静岡県から千葉県へ売り込めるトマト圃場と、千葉県の雨天リスクがあるDB状態。
+        - 処理: 静岡県の都道府県詳細ページを表示する。
+        - 期待値: 静岡県の天気・売り込み候補・静岡県の圃場だけが表示され、配車候補は重複表示されないこと。
+        """
+        shizuoka_city = self._get_city("静岡県")
+        chiba_city = self._get_city("千葉県")
+        shizuoka_land = Land.objects.create(
+            name="静岡トマト圃場",
+            company=self.company,
+            jma_city=shizuoka_city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="34.74424,137.64905",
+            area=12.5,
+        )
+        chiba_land = Land.objects.create(
+            name="千葉トマト圃場",
+            company=self.company,
+            jma_city=chiba_city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="35.607,140.106",
+        )
+        for land in (shizuoka_land, chiba_land):
+            LandLedger.objects.create(
+                land=land,
+                land_period=self.period,
+                sampling_date="2026-03-01",
+                analytical_agency=self.company,
+                crop=self.crop,
+                sampling_method=self.sampling_method,
+                sampling_staff=self.user,
+            )
+        JmaWeather.objects.create(
+            jma_region=shizuoka_city.jma_region,
+            reporting_date=date(2026, 6, 16),
+            jma_weather_code=self.sunny_weather_code,
+            weather_text="晴れ",
+            wind_text="北の風",
+            wave_text="なし",
+            avg_rain_probability=10,
+            avg_min_temperature=18,
+            avg_max_temperature=28,
+            avg_max_wind_speed=4,
+        )
+        JmaWarning.objects.create(jma_region=chiba_city.jma_region, warnings="大雨警報")
+        JmaWeather.objects.create(
+            jma_region=chiba_city.jma_region,
+            reporting_date=date(2026, 6, 16),
+            jma_weather_code=self.rainy_weather_code,
+            weather_text="雨",
+            wind_text="北の風",
+            wave_text="なし",
+            avg_rain_probability=80,
+            avg_min_temperature=18,
+            avg_max_temperature=22,
+            avg_max_wind_speed=8,
+        )
+
+        response = self.client.get(reverse("soil:prefecture_detail", args=[22]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["area"].prefecture_name, "静岡県")
+        self.assertContains(response, "静岡県 詳細")
+        self.assertContains(response, "静岡県エリア")
+        self.assertContains(response, "晴れ")
+        self.assertContains(response, "天気リスク指数")
+        self.assertContains(response, "静岡県→千葉県")
+        self.assertContains(response, "静岡トマト圃場")
+        self.assertNotContains(response, "千葉トマト圃場")
+        self.assertNotContains(response, "配車候補キュー")
+
+    def test_prefecture_detail_view_displays_empty_state_without_land(self):
+        """
+        シナリオ:
+        - 入力: 47都道府県マスタのみで沖縄県に圃場や売り込み候補がないDB状態。
+        - 処理: 沖縄県の都道府県詳細ページを表示する。
+        - 期待値: 画面が壊れず、売り込み候補と圃場一覧の空状態が表示されること。
+        """
+        response = self.client.get(reverse("soil:prefecture_detail", args=[47]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "沖縄県 詳細")
+        self.assertContains(response, "沖縄県 に関係する売り込み候補はありません。")
+        self.assertContains(response, "沖縄県 に登録済みの圃場はありません。")
 
     @staticmethod
     def _find_area(areas, prefecture_name):

--- a/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
+++ b/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
@@ -415,10 +415,12 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         prefecture_area_dashboard = PrefectureCommercialAreaService.build()
         sales_candidate = prefecture_area_dashboard.sales_opportunity_candidates[0]
         dispatch_candidate = prefecture_area_dashboard.dispatch_candidates[0]
+        chiba_area = self._find_area(prefecture_area_dashboard.areas, "千葉県")
 
         self.assertEqual(
             len(prefecture_area_dashboard.all_sales_opportunity_candidates), 1
         )
+        self.assertEqual(chiba_area.sales_offer_count, 1)
         self.assertEqual(prefecture_area_dashboard.sales_opportunity_candidate_count, 1)
         self.assertEqual(sales_candidate.relation_label, "静岡県→千葉県")
         self.assertEqual(sales_candidate.target_name, "千葉県")
@@ -427,9 +429,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertEqual(sales_candidate.weather_risk_index, 4.2)
         self.assertEqual(
             sales_candidate.weather_risk_index,
-            self._find_area(
-                prefecture_area_dashboard.areas, "千葉県"
-            ).weather_risk_index,
+            chiba_area.weather_risk_index,
         )
         self.assertIn("大雨警報", sales_candidate.reason)
         self.assertIn("同じトマトを出せる", sales_candidate.reason)
@@ -732,6 +732,9 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertEqual(response.context["prefecture_area_dashboard"].area_count, 47)
         self.assertEqual(len(response.context["commercial_area_map_data"]), 47)
         self.assertIn("jmaAreaName", response.context["commercial_area_map_data"][0])
+        self.assertIn(
+            "salesOfferCount", response.context["commercial_area_map_data"][0]
+        )
         self.assertContains(response, "都道府県別商圏マップ")
         self.assertContains(response, "日本地図商圏マップ")
         self.assertContains(response, "地図から都道府県を選択")
@@ -751,6 +754,9 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertContains(response, "詳細ページで深掘りする商圏")
         self.assertContains(response, "天気（予報日）")
         self.assertContains(response, '<th class="text-end">リスク指数</th>', html=True)
+        self.assertContains(
+            response, '<th class="text-end">オファー候補</th>', html=True
+        )
         self.assertContains(
             response,
             '<td class="fw-semibold"><a href="/soil_analysis/prefecture/47/detail" class="text-decoration-none">沖縄県</a></td>',
@@ -859,6 +865,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["area"].prefecture_name, "千葉県")
+        self.assertEqual(response.context["area"].sales_offer_count, 2)
         self.assertEqual(len(response.context["sales_opportunity_candidates"]), 2)
         self.assertContains(response, "千葉県 詳細")
         self.assertContains(response, "千葉県エリア")

--- a/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
+++ b/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
@@ -863,6 +863,8 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertContains(response, "千葉県 詳細")
         self.assertContains(response, "千葉県エリア")
         self.assertContains(response, "雨")
+        self.assertContains(response, "market-weather-value")
+        self.assertContains(response, "market-kpi-meta")
         self.assertContains(response, "天気リスク指数")
         self.assertContains(response, "静岡県→千葉県")
         self.assertContains(response, "愛知県→千葉県")

--- a/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
+++ b/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
@@ -416,6 +416,9 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         sales_candidate = prefecture_area_dashboard.sales_opportunity_candidates[0]
         dispatch_candidate = prefecture_area_dashboard.dispatch_candidates[0]
 
+        self.assertEqual(
+            len(prefecture_area_dashboard.all_sales_opportunity_candidates), 1
+        )
         self.assertEqual(prefecture_area_dashboard.sales_opportunity_candidate_count, 1)
         self.assertEqual(sales_candidate.relation_label, "静岡県→千葉県")
         self.assertEqual(sales_candidate.target_name, "千葉県")
@@ -772,11 +775,12 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
     def test_prefecture_detail_view_displays_area_candidates_and_lands(self):
         """
         シナリオ:
-        - 入力: 静岡県から千葉県へ売り込めるトマト圃場と、千葉県の雨天リスクがあるDB状態。
-        - 処理: 静岡県の都道府県詳細ページを表示する。
-        - 期待値: 静岡県の天気・売り込み候補・静岡県の圃場だけが表示され、配車候補は重複表示されないこと。
+        - 入力: 静岡県・愛知県から千葉県へ売り込めるトマト圃場と、千葉県の雨天リスクがあるDB状態。
+        - 処理: 千葉県の都道府県詳細ページを表示する。
+        - 期待値: 詳細ページでは同じ売り込み先への複数候補が表示され、配車候補は重複表示されないこと。
         """
         shizuoka_city = self._get_city("静岡県")
+        aichi_city = self._get_city("愛知県")
         chiba_city = self._get_city("千葉県")
         shizuoka_land = Land.objects.create(
             name="静岡トマト圃場",
@@ -787,6 +791,14 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
             center="34.74424,137.64905",
             area=12.5,
         )
+        aichi_land = Land.objects.create(
+            name="愛知トマト圃場",
+            company=self.company,
+            jma_city=aichi_city,
+            cultivation_type=self.cultivation_type,
+            owner=self.user,
+            center="35.180,136.906",
+        )
         chiba_land = Land.objects.create(
             name="千葉トマト圃場",
             company=self.company,
@@ -795,7 +807,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
             owner=self.user,
             center="35.607,140.106",
         )
-        for land in (shizuoka_land, chiba_land):
+        for land in (shizuoka_land, aichi_land, chiba_land):
             LandLedger.objects.create(
                 land=land,
                 land_period=self.period,
@@ -807,6 +819,18 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
             )
         JmaWeather.objects.create(
             jma_region=shizuoka_city.jma_region,
+            reporting_date=date(2026, 6, 16),
+            jma_weather_code=self.sunny_weather_code,
+            weather_text="晴れ",
+            wind_text="北の風",
+            wave_text="なし",
+            avg_rain_probability=10,
+            avg_min_temperature=18,
+            avg_max_temperature=28,
+            avg_max_wind_speed=4,
+        )
+        JmaWeather.objects.create(
+            jma_region=aichi_city.jma_region,
             reporting_date=date(2026, 6, 16),
             jma_weather_code=self.sunny_weather_code,
             weather_text="晴れ",
@@ -831,17 +855,20 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
             avg_max_wind_speed=8,
         )
 
-        response = self.client.get(reverse("soil:prefecture_detail", args=[22]))
+        response = self.client.get(reverse("soil:prefecture_detail", args=[12]))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["area"].prefecture_name, "静岡県")
-        self.assertContains(response, "静岡県 詳細")
-        self.assertContains(response, "静岡県エリア")
-        self.assertContains(response, "晴れ")
+        self.assertEqual(response.context["area"].prefecture_name, "千葉県")
+        self.assertEqual(len(response.context["sales_opportunity_candidates"]), 2)
+        self.assertContains(response, "千葉県 詳細")
+        self.assertContains(response, "千葉県エリア")
+        self.assertContains(response, "雨")
         self.assertContains(response, "天気リスク指数")
         self.assertContains(response, "静岡県→千葉県")
-        self.assertContains(response, "静岡トマト圃場")
-        self.assertNotContains(response, "千葉トマト圃場")
+        self.assertContains(response, "愛知県→千葉県")
+        self.assertContains(response, "千葉トマト圃場")
+        self.assertNotContains(response, "静岡トマト圃場")
+        self.assertNotContains(response, "愛知トマト圃場")
         self.assertNotContains(response, "配車候補キュー")
 
     def test_prefecture_detail_view_displays_empty_state_without_land(self):

--- a/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
+++ b/soil_analysis/tests/test_prefecture_commercial_area_dashboard.py
@@ -711,7 +711,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         シナリオ:
         - 入力: 47都道府県マスタと静岡県の圃場が登録されているDB状態。
         - 処理: soil_analysis のトップページを表示する。
-        - 期待値: 日本地図、全国商圏リスクランキング、配車候補、既存企業別圃場一覧が表示されること。
+        - 期待値: 日本地図と全国商圏リスクランキングが表示され、個別判断用の一覧は表示されないこと。
         """
         city = self._get_city("静岡県")
         Land.objects.create(
@@ -745,7 +745,7 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertContains(
             response, "これは天気リスクを織り込んだ全国ランキングです。"
         )
-        self.assertContains(response, "雨系の出荷元の代わり")
+        self.assertContains(response, "詳細ページで深掘りする商圏")
         self.assertContains(response, "天気（予報日）")
         self.assertContains(response, '<th class="text-end">リスク指数</th>', html=True)
         self.assertContains(
@@ -761,10 +761,11 @@ class PrefectureCommercialAreaDashboardTest(TestCase):
         self.assertNotContains(response, "<th>状態</th>", html=True)
         self.assertNotContains(response, "出荷信号")
         self.assertNotContains(response, "私は天気")
-        self.assertContains(response, "天気リスク県への売り込み候補")
-        self.assertContains(response, "売り込み候補")
-        self.assertContains(response, "配車候補キュー")
-        self.assertContains(response, "企業別圃場一覧")
+        self.assertContains(response, "注意商圏")
+        self.assertNotContains(response, "天気リスク県への売り込み候補")
+        self.assertNotContains(response, "売り込み候補")
+        self.assertNotContains(response, "配車候補キュー")
+        self.assertNotContains(response, "企業別圃場一覧")
         self.assertContains(response, reverse("soil:prefecture_detail", args=[22]))
         self.assertContains(response, "静岡県")
 

--- a/soil_analysis/urls.py
+++ b/soil_analysis/urls.py
@@ -25,6 +25,11 @@ urlpatterns = [
         name="prefecture_cities",
     ),
     path(
+        "prefecture/<int:prefecture_id>/detail",
+        views.PrefectureDetailView.as_view(),
+        name="prefecture_detail",
+    ),
+    path(
         "company/<int:company_id>/land/<int:pk>/detail",
         views.LandDetailView.as_view(),
         name="land_detail",

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -159,7 +159,7 @@ class PrefectureDetailView(ListView):
         context["area"] = area
         context["sales_opportunity_candidates"] = [
             candidate
-            for candidate in prefecture_area_dashboard.sales_opportunity_candidates
+            for candidate in prefecture_area_dashboard.all_sales_opportunity_candidates
             if candidate.origin_name == area.prefecture_name
             or candidate.target_name == area.prefecture_name
         ]

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -123,6 +123,59 @@ class Home(ListView):
         return context
 
 
+class PrefectureDetailView(ListView):
+    model = Company
+    template_name = "soil_analysis/prefecture/detail.html"
+    context_object_name = "companies"
+
+    def get_queryset(self):
+        prefecture_id = self.kwargs["prefecture_id"]
+        land_queryset = (
+            Land.objects.filter(
+                jma_city__jma_region__jma_prefecture__code__startswith=(
+                    f"{prefecture_id:02d}"
+                )
+            )
+            .select_related("jma_city", "cultivation_type")
+            .order_by("name")
+        )
+        return (
+            Company.objects.filter(
+                category__name="農業法人",
+                land__jma_city__jma_region__jma_prefecture__code__startswith=(
+                    f"{prefecture_id:02d}"
+                ),
+            )
+            .prefetch_related(Prefetch("land_set", queryset=land_queryset))
+            .distinct()
+            .order_by("name")
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        prefecture_id = self.kwargs["prefecture_id"]
+        prefecture_area_dashboard = PrefectureCommercialAreaService.build()
+        area = next(
+            (
+                area
+                for area in prefecture_area_dashboard.areas
+                if area.japan_map_code == prefecture_id
+            ),
+            None,
+        )
+        if area is None:
+            raise Http404("Prefecture does not exist.")
+
+        context["area"] = area
+        context["sales_opportunity_candidates"] = [
+            candidate
+            for candidate in prefecture_area_dashboard.sales_opportunity_candidates
+            if candidate.origin_name == area.prefecture_name
+            or candidate.target_name == area.prefecture_name
+        ]
+        return context
+
+
 class CompanyCreateView(CreateView):
     model = Company
     template_name = "soil_analysis/company/create.html"

--- a/soil_analysis/views.py
+++ b/soil_analysis/views.py
@@ -101,17 +101,8 @@ from soil_analysis.models import (
 SAMPLING_TIMES_PER_BLOCK = 5
 
 
-class Home(ListView):
-    model = Company
+class Home(TemplateView):
     template_name = "soil_analysis/home.html"
-    context_object_name = "companies"
-
-    def get_queryset(self):
-        return (
-            Company.objects.filter(category__name="農業法人")
-            .prefetch_related("land_set")
-            .order_by("name")
-        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -119,7 +110,6 @@ class Home(ListView):
         context["prefecture_area_dashboard"] = prefecture_area_dashboard
         context["commercial_areas"] = prefecture_area_dashboard.areas
         context["commercial_area_map_data"] = prefecture_area_dashboard.map_payload
-        context["dispatch_candidates"] = prefecture_area_dashboard.dispatch_candidates
         return context
 
 


### PR DESCRIPTION
## Summary
soil_analysis の全国商圏マップから都道府県詳細ページへ遷移できるようにし、トップページは全国俯瞰、詳細ページは個別判断に整理しました。

- 地図クリック時の情報欄と全国リスクランキングに都道府県詳細ページへの導線を追加
- Home の地図クリック詳細と全国商圏リスクランキングに、売り込み先として受けられるオファー候補数を追加
- 都道府県詳細ページ用の URL / View / Template を追加し、JMAエリア・天気・警報注意報・天気リスク指数を表示
- 詳細ページ上部の天気・警報注意報サマリーを調整し、長い日本語や日付が崩れにくいレイアウトに変更
- 売り込み候補は全量を保持し、詳細ページでは対象都道府県に関係する候補を間引かず表示
- 代表候補だけを選ぶ既存ロジックは残し、配車候補などの全国俯瞰用途と詳細ページ用途を分離
- 詳細ページでは対象都道府県の企業別圃場一覧だけを表示
- トップページから「天気リスク県への売り込み候補」「配車候補キュー」「企業別圃場一覧」を削除し、地図と全国商圏リスクランキング中心に整理
- 詳細ページで配車候補キューを重複表示しないこと、データなしでも空状態になることをテストで確認

## 目検による動作確認手順
- [x] soil_analysis トップページで都道府県をクリックし、地図下の情報欄に「詳細ページへ」ボタンが表示されること
- [x] 地図クリック時の情報欄に「オファー候補 n件」が表示されること
- [x] 全国商圏リスクランキングに「オファー候補」列が表示されること
- [x] トップページに「天気リスク県への売り込み候補」「配車候補キュー」「企業別圃場一覧」が表示されないこと
- [x] 「詳細ページへ」から対象都道府県の詳細ページへ遷移できること
- [x] 詳細ページ上部で天気名・警報注意報が大きすぎず、予報日が途中で不自然に折り返されないこと
- [x] 詳細ページに対象都道府県の天気情報、売り込み候補、対象県の圃場一覧が表示されること
- [x] 同じ売り込み先に複数の売り込み元がある場合、詳細ページに複数候補が並ぶこと
- [x] 対象データがない都道府県でも空状態が自然に表示されること

## 自動テストでカバーできた範囲
- `black soil_analysis\views.py soil_analysis\urls.py soil_analysis\tests\test_prefecture_commercial_area_dashboard.py`
- `black soil_analysis\views.py soil_analysis\tests\test_prefecture_commercial_area_dashboard.py`
- `black soil_analysis\views.py soil_analysis\domain\valueobject\prefecture_commercial_area.py soil_analysis\domain\service\prefecture_commercial_area.py soil_analysis\tests\test_prefecture_commercial_area_dashboard.py`
- `black soil_analysis\tests\test_prefecture_commercial_area_dashboard.py`
- `black soil_analysis\domain\valueobject\prefecture_commercial_area.py soil_analysis\domain\service\prefecture_commercial_area.py soil_analysis\tests\test_prefecture_commercial_area_dashboard.py`
- `python manage.py test soil_analysis.tests.test_prefecture_commercial_area_dashboard`
- `python manage.py test soil_analysis`

## 関連Issue
Closes #774
https://github.com/duri0214/portfolio/issues/774
