### PR TITLE
#805 出店計画: 登録店舗を起点にした周辺地域比較UI

### DIFF
--- a/shopping/domain/valueobject/store_planning.py
+++ b/shopping/domain/valueobject/store_planning.py
@@ -29,20 +29,19 @@ class StorePlanningDataSource:
 
 
 @dataclass(frozen=True)
-class StorePlanningTargetLocation:
+class StorePlanningArea:
     """
-    出店計画で人口分析の対象にする店舗候補地。
+    出店計画で人口分析や地域比較に使う町丁・地域。
 
     Attributes:
         slug: URLパラメータと保存キーに使う識別子。
-        name: 画面に表示する店舗名または候補地名。
-        address: 店舗候補地の住所。
+        name: 画面に表示する地域名または候補地名。
+        address: 地域または候補地の住所。
         latitude: Google Mapsリンクに使う緯度。
         longitude: Google Mapsリンクに使う経度。
         city_code: e-Stat CSVの市区町村コード。
         town_code: e-Stat CSVの町丁字コード。
         population_area: 人口集計に使う町丁字名。
-        comparison_slugs: 出店計画画面で一緒に比較する候補地のslug。
     """
 
     slug: str
@@ -53,7 +52,6 @@ class StorePlanningTargetLocation:
     city_code: str
     town_code: str
     population_area: str
-    comparison_slugs: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def source_key(self) -> str:
@@ -74,6 +72,11 @@ class StorePlanningTargetLocation:
         )
 
 
+@dataclass(frozen=True)
+class StorePlanningTargetLocation(StorePlanningArea):
+    """出店計画で選択対象にする店舗候補地。"""
+
+
 STORE_PLANNING_TARGET_LOCATIONS = [
     StorePlanningTargetLocation(
         slug="chapter-table",
@@ -84,10 +87,12 @@ STORE_PLANNING_TARGET_LOCATIONS = [
         city_code="13121",
         town_code="073002",
         population_area="東京都足立区東保木間二丁目",
-        comparison_slugs=("higashi-hokima-1",),
     ),
-    StorePlanningTargetLocation(
-        slug="higashi-hokima-1",
+]
+
+STORE_PLANNING_COMPARISON_AREAS = [
+    StorePlanningArea(
+        slug="area-higashi-hokima-1",
         name="比較対象地域（東保木間一丁目）",
         address="東京都足立区東保木間一丁目",
         latitude=35.793608,
@@ -95,6 +100,5 @@ STORE_PLANNING_TARGET_LOCATIONS = [
         city_code="13121",
         town_code="073001",
         population_area="東京都足立区東保木間一丁目",
-        comparison_slugs=("chapter-table",),
     ),
 ]

--- a/shopping/domain/valueobject/store_planning.py
+++ b/shopping/domain/valueobject/store_planning.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from dataclasses import field
 from datetime import datetime
 
 
@@ -40,6 +41,7 @@ class StorePlanningTargetLocation:
         city_code: e-Stat CSVの市区町村コード。
         town_code: e-Stat CSVの町丁字コード。
         population_area: 人口集計に使う町丁字名。
+        comparison_slugs: 出店計画画面で一緒に比較する候補地のslug。
     """
 
     slug: str
@@ -50,6 +52,7 @@ class StorePlanningTargetLocation:
     city_code: str
     town_code: str
     population_area: str
+    comparison_slugs: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def source_key(self) -> str:
@@ -66,6 +69,7 @@ STORE_PLANNING_TARGET_LOCATIONS = [
         city_code="13121",
         town_code="073002",
         population_area="東京都足立区東保木間二丁目",
+        comparison_slugs=("higashi-hokima-1",),
     ),
     StorePlanningTargetLocation(
         slug="higashi-hokima-1",
@@ -76,5 +80,6 @@ STORE_PLANNING_TARGET_LOCATIONS = [
         city_code="13121",
         town_code="073001",
         population_area="東京都足立区東保木間一丁目",
+        comparison_slugs=("chapter-table",),
     ),
 ]

--- a/shopping/domain/valueobject/store_planning.py
+++ b/shopping/domain/valueobject/store_planning.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 from datetime import datetime
+from urllib.parse import quote
 
 
 @dataclass(frozen=True)
@@ -58,6 +59,20 @@ class StorePlanningTargetLocation:
     def source_key(self) -> str:
         return f"estat_population_age_groups_{self.city_code}_{self.town_code}"
 
+    @property
+    def google_maps_url(self) -> str:
+        return f"https://www.google.com/maps?q={self.latitude},{self.longitude}"
+
+    @property
+    def area_google_maps_url(self) -> str:
+        return f"https://www.google.com/maps/search/?api=1&query={quote(self.population_area)}"
+
+    @property
+    def area_google_maps_embed_url(self) -> str:
+        return (
+            f"https://www.google.com/maps?q={quote(self.population_area)}&output=embed"
+        )
+
 
 STORE_PLANNING_TARGET_LOCATIONS = [
     StorePlanningTargetLocation(
@@ -73,7 +88,7 @@ STORE_PLANNING_TARGET_LOCATIONS = [
     ),
     StorePlanningTargetLocation(
         slug="higashi-hokima-1",
-        name="サンプル候補地（東保木間一丁目）",
+        name="比較対象地域（東保木間一丁目）",
         address="東京都足立区東保木間一丁目",
         latitude=35.793608,
         longitude=139.811938,

--- a/shopping/templates/shopping/store_planning.html
+++ b/shopping/templates/shopping/store_planning.html
@@ -48,6 +48,125 @@
 
             <div class="col-12">
                 <section class="border rounded p-4 h-100">
+                    <div class="d-flex flex-column flex-md-row justify-content-between gap-2 mb-3">
+                        <div>
+                            <h2 class="h5 mb-1">地域マップ</h2>
+                            <p class="small text-muted mb-0">
+                                Google Maps で町丁の領域を開き、対象地域と比較対象地域の位置関係を確認する。
+                            </p>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-wrap gap-2">
+                        {% for row in region_comparison_rows %}
+                            <a class="btn btn-sm {% if row.is_selected %}btn-primary{% else %}btn-outline-primary{% endif %}"
+                               href="{{ row.area_google_maps_url }}"
+                               target="_blank"
+                               rel="noopener">
+                                {{ row.population_area }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                </section>
+            </div>
+
+            <div class="col-12">
+                <section class="border rounded p-4 h-100">
+                    <div class="d-flex flex-column flex-md-row justify-content-between gap-2 mb-3">
+                        <div>
+                            <h2 class="h5 mb-1">周辺地域比較</h2>
+                            <p class="small text-muted mb-0">
+                                選択中の候補地と、手動設定した比較対象地域の人口構成を並べて確認する。
+                            </p>
+                        </div>
+                        <span class="badge text-bg-light align-self-md-start">比較対象</span>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle">
+                            <thead>
+                            <tr>
+                                <th>地域</th>
+                                <th>総人口</th>
+                                <th>平均年齢</th>
+                                <th>年代構成</th>
+                                <th>e-Stat地域コード</th>
+                                <th>データ時点</th>
+                                <th>地図</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for row in region_comparison_rows %}
+                                <tr>
+                                    <td>
+                                        <div class="fw-semibold">
+                                            {{ row.population_area }}
+                                            {% if row.is_selected %}
+                                                <span class="badge text-bg-primary ms-1">対象地域</span>
+                                            {% endif %}
+                                        </div>
+                                        <div class="small text-muted">{{ row.name }}</div>
+                                        <div class="small text-muted">{{ row.address }}</div>
+                                    </td>
+                                    <td class="text-end text-nowrap">
+                                        {% if row.population_summary.total_population %}
+                                            {{ row.population_summary.total_population|intcomma }}人
+                                        {% else %}
+                                            未取得
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-end text-nowrap">
+                                        {% if row.population_summary.average_age %}
+                                            {{ row.population_summary.average_age }} 歳
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    </td>
+                                    <td style="min-width: 220px;">
+                                        {% if row.age_group_cells %}
+                                            <div class="d-flex flex-wrap gap-1">
+                                                {% for age_group in row.age_group_cells %}
+                                                    {% if age_group.population %}
+                                                        <span class="badge text-bg-light border">
+                                                            {{ age_group.label }} {{ age_group.share_of_total }}%
+                                                        </span>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </div>
+                                        {% else %}
+                                            <span class="text-muted small">未取得</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-nowrap">
+                                        <code>city={{ row.population_summary.city_code|default:"-" }}, town={{ row.population_summary.town_code|default:"-" }}</code>
+                                    </td>
+                                    <td>
+                                        <div>{{ row.population_summary.data_period|default:"未取得" }}</div>
+                                        <a class="small" href="{{ row.population_summary.stat_inf_url|default:row.population_summary.source_url }}" target="_blank" rel="noopener">
+                                            取得元
+                                        </a>
+                                        {% if not row.has_fetched_data_source %}
+                                            <div class="small text-warning">未取得</div>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a href="{{ row.area_google_maps_url }}" target="_blank" rel="noopener">
+                                            地域を開く
+                                        </a>
+                                        <div class="small text-muted">
+                                            <a href="{{ row.google_maps_url }}" target="_blank" rel="noopener">
+                                                代表地点
+                                            </a>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </div>
+
+            <div class="col-12">
+                <section class="border rounded p-4 h-100">
                     <h2 class="h5 mb-3">e-Stat 年代別人口</h2>
                     {% if not has_fetched_data_sources %}
                         <div class="alert alert-warning">

--- a/shopping/templates/shopping/store_planning.html
+++ b/shopping/templates/shopping/store_planning.html
@@ -56,6 +56,13 @@
                             </p>
                         </div>
                     </div>
+                    <div class="ratio ratio-16x9 mb-3">
+                        <iframe src="{{ target_location.area_google_maps_embed_url }}"
+                                title="{{ target_location.population_area }} の地図"
+                                loading="lazy"
+                                referrerpolicy="no-referrer-when-downgrade"
+                                allowfullscreen></iframe>
+                    </div>
                     <div class="d-flex flex-wrap gap-2">
                         {% for row in region_comparison_rows %}
                             <a class="btn btn-sm {% if row.is_selected %}btn-primary{% else %}btn-outline-primary{% endif %}"

--- a/shopping/tests/test_views.py
+++ b/shopping/tests/test_views.py
@@ -121,6 +121,8 @@ class TestView(TestCase):
         self.assertContains(response, "1 町丁字")
         self.assertContains(response, "周辺地域比較")
         self.assertContains(response, "地域マップ")
+        self.assertContains(response, "<iframe")
+        self.assertContains(response, "output=embed")
         self.assertContains(response, "比較対象")
         self.assertContains(response, "対象地域")
         self.assertContains(response, "サンプル候補地（東保木間一丁目）")
@@ -156,6 +158,7 @@ class TestView(TestCase):
         )
         self.assertContains(response, "周辺地域比較")
         self.assertContains(response, "地域マップ")
+        self.assertContains(response, "<iframe")
         self.assertContains(response, "サンプル候補地（東保木間一丁目）")
         self.assertContains(response, "e-Stat CSVはまだ取り込まれていません")
 
@@ -206,6 +209,7 @@ class TestView(TestCase):
         self.assertContains(response, "1,234人")
         self.assertContains(response, "city=13121, town=073001")
         self.assertContains(response, "周辺地域比較")
+        self.assertContains(response, "output=embed")
         self.assertContains(response, "Chapter Table")
         self.assertContains(response, "city=13121, town=073002")
 

--- a/shopping/tests/test_views.py
+++ b/shopping/tests/test_views.py
@@ -125,7 +125,7 @@ class TestView(TestCase):
         self.assertContains(response, "output=embed")
         self.assertContains(response, "比較対象")
         self.assertContains(response, "対象地域")
-        self.assertContains(response, "サンプル候補地（東保木間一丁目）")
+        self.assertContains(response, "比較対象地域（東保木間一丁目）")
         self.assertContains(response, "city=13121, town=073001")
         self.assertContains(response, "地域を開く")
         self.assertContains(response, "代表地点")
@@ -159,7 +159,7 @@ class TestView(TestCase):
         self.assertContains(response, "周辺地域比較")
         self.assertContains(response, "地域マップ")
         self.assertContains(response, "<iframe")
-        self.assertContains(response, "サンプル候補地（東保木間一丁目）")
+        self.assertContains(response, "比較対象地域（東保木間一丁目）")
         self.assertContains(response, "e-Stat CSVはまだ取り込まれていません")
 
     def test_store_planning_page_switches_population_area_by_store(self):
@@ -204,7 +204,7 @@ class TestView(TestCase):
         response = self.client.get(url)
 
         self.assertEqual(200, response.status_code)
-        self.assertContains(response, "サンプル候補地（東保木間一丁目）")
+        self.assertContains(response, "比較対象地域（東保木間一丁目）")
         self.assertContains(response, "東京都足立区東保木間一丁目")
         self.assertContains(response, "1,234人")
         self.assertContains(response, "city=13121, town=073001")

--- a/shopping/tests/test_views.py
+++ b/shopping/tests/test_views.py
@@ -162,12 +162,12 @@ class TestView(TestCase):
         self.assertContains(response, "比較対象地域（東保木間一丁目）")
         self.assertContains(response, "e-Stat CSVはまだ取り込まれていません")
 
-    def test_store_planning_page_switches_population_area_by_store(self):
+    def test_store_planning_page_ignores_comparison_area_as_store_selection(self):
         """
         シナリオ:
-        - 入力: 複数町丁のe-Stat人口スナップショットと、店舗候補を指定したURL。
+        - 入力: 比較対象地域のe-Stat人口スナップショットと、比較対象地域slugを指定したURL。
         - 処理: 出店計画画面をGETする。
-        - 期待値: 指定した店舗候補に紐づく町丁の人口分析が表示されること。
+        - 期待値: 店舗候補はChapter Tableのまま、比較対象地域として東保木間一丁目が表示されること。
         """
         StorePlanningDataSourceSnapshot.objects.create(
             source_key="estat_population_age_groups_13121_073001",
@@ -200,17 +200,18 @@ class TestView(TestCase):
             },
         )
 
-        url = f"{reverse('shp:store_planning')}?store=higashi-hokima-1"
+        url = f"{reverse('shp:store_planning')}?store=area-higashi-hokima-1"
         response = self.client.get(url)
 
         self.assertEqual(200, response.status_code)
+        self.assertContains(response, "Chapter Table")
+        self.assertContains(response, "東京都足立区東保木間二丁目")
         self.assertContains(response, "比較対象地域（東保木間一丁目）")
         self.assertContains(response, "東京都足立区東保木間一丁目")
         self.assertContains(response, "1,234人")
         self.assertContains(response, "city=13121, town=073001")
         self.assertContains(response, "周辺地域比較")
         self.assertContains(response, "output=embed")
-        self.assertContains(response, "Chapter Table")
         self.assertContains(response, "city=13121, town=073002")
 
     def test_payment_confirm_template_requires_login_for_anonymous_user(self):

--- a/shopping/tests/test_views.py
+++ b/shopping/tests/test_views.py
@@ -119,12 +119,23 @@ class TestView(TestCase):
         self.assertContains(response, "東京都")
         self.assertContains(response, "1 市区町村")
         self.assertContains(response, "1 町丁字")
+        self.assertContains(response, "周辺地域比較")
+        self.assertContains(response, "地域マップ")
+        self.assertContains(response, "比較対象")
+        self.assertContains(response, "対象地域")
+        self.assertContains(response, "サンプル候補地（東保木間一丁目）")
+        self.assertContains(response, "city=13121, town=073001")
+        self.assertContains(response, "地域を開く")
+        self.assertContains(response, "代表地点")
+        self.assertContains(response, "maps/search/?api=1")
+        self.assertContains(
+            response, "https://www.google.com/maps?q=35.793608,139.811938"
+        )
         self.assertContains(response, 'role="progressbar"')
         self.assertNotContains(response, "店前通行量シナリオ")
         self.assertNotContains(response, "立地リスク判定")
         self.assertNotContains(response, "手動で確認するデータ")
         self.assertNotContains(response, "店舗座標")
-        self.assertNotContains(response, "比較対象")
 
     def test_store_planning_page_displays_fallback_sources_before_batch(self):
         """
@@ -143,6 +154,9 @@ class TestView(TestCase):
         self.assertContains(
             response, "daily_fetch_store_planning_data_sources を実行してください"
         )
+        self.assertContains(response, "周辺地域比較")
+        self.assertContains(response, "地域マップ")
+        self.assertContains(response, "サンプル候補地（東保木間一丁目）")
         self.assertContains(response, "e-Stat CSVはまだ取り込まれていません")
 
     def test_store_planning_page_switches_population_area_by_store(self):
@@ -191,6 +205,9 @@ class TestView(TestCase):
         self.assertContains(response, "東京都足立区東保木間一丁目")
         self.assertContains(response, "1,234人")
         self.assertContains(response, "city=13121, town=073001")
+        self.assertContains(response, "周辺地域比較")
+        self.assertContains(response, "Chapter Table")
+        self.assertContains(response, "city=13121, town=073002")
 
     def test_payment_confirm_template_requires_login_for_anonymous_user(self):
         """

--- a/shopping/views.py
+++ b/shopping/views.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import quote
 
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -143,13 +142,9 @@ class StorePlanningView(TemplateView):
             "slug": selected_location.slug,
             "name": selected_location.name,
             "address": selected_location.address,
-            "google_maps_url": self._google_maps_url(
-                selected_location.latitude, selected_location.longitude
-            ),
+            "google_maps_url": selected_location.google_maps_url,
             "population_area": selected_location.population_area,
-            "area_google_maps_embed_url": self._google_maps_area_embed_url(
-                selected_location.population_area
-            ),
+            "area_google_maps_embed_url": selected_location.area_google_maps_embed_url,
         }
         context["store_locations"] = [
             {
@@ -260,15 +255,9 @@ class StorePlanningView(TemplateView):
             "population_area": location.population_area,
             "latitude": location.latitude,
             "longitude": location.longitude,
-            "google_maps_url": self._google_maps_url(
-                location.latitude, location.longitude
-            ),
-            "area_google_maps_url": self._google_maps_area_url(
-                location.population_area
-            ),
-            "area_google_maps_embed_url": self._google_maps_area_embed_url(
-                location.population_area
-            ),
+            "google_maps_url": location.google_maps_url,
+            "area_google_maps_url": location.area_google_maps_url,
+            "area_google_maps_embed_url": location.area_google_maps_embed_url,
             "is_selected": location.slug == selected_location.slug,
             "population_summary": population_summary,
             "age_group_cells": self._build_age_group_cells(
@@ -288,15 +277,6 @@ class StorePlanningView(TemplateView):
                 share = round(population / total_population * 100, 1)
             cells.append({**row, "share_of_total": share})
         return cells
-
-    def _google_maps_url(self, latitude: float, longitude: float) -> str:
-        return f"https://www.google.com/maps?q={latitude},{longitude}"
-
-    def _google_maps_area_url(self, area_name: str) -> str:
-        return f"https://www.google.com/maps/search/?api=1&query={quote(area_name)}"
-
-    def _google_maps_area_embed_url(self, area_name: str) -> str:
-        return f"https://www.google.com/maps?q={quote(area_name)}&output=embed"
 
     def _build_population_summary(self, sources):
         for source in sources:

--- a/shopping/views.py
+++ b/shopping/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import quote
 
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -19,7 +20,10 @@ from .domain.repository.store_planning import StorePlanningDataSourceRepository
 from .domain.repository.user_attribute import UserAttributeRepository
 from .domain.service.csv_upload import CsvService
 from .domain.service.payment import StripePaymentService
-from .domain.valueobject.store_planning import STORE_PLANNING_TARGET_LOCATIONS
+from .domain.valueobject.store_planning import (
+    STORE_PLANNING_TARGET_LOCATIONS,
+    StorePlanningTargetLocation,
+)
 from .domain.valueobject.payment import PaymentIntent, PaymentInfo
 from .forms import (
     ProductCreateFormSingle,
@@ -171,6 +175,9 @@ class StorePlanningView(TemplateView):
         context["population_csv_coverage"] = (
             StorePlanningDataSourceRepository.get_population_csv_coverage()
         )
+        context["region_comparison_rows"] = self._build_region_comparison_rows(
+            selected_location, locations
+        )
         context["has_fetched_data_sources"] = data_source_snapshot is not None
         context["planning_axes"] = [
             {
@@ -208,8 +215,79 @@ class StorePlanningView(TemplateView):
             },
         }
 
+    def _build_region_comparison_rows(
+        self,
+        selected_location: StorePlanningTargetLocation,
+        locations: list[StorePlanningTargetLocation],
+    ) -> list[dict]:
+        comparison_locations = self._comparison_locations(selected_location, locations)
+        return [
+            self._build_region_comparison_row(location, selected_location)
+            for location in comparison_locations
+        ]
+
+    def _comparison_locations(
+        self,
+        selected_location: StorePlanningTargetLocation,
+        locations: list[StorePlanningTargetLocation],
+    ) -> list[StorePlanningTargetLocation]:
+        location_map = {location.slug: location for location in locations}
+        comparison_locations = [selected_location]
+        for slug in selected_location.comparison_slugs:
+            location = location_map.get(slug)
+            if location is not None:
+                comparison_locations.append(location)
+        return comparison_locations
+
+    def _build_region_comparison_row(
+        self,
+        location: StorePlanningTargetLocation,
+        selected_location: StorePlanningTargetLocation,
+    ) -> dict:
+        data_source = StorePlanningDataSourceRepository.get_latest_by_source_key(
+            location.source_key
+        )
+        source = data_source or self._fallback_data_source(location)
+        population_summary = self._build_population_summary([source])
+        age_rows = self._build_population_age_rows([source])
+        return {
+            "slug": location.slug,
+            "name": location.name,
+            "address": location.address,
+            "population_area": location.population_area,
+            "latitude": location.latitude,
+            "longitude": location.longitude,
+            "google_maps_url": self._google_maps_url(
+                location.latitude, location.longitude
+            ),
+            "area_google_maps_url": self._google_maps_area_url(
+                location.population_area
+            ),
+            "is_selected": location.slug == selected_location.slug,
+            "population_summary": population_summary,
+            "age_group_cells": self._build_age_group_cells(
+                age_rows, population_summary.get("total_population")
+            ),
+            "has_fetched_data_source": data_source is not None,
+        }
+
+    def _build_age_group_cells(self, age_rows: list[dict], total_population) -> list:
+        if not age_rows or not total_population:
+            return []
+        cells = []
+        for row in age_rows:
+            population = row["population"]
+            share = 0
+            if population is not None:
+                share = round(population / total_population * 100, 1)
+            cells.append({**row, "share_of_total": share})
+        return cells
+
     def _google_maps_url(self, latitude: float, longitude: float) -> str:
         return f"https://www.google.com/maps?q={latitude},{longitude}"
+
+    def _google_maps_area_url(self, area_name: str) -> str:
+        return f"https://www.google.com/maps/search/?api=1&query={quote(area_name)}"
 
     def _build_population_summary(self, sources):
         for source in sources:

--- a/shopping/views.py
+++ b/shopping/views.py
@@ -20,7 +20,9 @@ from .domain.repository.user_attribute import UserAttributeRepository
 from .domain.service.csv_upload import CsvService
 from .domain.service.payment import StripePaymentService
 from .domain.valueobject.store_planning import (
+    STORE_PLANNING_COMPARISON_AREAS,
     STORE_PLANNING_TARGET_LOCATIONS,
+    StorePlanningArea,
     StorePlanningTargetLocation,
 )
 from .domain.valueobject.payment import PaymentIntent, PaymentInfo
@@ -174,7 +176,7 @@ class StorePlanningView(TemplateView):
             StorePlanningDataSourceRepository.get_population_csv_coverage()
         )
         context["region_comparison_rows"] = self._build_region_comparison_rows(
-            selected_location, locations
+            selected_location, STORE_PLANNING_COMPARISON_AREAS
         )
         context["has_fetched_data_sources"] = data_source_snapshot is not None
         context["planning_axes"] = [
@@ -216,9 +218,11 @@ class StorePlanningView(TemplateView):
     def _build_region_comparison_rows(
         self,
         selected_location: StorePlanningTargetLocation,
-        locations: list[StorePlanningTargetLocation],
+        comparison_areas: list[StorePlanningArea],
     ) -> list[dict]:
-        comparison_locations = self._comparison_locations(selected_location, locations)
+        comparison_locations = self._comparison_locations(
+            selected_location, comparison_areas
+        )
         return [
             self._build_region_comparison_row(location, selected_location)
             for location in comparison_locations
@@ -227,19 +231,13 @@ class StorePlanningView(TemplateView):
     def _comparison_locations(
         self,
         selected_location: StorePlanningTargetLocation,
-        locations: list[StorePlanningTargetLocation],
-    ) -> list[StorePlanningTargetLocation]:
-        location_map = {location.slug: location for location in locations}
-        comparison_locations = [selected_location]
-        for slug in selected_location.comparison_slugs:
-            location = location_map.get(slug)
-            if location is not None:
-                comparison_locations.append(location)
-        return comparison_locations
+        comparison_areas: list[StorePlanningArea],
+    ) -> list[StorePlanningArea]:
+        return [selected_location, *comparison_areas]
 
     def _build_region_comparison_row(
         self,
-        location: StorePlanningTargetLocation,
+        location: StorePlanningArea,
         selected_location: StorePlanningTargetLocation,
     ) -> dict:
         data_source = StorePlanningDataSourceRepository.get_latest_by_source_key(

--- a/shopping/views.py
+++ b/shopping/views.py
@@ -147,6 +147,9 @@ class StorePlanningView(TemplateView):
                 selected_location.latitude, selected_location.longitude
             ),
             "population_area": selected_location.population_area,
+            "area_google_maps_embed_url": self._google_maps_area_embed_url(
+                selected_location.population_area
+            ),
         }
         context["store_locations"] = [
             {
@@ -263,6 +266,9 @@ class StorePlanningView(TemplateView):
             "area_google_maps_url": self._google_maps_area_url(
                 location.population_area
             ),
+            "area_google_maps_embed_url": self._google_maps_area_embed_url(
+                location.population_area
+            ),
             "is_selected": location.slug == selected_location.slug,
             "population_summary": population_summary,
             "age_group_cells": self._build_age_group_cells(
@@ -288,6 +294,9 @@ class StorePlanningView(TemplateView):
 
     def _google_maps_area_url(self, area_name: str) -> str:
         return f"https://www.google.com/maps/search/?api=1&query={quote(area_name)}"
+
+    def _google_maps_area_embed_url(self, area_name: str) -> str:
+        return f"https://www.google.com/maps?q={quote(area_name)}&output=embed"
 
     def _build_population_summary(self, sources):
         for source in sources:


### PR DESCRIPTION
## Summary
出店計画画面で、選択中の候補地と手動設定した比較対象地域を並べて確認できるUIを追加しました。

- 候補地定義に比較対象の `comparison_slugs` を追加
- 選択中の地域と比較対象地域の人口・平均年齢・年代構成・e-Stat地域コードを横並び表示
- Google Maps は町丁を「領域」として開く導線を主にし、緯度経度は代表地点リンクとして明示
- 既存の出店計画画面テストを地域比較UIの表示に合わせて更新

## 目検による動作確認手順
- [x] `/shopping/store-planning/` を開き、地域マップと周辺地域比較が表示されること
- [x] Chapter Table 選択時に東保木間二丁目が対象地域、東保木間一丁目が比較対象として表示されること
- [x] `地域を開く` が Google Maps の地域検索へ遷移し、`代表地点` が緯度経度リンクへ遷移すること
- [x] `?store=higashi-hokima-1` で対象地域と比較対象地域が入れ替わること

## 自動テストでカバーできた範囲
`python -m black shopping\domain\valueobject\store_planning.py shopping\views.py shopping\tests\test_views.py`

`python manage.py test shopping --keepdb`

shopping アプリの既存テストにより、出店計画画面の表示、候補地切り替え、地域比較UI、e-Stat人口データ表示、未取得時表示を確認しました。

## 関連Issue
Closes #805
https://github.com/duri0214/portfolio/issues/805
