### PR TITLE
#432 非ログインユーザーの購入制限とUI改善

### DIFF
--- a/shopping/templates/shopping/product/payment/confirm.html
+++ b/shopping/templates/shopping/product/payment/confirm.html
@@ -81,106 +81,119 @@
 
                 <div class="payment-form">
                     <h4 class="border-bottom pb-2 mb-3">クレジットカード決済</h4>
-                    <p>
-                        開発やテスト中に使用するカード情報については
-                        <a href="https://docs.stripe.com/testing?testing-method=card-numbers#visa"
-                           target="_blank"
-                           rel="noopener noreferrer">こちら</a>
-                        をご確認ください。
-                    </p>
 
-                    {% if error %}
-                        <div class="alert alert-danger" role="alert">
-                            {{ error }}
+                    {% if not user.is_authenticated %}
+                        <div class="alert alert-warning" role="alert">
+                            商品を購入するにはログインが必要です
                         </div>
-                    {% elif client_secret %}
-                        <!-- Stripe Elements決済フォーム -->
-                        <form id="payment-form">
-                            {% csrf_token %}
-                            <div id="payment-element" class="mb-3">
-                                <!-- Stripe Elementsがここにマウントされます -->
+                        <div class="d-flex justify-content-between">
+                            <a href="{% url 'shp:product_detail' object.pk %}"
+                               class="btn btn-outline-secondary">戻る</a>
+                            <a href="{% url 'login' %}?next={{ request.path }}"
+                               class="btn btn-primary">ログイン</a>
+                        </div>
+                    {% else %}
+                        <p>
+                            開発やテスト中に使用するカード情報については
+                            <a href="https://docs.stripe.com/testing?testing-method=card-numbers#visa"
+                               target="_blank"
+                               rel="noopener noreferrer">こちら</a>
+                            をご確認ください。
+                        </p>
+
+                        {% if error %}
+                            <div class="alert alert-danger" role="alert">
+                                {{ error }}
                             </div>
-                            <div id="error-message" class="alert alert-danger d-none" role="alert"></div>
-                            <div class="d-flex justify-content-between">
-                                <a href="{% url 'shp:product_detail' object.pk %}" 
-                                   class="btn btn-outline-secondary">戻る</a>
-                                <button type="submit" id="submit-button" class="btn btn-primary">
-                                    <span id="button-text">支払う</span>
-                                    <span id="spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
-                                </button>
-                            </div>
-                        </form>
+                        {% elif client_secret %}
+                            <!-- Stripe Elements決済フォーム -->
+                            <form id="payment-form">
+                                {% csrf_token %}
+                                <div id="payment-element" class="mb-3">
+                                    <!-- Stripe Elementsがここにマウントされます -->
+                                </div>
+                                <div id="error-message" class="alert alert-danger d-none" role="alert"></div>
+                                <div class="d-flex justify-content-between">
+                                    <a href="{% url 'shp:product_detail' object.pk %}"
+                                       class="btn btn-outline-secondary">戻る</a>
+                                    <button type="submit" id="submit-button" class="btn btn-primary">
+                                        <span id="button-text">支払う</span>
+                                        <span id="spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                    </button>
+                                </div>
+                            </form>
 
-                        <script src="https://js.stripe.com/v3/"></script>
-                        <script>
-                            const stripe = Stripe('{{ public_key }}');
-                            const options = {
-                                clientSecret: '{{ client_secret }}',
-                                appearance: {
-                                    theme: 'stripe',
-                                    labels: 'floating'
-                                },
-                                locale: 'ja'
-                            };
-
-                            const elements = stripe.elements(options);
-                            const paymentElement = elements.create('payment');
-                            paymentElement.mount('#payment-element');
-
-                            const form = document.getElementById('payment-form');
-                            const submitButton = document.getElementById('submit-button');
-                            const buttonText = document.getElementById('button-text');
-                            const spinner = document.getElementById('spinner');
-                            const errorMessage = document.getElementById('error-message');
-
-                            form.addEventListener('submit', async (event) => {
-                                event.preventDefault();
-
-                                // ボタンを無効化
-                                submitButton.disabled = true;
-                                buttonText.classList.add('d-none');
-                                spinner.classList.remove('d-none');
-                                errorMessage.classList.add('d-none');
-
-                                const {error} = await stripe.confirmPayment({
-                                    elements,
-                                    confirmParams: {
-                                        return_url: window.location.origin + '{% url "shp:payment_confirm" object.pk %}',
+                            <script src="https://js.stripe.com/v3/"></script>
+                            <script>
+                                const stripe = Stripe('{{ public_key }}');
+                                const options = {
+                                    clientSecret: '{{ client_secret }}',
+                                    appearance: {
+                                        theme: 'stripe',
+                                        labels: 'floating'
                                     },
-                                    redirect: 'if_required'
-                                });
+                                    locale: 'ja'
+                                };
 
-                                if (error) {
-                                    // エラー表示
-                                    errorMessage.textContent = error.message;
-                                    errorMessage.classList.remove('d-none');
+                                const elements = stripe.elements(options);
+                                const paymentElement = elements.create('payment');
+                                paymentElement.mount('#payment-element');
 
-                                    // ボタンを再度有効化
-                                    submitButton.disabled = false;
-                                    buttonText.classList.remove('d-none');
-                                    spinner.classList.add('d-none');
-                                } else {
-                                    // 支払い成功 - サーバーに通知
-                                    const formData = new FormData(form);
-                                    const response = await fetch(window.location.href, {
-                                        method: 'POST',
-                                        body: formData,
-                                        headers: {
-                                            'X-CSRFToken': formData.get('csrfmiddlewaretoken')
-                                        }
+                                const form = document.getElementById('payment-form');
+                                const submitButton = document.getElementById('submit-button');
+                                const buttonText = document.getElementById('button-text');
+                                const spinner = document.getElementById('spinner');
+                                const errorMessage = document.getElementById('error-message');
+
+                                form.addEventListener('submit', async (event) => {
+                                    event.preventDefault();
+
+                                    // ボタンを無効化
+                                    submitButton.disabled = true;
+                                    buttonText.classList.add('d-none');
+                                    spinner.classList.remove('d-none');
+                                    errorMessage.classList.add('d-none');
+
+                                    const {error} = await stripe.confirmPayment({
+                                        elements,
+                                        confirmParams: {
+                                            return_url: window.location.origin + '{% url "shp:payment_confirm" object.pk %}',
+                                        },
+                                        redirect: 'if_required'
                                     });
 
-                                    if (response.redirected) {
-                                        window.location.href = response.url;
+                                    if (error) {
+                                        // エラー表示
+                                        errorMessage.textContent = error.message;
+                                        errorMessage.classList.remove('d-none');
+
+                                        // ボタンを再度有効化
+                                        submitButton.disabled = false;
+                                        buttonText.classList.remove('d-none');
+                                        spinner.classList.add('d-none');
                                     } else {
-                                        const html = await response.text();
-                                        document.open();
-                                        document.write(html);
-                                        document.close();
+                                        // 支払い成功 - サーバーに通知
+                                        const formData = new FormData(form);
+                                        const response = await fetch(window.location.href, {
+                                            method: 'POST',
+                                            body: formData,
+                                            headers: {
+                                                'X-CSRFToken': formData.get('csrfmiddlewaretoken')
+                                            }
+                                        });
+
+                                        if (response.redirected) {
+                                            window.location.href = response.url;
+                                        } else {
+                                            const html = await response.text();
+                                            document.open();
+                                            document.write(html);
+                                            document.close();
+                                        }
                                     }
-                                }
-                            });
-                        </script>
+                                });
+                            </script>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/shopping/tests/test_views.py
+++ b/shopping/tests/test_views.py
@@ -1,17 +1,94 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
+from django.template.loader import render_to_string
 from django.test import TestCase
+from django.test.client import RequestFactory
 from django.urls import reverse
 
-from shopping.models import Store
+from shopping.models import Product, Store
 
 
 class TestView(TestCase):
     @classmethod
     def setUpTestData(cls):
-        User.objects.create_user(email="tester@b.c", username='John Doe').set_password("12345")
+        User.objects.create_user(email="tester@b.c", username="John Doe").set_password(
+            "12345"
+        )
         Store.objects.create(name="笹塚")
         Store.objects.create(name="新宿")
+        cls.product = Product.objects.create(
+            code="test-product",
+            name="テスト商品",
+            price=1000,
+            description="テスト用の商品です",
+            picture="shopping/test-product.jpg",
+        )
 
     def test_get_top_page_200(self):
+        """
+        シナリオ:
+        - 入力: shoppingトップページのURL。
+        - 処理: テストクライアントでGETする。
+        - 期待値: HTTP 200 が返されること。
+        """
         response = self.client.get(reverse("shp:index"))
         self.assertEqual(200, response.status_code)
+
+    def test_payment_confirm_template_requires_login_for_anonymous_user(self):
+        """
+        シナリオ:
+        - 入力: 非ログインユーザーと決済確認テンプレート用の決済情報。
+        - 処理: 決済確認テンプレートをレンダリングする。
+        - 期待値: ログイン誘導が表示され、Stripe決済フォームは表示されないこと。
+        """
+        path = reverse("shp:payment_confirm", kwargs={"pk": self.product.pk})
+        request = RequestFactory().get(path)
+        request.user = AnonymousUser()
+
+        html = render_to_string(
+            "shopping/product/payment/confirm.html",
+            self._payment_confirm_context(request.user),
+            request=request,
+        )
+
+        self.assertIn("商品を購入するにはログインが必要です", html)
+        self.assertIn(f'{reverse("login")}?next={path}', html)
+        self.assertIn(
+            reverse("shp:product_detail", kwargs={"pk": self.product.pk}), html
+        )
+        self.assertNotIn('id="payment-form"', html)
+        self.assertNotIn('id="submit-button"', html)
+
+    def test_payment_confirm_template_shows_payment_form_for_authenticated_user(self):
+        """
+        シナリオ:
+        - 入力: ログイン済みユーザーとclient_secretを含む決済確認テンプレート用の決済情報。
+        - 処理: 決済確認テンプレートをレンダリングする。
+        - 期待値: Stripe決済フォームが表示され、ログイン誘導は表示されないこと。
+        """
+        user = User.objects.create_user(username="payment-user", password="password")
+        path = reverse("shp:payment_confirm", kwargs={"pk": self.product.pk})
+        request = RequestFactory().get(path)
+        request.user = user
+
+        html = render_to_string(
+            "shopping/product/payment/confirm.html",
+            self._payment_confirm_context(request.user),
+            request=request,
+        )
+
+        self.assertIn('id="payment-form"', html)
+        self.assertIn('id="submit-button"', html)
+        self.assertIn("支払う", html)
+        self.assertNotIn("商品を購入するにはログインが必要です", html)
+
+    def _payment_confirm_context(self, user):
+        return {
+            "object": self.product,
+            "user": user,
+            "quantity": 2,
+            "subtotal": 2000,
+            "tax": 200,
+            "total_price": 2200,
+            "public_key": "pk_test_dummy",
+            "client_secret": "pi_dummy_secret_dummy",
+        }


### PR DESCRIPTION
## Summary
非ログインユーザーが決済確認画面で支払いを実行できないようにし、ログイン誘導を表示するようにしました。

- 非ログイン時は決済フォームと支払いボタンを表示せず、「商品を購入するにはログインが必要です」を表示
- ログインボタンに `?next={{ request.path }}` を付け、ログイン後に元の確認画面へ戻れる導線を追加
- ログイン済みユーザーでは既存の Stripe 決済フォームをそのまま表示
- 決済確認テンプレートの認証状態別表示をテストで確認

## 目検による動作確認手順
- [x] 非ログイン状態で決済確認画面にアクセスし、ログイン誘導と「ログイン」「戻る」ボタンが表示されること
- [x] ログインボタンからログイン画面へ遷移し、URLに `next=/shopping/payment/confirm/<商品ID>/` が付くこと
- [x] ログイン状態で決済確認画面にアクセスし、通常の決済フォームと「支払う」ボタンが表示されること

## 自動テストでカバーできた範囲
- `python -m black --check shopping\tests\test_views.py`
- `python manage.py test shopping.tests.test_views`
- `python manage.py test shopping`

非ログイン時のログイン誘導、決済フォーム非表示、ログイン済み時の決済フォーム表示、shopping アプリの既存 view テストを確認しました。

## 関連Issue
Closes #432
https://github.com/duri0214/portfolio/issues/432
