### PR TITLE
#791 riddle以外のときは なぞなぞをスタート をdisabled にする

### DIFF
--- a/llm_chat/static/llm_chat/js/index.js
+++ b/llm_chat/static/llm_chat/js/index.js
@@ -16,9 +16,35 @@ document.addEventListener("DOMContentLoaded", function () {
     const loadingIndicator = document.getElementById("loading-indicator");
     let isLoading = false;
 
-    function isSuperuserButtonEnabled() {
-        // when not superuser, a button is rendered disabled; keep it disabled
-        return !sendButton.hasAttribute("disabled") || sendButton.classList.contains("btn-primary");
+    function canUseChatButtons() {
+        return sendButton.classList.contains("btn-primary");
+    }
+
+    function isRiddleResetButton() {
+        return riddleButton && riddleButton.classList.contains("btn-warning");
+    }
+
+    function updateActionButtons() {
+        if (!canUseChatButtons()) {
+            return;
+        }
+
+        const isRiddleSelected = useCaseType.value === "Riddle";
+        const isRiddleReset = isRiddleResetButton();
+
+        if (riddleButton) {
+            riddleButton.disabled = !isRiddleSelected && !isRiddleReset;
+        }
+        if (sendButton) {
+            sendButton.disabled = isRiddleSelected && !isRiddleReset;
+        }
+    }
+
+    function updateUseCaseFields() {
+        audioFileContainer.style.display = useCaseType.value === "OpenAISpeechToText" ? "block" : "none";
+        genderContainer.style.display = useCaseType.value === "Riddle" ? "block" : "none";
+        ragPdfContainer.style.display = useCaseType.value === "OpenAIRag" ? "block" : "none";
+        updateActionButtons();
     }
 
     function startLoading() {
@@ -45,15 +71,8 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         if (sendButton) {
             sendButton.value = "送信";
-            if (isSuperuserButtonEnabled()) {
-                sendButton.disabled = false;
-            }
         }
-        if (riddleButton) {
-            if (isSuperuserButtonEnabled()) {
-                riddleButton.disabled = false;
-            }
-        }
+        updateActionButtons();
     }
 
     // ChatLogs全削除ボタン
@@ -287,43 +306,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // ドロップダウン変更時のイベント処理
     useCaseType.addEventListener("change", function () {
-        if (useCaseType.value === "OpenAISpeechToText") {
-            audioFileContainer.style.display = "block"; // フォームを表示
-        } else {
-            audioFileContainer.style.display = "none"; // フォームを非表示
-        }
-
-        if (useCaseType.value === "Riddle") {
-            genderContainer.style.display = "block";
-        } else {
-            genderContainer.style.display = "none";
-        }
-
-        if (useCaseType.value === "OpenAIRag") {
-            ragPdfContainer.style.display = "block";
-        } else {
-            ragPdfContainer.style.display = "none";
-        }
+        updateUseCaseFields();
     });
 
     // ページロード時にも選択状態に応じてフィールドを表示／非表示
-    if (useCaseType.value === "OpenAISpeechToText") {
-        audioFileContainer.style.display = "block";
-    } else {
-        audioFileContainer.style.display = "none";
-    }
-
-    if (useCaseType.value === "Riddle") {
-        genderContainer.style.display = "block";
-    } else {
-        genderContainer.style.display = "none";
-    }
-
-    if (useCaseType.value === "OpenAIRag") {
-        ragPdfContainer.style.display = "block";
-    } else {
-        ragPdfContainer.style.display = "none";
-    }
+    updateUseCaseFields();
 
     // ページ下部へスクロール
     function scrollToBottom() {


### PR DESCRIPTION
## Summary
riddle以外のユースケースを選択しているときに「なぞなぞをスタート」を押せないようにし、「送信」と二律背反になるようにしました。

- ユースケース選択に応じて「なぞなぞをスタート」と「送信」の disabled 状態を同期
- `Riddle` 選択中の未開始状態では「送信」を無効化し、「なぞなぞをスタート」を有効化
- なぞなぞ進行中の「なぞなぞをリセット」状態では回答送信フローを維持
- 音声、RAG、性別フォームの表示切り替えとボタン状態更新を共通関数へ整理

## 目検による動作確認手順
- [x] LLM Chat 画面でユースケースを `Riddle` にすると「なぞなぞをスタート」が有効、「送信」が無効になること
- [x] `Riddle` 以外を選ぶと「なぞなぞをスタート」が無効、「送信」が有効になること
- [x] なぞなぞ進行中のリセット表示では、既存の回答送信フローが維持されること

## 自動テストでカバーできた範囲
- `node --check llm_chat\static\llm_chat\js\index.js`
  - JS の構文チェックを確認
- `python manage.py test llm_chat.tests.test_views --keepdb`
  - LLM Chat の View 周辺の既存挙動を確認
- `python manage.py test llm_chat --keepdb`
  - llm_chat アプリ全体の既存テストが通ることを確認

## 関連Issue
Closes #791
https://github.com/duri0214/portfolio/issues/791
