### PR TITLE
#781 VN-INDEX取得をInvesting.comスクレイピングからYahoo Finance APIへ切り替える

### DIFF
--- a/vietnam_research/management/commands/daily_import_market_data.py
+++ b/vietnam_research/management/commands/daily_import_market_data.py
@@ -11,7 +11,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """
         Yahoo Finance APIから為替レートとVN-INDEXを取得します。
-        Bloombergの403エラー対策としてAPI経由に切り替えました。
+
+        外部サイトのHTML構造やbot対策に依存しないよう、為替とVN-INDEXを
+        同じYahoo Finance chart API経由で取得します。
         """
         headers = {"User-Agent": "Mozilla/5.0"}
 
@@ -40,7 +42,9 @@ class Command(BaseCommand):
                 if rate == 0 or rate is None:
                     if base == "VND" and dest == "USD":
                         # USDVNDの逆数を使用
-                        url_inv = "https://query1.finance.yahoo.com/v8/finance/chart/USDVND=X"
+                        url_inv = (
+                            "https://query1.finance.yahoo.com/v8/finance/chart/USDVND=X"
+                        )
                         res_inv = requests.get(url_inv, headers=headers, timeout=10)
                         rate_inv = res_inv.json()["chart"]["result"][0]["meta"][
                             "regularMarketPrice"
@@ -48,7 +52,9 @@ class Command(BaseCommand):
                         if rate_inv and rate_inv != 0:
                             rate = 1 / rate_inv
                         else:
-                            raise ValueError(f"Rate for {symbol} is 0 and fallback failed")
+                            raise ValueError(
+                                f"Rate for {symbol} is 0 and fallback failed"
+                            )
                     else:
                         raise ValueError(f"Rate for {symbol} is 0")
 
@@ -65,22 +71,18 @@ class Command(BaseCommand):
                     self.style.ERROR(f"Failed to fetch exchange rate {symbol}: {e}")
                 )
 
-        # VN-INDEXの取得 (Investing.com からスクレイピング)
-        vn_index_url = "https://jp.investing.com/indices/vn"
+        # VN-INDEXの取得
+        vn_index_symbol = "%5EVNINDEX.VN"
+        vn_index_url = (
+            f"https://query1.finance.yahoo.com/v8/finance/chart/{vn_index_symbol}"
+        )
         try:
-            # 取得用のヘッダー（Investing.comはボット対策が厳しいためブラウザを模倣）
-            scrape_headers = {"User-Agent": "Mozilla/5.0"}
-            response = requests.get(vn_index_url, headers=scrape_headers, timeout=10)
+            response = requests.get(vn_index_url, headers=headers, timeout=10)
             response.raise_for_status()
+            data = response.json()
+            closing_price = data["chart"]["result"][0]["meta"]["regularMarketPrice"]
 
-            from bs4 import BeautifulSoup
-
-            soup = BeautifulSoup(response.text, "lxml")
-            price_element = soup.find(attrs={"data-test": "instrument-price-last"})
-
-            if price_element:
-                price_str = price_element.text.replace(",", "")
-                closing_price = float(price_str)
+            if closing_price:
                 now = datetime.datetime.now()
                 VnIndex.objects.update_or_create(
                     Y=now.strftime("%Y"),
@@ -88,12 +90,14 @@ class Command(BaseCommand):
                     defaults={"closing_price": closing_price},
                 )
                 self.stdout.write(
-                    self.style.SUCCESS(f"Successfully fetched VN-INDEX: {closing_price}")
+                    self.style.SUCCESS(
+                        f"Successfully fetched VN-INDEX: {closing_price}"
+                    )
                 )
             else:
                 self.stdout.write(
                     self.style.WARNING(
-                        f"VN-INDEX element not found on Investing.com ({vn_index_url})"
+                        f"VN-INDEX price not found on Yahoo Finance ({vn_index_url})"
                     )
                 )
         except Exception as e:

--- a/vietnam_research/models.py
+++ b/vietnam_research/models.py
@@ -150,7 +150,7 @@ class VnIndex(models.Model):
     """
     ベトナムの世界での日経平均のような数字
 
-    See Also: https://jp.investing.com/indices/vn-historical-data
+    See Also: https://finance.yahoo.com/quote/%5EVNINDEX.VN/
     """
 
     Y = models.CharField(max_length=4)

--- a/vietnam_research/tests/management/test_daily_import_market_data.py
+++ b/vietnam_research/tests/management/test_daily_import_market_data.py
@@ -1,0 +1,90 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from vietnam_research.models import ExchangeRate, VnIndex
+
+
+class YahooFinanceResponse:
+    def __init__(self, price):
+        self.price = price
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {
+            "chart": {
+                "result": [
+                    {
+                        "meta": {
+                            "regularMarketPrice": self.price,
+                        },
+                    },
+                ],
+            },
+        }
+
+
+def yahoo_finance_response_by_url(vn_index_price):
+    prices = {
+        "VNDJPY=X": 0.0061,
+        "VNDUSD=X": 3.797228023542814e-05,
+        "JPYVND=X": 162.51,
+        "JPYUSD=X": 0.0062,
+        "USDVND=X": 26335.0,
+        "USDJPY=X": 161.723,
+        "%5EVNINDEX.VN": vn_index_price,
+    }
+
+    def response(url, headers=None, timeout=10):
+        symbol = url.rsplit("/", maxsplit=1)[-1]
+        return YahooFinanceResponse(prices[symbol])
+
+    return response
+
+
+class TestDailyImportMarketData(TestCase):
+    @patch("vietnam_research.management.commands.daily_import_market_data.requests.get")
+    def test_imports_exchange_rates_and_vn_index_from_yahoo_finance(
+        self, mock_requests_get
+    ):
+        """
+        シナリオ:
+        - 入力: Yahoo Finance chart APIが為替6件とVN-INDEXの価格を返す。
+        - 処理: daily_import_market_data コマンドを実行する。
+        - 期待値: 為替レート6件と当月のVN-INDEX終値がDBに保存される。
+        """
+        mock_requests_get.side_effect = yahoo_finance_response_by_url(1857.91)
+        stdout = StringIO()
+
+        call_command("daily_import_market_data", stdout=stdout)
+
+        self.assertEqual(ExchangeRate.objects.count(), 6)
+        self.assertTrue(VnIndex.objects.filter(closing_price=1857.91).exists())
+        self.assertIn("Successfully fetched VN-INDEX: 1857.91", stdout.getvalue())
+        fetched_urls = [call.args[0] for call in mock_requests_get.call_args_list]
+        self.assertIn(
+            "https://query1.finance.yahoo.com/v8/finance/chart/%5EVNINDEX.VN",
+            fetched_urls,
+        )
+
+    @patch("vietnam_research.management.commands.daily_import_market_data.requests.get")
+    def test_does_not_save_vn_index_when_yahoo_finance_has_no_price(
+        self, mock_requests_get
+    ):
+        """
+        シナリオ:
+        - 入力: Yahoo Finance chart APIがVN-INDEXの価格としてNoneを返す。
+        - 処理: daily_import_market_data コマンドを実行する。
+        - 期待値: VN-INDEXは保存されず、価格未取得の警告が出力される。
+        """
+        mock_requests_get.side_effect = yahoo_finance_response_by_url(None)
+        stdout = StringIO()
+
+        call_command("daily_import_market_data", stdout=stdout)
+
+        self.assertEqual(VnIndex.objects.count(), 0)
+        self.assertIn("VN-INDEX price not found on Yahoo Finance", stdout.getvalue())


### PR DESCRIPTION
## Summary
VN-INDEX取得を Investing.com のHTMLスクレイピングから Yahoo Finance chart API に切り替えました。

- VN-INDEXの取得先を `%5EVNINDEX.VN` に変更し、為替取得と同じYahoo Finance API方式に統一
- Investing.com 前提のコメント・警告メッセージ・`VnIndex` docstringの参照URLを更新
- 管理コマンドのテストを追加し、VN-INDEX保存成功と価格未取得時の未保存を確認

## 目検による動作確認手順
- [x] 本番相当環境で `python manage.py daily_import_market_data` を実行し、`Successfully fetched VN-INDEX` が出力されること
- [x] `/vietnam_research/market/` でVN-INDEXグラフが引き続き表示されること

## 自動テストでカバーできた範囲
- `python -m black --check vietnam_research\management\commands\daily_import_market_data.py vietnam_research\models.py vietnam_research\tests\management\test_daily_import_market_data.py`
- `python manage.py test vietnam_research.tests.management.test_daily_import_market_data`
- `python manage.py test vietnam_research`

Yahoo Financeレスポンスからの為替・VN-INDEX保存、VN-INDEX価格未取得時の未保存、vietnam_researchアプリ全体の回帰を確認しました。

## 関連Issue
Closes #781
https://github.com/duri0214/portfolio/issues/781
