### PR TITLE
#787 vietnam_researchの上昇トレンド検出ログを整形する

### DIFF
--- a/vietnam_research/management/commands/daily_industry_chart_and_uptrend.py
+++ b/vietnam_research/management/commands/daily_industry_chart_and_uptrend.py
@@ -35,12 +35,21 @@ def calc_price(price_for_several_days: pd.Series) -> dict:
     return {"initial": initial_price, "latest": latest_price, "delta": delta_pct}
 
 
-def formatted_text(code: str, slopes: list, passed: int, price: dict) -> str:
-    initial = price.get("initial", "-")
-    latest = price.get("latest", "-")
-    delta = price.get("delta", "-")
+def _format_number(value: object) -> str:
+    if value == "-" or value is None:
+        return "-"
 
-    return f"{code}｜{slopes}, passed: {passed}, initial: {initial}, latest: {latest}, delta: {delta}"
+    return f"{float(value):.2f}"
+
+
+def formatted_text(code: str, slopes: list, passed: int, price: dict) -> str:
+    formatted_slopes = [_format_number(slope) for slope in slopes]
+    slopes_text = ", ".join(formatted_slopes)
+    initial = _format_number(price.get("initial", "-"))
+    latest = _format_number(price.get("latest", "-"))
+    delta = _format_number(price.get("delta", "-"))
+
+    return f"{code}｜slopes: [{slopes_text}], passed: {passed}, initial: {initial}, latest: {latest}, delta: {delta}"
 
 
 class Command(BaseCommand):

--- a/vietnam_research/tests/management/test_daily_industry_uptrends.py
+++ b/vietnam_research/tests/management/test_daily_industry_uptrends.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from django.test import TestCase
 
@@ -14,6 +15,12 @@ class Test(TestCase):
     """
 
     def test_calc_price(self):
+        """
+        シナリオ:
+        - 入力: 14日分の終値データ。
+        - 処理: calc_price を呼び出す。
+        - 期待値: 初日から最終日までの変化率が小数2桁で返されること。
+        """
         data = pd.Series(
             [
                 7.17,
@@ -36,22 +43,34 @@ class Test(TestCase):
         self.assertEqual(calc_price(data)["delta"], expected)
 
     def test_formatted_text_has_value(self):
+        """
+        シナリオ:
+        - 入力: numpy由来の傾き、通過数、価格情報。
+        - 処理: formatted_text を呼び出す。
+        - 期待値: numpyの型表現を含まず、小数2桁に整形された文字列が返されること。
+        """
         code = "AAA"
-        slopes = [-0.123, 0.25, -0.1]
+        slopes = [np.float64(-0.123), np.float64(0.25), np.float64(-0.1)]
         passed = 1
-        price = {"initial": 100, "latest": 150, "delta": 50}
+        price = {"initial": np.float64(100), "latest": 150, "delta": 50}
         expected = (
-            f"{code}｜{slopes}, passed: {passed}, initial: {price.get('initial')},"
-            f" latest: {price.get('latest')}, delta: {price.get('delta')}"
+            f"{code}｜slopes: [-0.12, 0.25, -0.10], passed: {passed},"
+            " initial: 100.00, latest: 150.00, delta: 50.00"
         )
-        self.assertEqual(formatted_text(code, slopes, passed, price), expected)
+        actual = formatted_text(code, slopes, passed, price)
+        self.assertEqual(actual, expected)
+        self.assertNotIn("np.float", actual)
 
     def test_formatted_text_has_no_value(self):
+        """
+        シナリオ:
+        - 入力: 傾きと通過数のみで、価格情報が空の辞書。
+        - 処理: formatted_text を呼び出す。
+        - 期待値: 価格情報はハイフンで表示され、傾きは小数2桁で返されること。
+        """
         code = "AAA"
         slopes = [-0.123, 0.25, -0.1]
         passed = 1
         price = {}
-        expected = (
-            f"{code}｜{slopes}, passed: {passed}, initial: -, latest: -, delta: -"
-        )
+        expected = f"{code}｜slopes: [-0.12, 0.25, -0.10], passed: {passed}, initial: -, latest: -, delta: -"
         self.assertEqual(formatted_text(code, slopes, passed, price), expected)


### PR DESCRIPTION
## Summary
`daily_industry_chart_and_uptrend` の上昇トレンド検出ログを、numpy の型表現が露出しない読みやすい形式に整えました。

- `formatted_text()` で slopes / initial / latest / delta を表示用に小数2桁へ整形
- `np.float64(...)` のような内部型表現がログに出ないように変更
- numpy 型を含む入力でも期待したログ文字列になることをテストで確認

## 目検による動作確認手順
- [x] `python manage.py daily_industry_chart_and_uptrend` を実行する
- [x] `Detecting uptrend stocks...` 以降のログで `np.float64(...)` が表示されないことを確認する
- [x] slopes が `slopes: [1209.40, 1067.60, 156.18]` のように小数2桁で表示されることを確認する

```
🔍 Detecting uptrend stocks...
  ABT｜slopes: [479.60, 1462.50, 876.43], passed: 3, initial: 77548.66, latest: 80894.29, delta: 4.31
  BMP｜slopes: [731.64, 376.90, 1038.28], passed: 3, initial: 70328.93, latest: 81589.07, delta: 16.01
  CCI｜slopes: [77.46, 726.56, 533.75], passed: 3, initial: 48349.41, latest: 51783.87, delta: 7.10
  COM｜slopes: [232.92, 1390.54, 1891.10], passed: 3, initial: 52779.78, latest: 57384.00, delta: 8.72
  CSM｜slopes: [64.63, 305.93, 289.04], passed: 3, initial: 31828.75, latest: 33880.83, delta: 6.45
  CTG｜slopes: [50.43, 78.52, -174.37], passed: 2, initial: 14214.69, latest: 14980.85, delta: 5.39 (in watchlist)
  CTI｜slopes: [560.79, 678.89, 1183.52], passed: 3, initial: 43105.83, latest: 50863.64, delta: 18.00
  DHC｜slopes: [492.03, 399.32, 177.90], passed: 3, initial: 39728.46, latest: 46427.54, delta: 16.86
  DHG｜slopes: [805.13, 1045.49, 1211.59], passed: 3, initial: 56169.69, latest: 65973.36, delta: 17.45
  DLG｜slopes: [523.43, 386.97, 205.88], passed: 3, initial: 74072.99, latest: 79918.00, delta: 7.89
  DTA｜slopes: [806.02, 1393.21, 846.93], passed: 3, initial: 64195.36, latest: 72517.59, delta: 12.96
  DVP｜slopes: [943.07, 1897.90, 3127.38], passed: 3, initial: 87015.69, latest: 105235.85, delta: 20.94
  FRT｜slopes: [626.40, 1279.59, 1527.65], passed: 3, initial: 44937.95, latest: 52562.52, delta: 16.97
  HRC｜slopes: [609.52, 522.82, 201.91], passed: 3, initial: 33461.47, latest: 40778.84, delta: 21.87
  ITC｜slopes: [418.96, 248.55, 2090.84], passed: 3, initial: 98411.37, latest: 103681.60, delta: 5.36
  KDH｜slopes: [7.34, 159.32, 34.84], passed: 3, initial: 14470.59, latest: 14429.83, delta: -0.28
  KHP｜slopes: [9.89, 313.03, 651.98], passed: 3, initial: 42974.46, latest: 43243.55, delta: 0.63
  L10｜slopes: [457.33, 526.02, 662.42], passed: 3, initial: 65022.37, latest: 72326.79, delta: 11.23
  LCG｜slopes: [62.79, 492.99, 887.59], passed: 3, initial: 24651.42, latest: 27263.47, delta: 10.60
  LGL｜slopes: [583.07, 1468.41, 1302.71], passed: 3, initial: 36172.08, latest: 42820.03, delta: 18.38
  LHG｜slopes: [333.03, 140.05, 1114.35], passed: 3, initial: 69952.74, latest: 74516.24, delta: 6.52
  NCT｜slopes: [465.80, 690.23, 1184.91], passed: 3, initial: 63449.75, latest: 70230.21, delta: 10.69
  OPC｜slopes: [405.13, 11.27, 1184.35], passed: 3, initial: 57322.58, latest: 59469.33, delta: 3.75
  PNJ｜slopes: [765.76, 1132.85, 1870.21], passed: 3, initial: 92616.70, latest: 104017.64, delta: 12.31
  PPC｜slopes: [254.94, 250.92, 847.43], passed: 3, initial: 41712.36, latest: 43727.34, delta: 4.83
  PTC｜slopes: [68.34, 352.07, 291.96], passed: 3, initial: 21976.12, latest: 23642.02, delta: 7.58
  PTL｜slopes: [376.10, 3.22, 1792.83], passed: 3, initial: 75367.95, latest: 80307.08, delta: 6.55
  SAB｜slopes: [-155.37, -61.73, -54.84], passed: 0, initial: 15761.09, latest: 14180.38, delta: -10.03 (in watchlist)
  SJS｜slopes: [241.88, 448.99, 511.56], passed: 3, initial: 27908.24, latest: 30300.77, delta: 8.57
  SRC｜slopes: [637.81, 1265.11, 1325.66], passed: 3, initial: 46758.46, latest: 56281.45, delta: 20.37
  SVC｜slopes: [-1077.08, -1217.63, -261.41], passed: 0, initial: 83374.94, latest: 67515.79, delta: -19.02 (in watchlist)
  TDC｜slopes: [34.78, 636.76, 1333.99], passed: 3, initial: 54185.21, latest: 58982.38, delta: 8.85
  TIX｜slopes: [530.84, 1727.47, 972.04], passed: 3, initial: 58159.19, latest: 62434.31, delta: 7.35
  TPB｜slopes: [61.86, 338.55, 728.50], passed: 3, initial: 18072.83, latest: 18697.78, delta: 3.46
  VHM｜slopes: [-27.43, -85.01, -836.60], passed: 0, initial: 40491.86, latest: 39101.11, delta: -3.43 (in watchlist)
  VND｜slopes: [135.31, 438.58, 377.63], passed: 3, initial: 23724.05, latest: 25315.27, delta: 6.71
  VNL｜slopes: [381.97, 754.59, 275.00], passed: 3, initial: 69065.84, latest: 70534.60, delta: 2.13
  VNS｜slopes: [235.81, 1805.68, 3010.20], passed: 3, initial: 90827.54, latest: 93226.99, delta: 2.64
  VSH｜slopes: [1046.55, 990.39, 199.37], passed: 3, initial: 86026.64, latest: 97690.07, delta: 13.56
  VTO｜slopes: [81.69, 200.43, 442.17], passed: 3, initial: 78466.69, latest: 80094.18, delta: 2.07
  APS｜slopes: [1147.55, 201.75, 310.62], passed: 3, initial: 83579.35, latest: 96006.85, delta: 14.87
  BVS｜slopes: [47.48, 399.83, 10.68], passed: 3, initial: 34268.71, latest: 36230.28, delta: 5.72
  CAN｜slopes: [616.13, 1288.85, 1677.21], passed: 3, initial: 82847.53, latest: 90935.95, delta: 9.76
  CTB｜slopes: [202.38, 357.60, 727.54], passed: 3, initial: 30907.53, latest: 34840.67, delta: 12.73
  EID｜slopes: [151.38, 13.23, 735.91], passed: 3, initial: 35678.44, latest: 37867.30, delta: 6.13
  GLT｜slopes: [520.73, 639.98, 1844.37], passed: 3, initial: 49481.14, latest: 57910.56, delta: 17.04
  HAD｜slopes: [4.16, 65.87, 195.35], passed: 3, initial: 31558.28, latest: 31341.00, delta: -0.69
  HCT｜slopes: [148.06, 291.64, 240.21], passed: 3, initial: 12456.65, latest: 14750.89, delta: 18.42
  HOM｜slopes: [403.76, 533.92, 892.94], passed: 3, initial: 58295.23, latest: 62611.74, delta: 7.40
  HUT｜slopes: [256.95, 293.76, 795.36], passed: 3, initial: 76373.28, latest: 80444.76, delta: 5.33
  ICG｜slopes: [1231.47, 677.06, 551.95], passed: 3, initial: 94987.48, latest: 111831.21, delta: 17.73
  IDJ｜slopes: [1074.64, 2063.55, 1784.36], passed: 3, initial: 62895.17, latest: 76081.15, delta: 20.97
  LDP｜slopes: [402.84, 368.54, 937.10], passed: 3, initial: 24443.76, latest: 29775.02, delta: 21.81
  NBP｜slopes: [98.56, 573.54, 1192.20], passed: 3, initial: 64144.15, latest: 69119.79, delta: 7.76
  ONE｜slopes: [285.61, 519.36, 1257.38], passed: 3, initial: 26468.68, latest: 30802.28, delta: 16.37
  TC6｜slopes: [1657.79, 1772.98, 4088.80], passed: 3, initial: 76641.31, latest: 96778.20, delta: 26.27
  TV4｜slopes: [302.59, 313.45, 182.56], passed: 3, initial: 44503.00, latest: 46866.39, delta: 5.31
  VBC｜slopes: [219.87, 10.79, 600.59], passed: 3, initial: 21969.95, latest: 25652.36, delta: 16.76
  VCS｜slopes: [689.13, 181.76, -2250.43], passed: 2, initial: 73202.42, latest: 76403.83, delta: 4.37 (in watchlist)
  VDL｜slopes: [263.42, 96.83, 816.72], passed: 3, initial: 76273.54, latest: 79368.79, delta: 4.06
  VGP｜slopes: [27.33, 112.88, 222.76], passed: 3, initial: 14277.68, latest: 14808.07, delta: 3.71
  VIX｜slopes: [133.68, 59.78, 274.38], passed: 3, initial: 34612.04, latest: 36413.01, delta: 5.20
  VNT｜slopes: [215.08, 77.33, 134.83], passed: 3, initial: 14590.18, latest: 16415.84, delta: 12.51

✅ daily_industry_chart_and_uptrend completed successfully.
   - Total tickers processed: 277
   - Charts generated: 63
 ```
## 自動テストでカバーできた範囲
- `python -m black --check vietnam_research\management\commands\daily_industry_chart_and_uptrend.py vietnam_research\tests\management\test_daily_industry_uptrends.py`
- `python manage.py test vietnam_research.tests.management.test_daily_industry_uptrends`
- `python manage.py test vietnam_research`

`formatted_text()` が numpy の型表現を含まない文字列を返すこと、価格情報がない場合はハイフン表示を維持すること、vietnam_research アプリ全体の回帰を確認しました。

## 関連Issue
Closes #787
https://github.com/duri0214/portfolio/issues/787
