### PR TITLE
#813 出店計画: Places Aggregate API のヒートマップで周辺賑わいを表示する

### DIFF
--- a/shopping/domain/dataprovider/google_places_aggregate.py
+++ b/shopping/domain/dataprovider/google_places_aggregate.py
@@ -1,0 +1,92 @@
+import requests
+
+from lib.geo.valueobject.coord import GoogleMapsCoord
+
+
+class GooglePlacesAggregateClient:
+    """Places Aggregate API の件数集計だけを呼び出すHTTPクライアント。"""
+
+    TIMEOUT_SECONDS = 10
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.base_url = "https://areainsights.googleapis.com/v1:computeInsights"
+        self.last_error_status_code: int | None = None
+        self.last_error_message = ""
+
+    def count_places(
+        self,
+        center: GoogleMapsCoord,
+        radius: int,
+        included_types: list[str],
+    ) -> int | None:
+        """
+        指定円内にある対象 Place Type の施設数を取得する。
+
+        Args:
+            center: 集計円の中心座標。
+            radius: 集計円の半径メートル。
+            included_types: 集計対象の Place Type。
+
+        Returns:
+            取得できた施設件数。HTTPエラーやパース失敗時は None。
+        """
+        if not included_types:
+            raise ValueError("included_typesパラメータは必須です")
+
+        try:
+            response = requests.post(
+                url=self.base_url,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Goog-Api-Key": self.api_key,
+                },
+                json={
+                    "insights": ["INSIGHT_COUNT"],
+                    "filter": {
+                        "locationFilter": {
+                            "circle": {
+                                "latLng": {
+                                    "latitude": center.latitude,
+                                    "longitude": center.longitude,
+                                },
+                                "radius": radius,
+                            }
+                        },
+                        "typeFilter": {"includedTypes": included_types},
+                        "operatingStatus": ["OPERATING_STATUS_OPERATIONAL"],
+                    },
+                },
+                timeout=self.TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            self.last_error_status_code = None
+            self.last_error_message = ""
+            return int(response.json().get("count", 0))
+        except requests.HTTPError as e:
+            response = e.response
+            self.last_error_status_code = (
+                response.status_code if response is not None else None
+            )
+            self.last_error_message = self._error_message_from_response(response)
+            print(f"Google Places Aggregate API HTTP error: {e}")
+            return None
+        except (TypeError, ValueError, requests.RequestException) as e:
+            self.last_error_status_code = None
+            self.last_error_message = str(e)
+            print(f"Google Places Aggregate API fetch error: {e}")
+            return None
+
+    @staticmethod
+    def _error_message_from_response(response) -> str:
+        if response is None:
+            return ""
+        try:
+            error_data = response.json().get("error", {})
+        except ValueError:
+            return response.text[:500]
+        status = error_data.get("status") or ""
+        message = error_data.get("message") or ""
+        if status and message:
+            return f"{status}: {message}"
+        return message or status

--- a/shopping/domain/service/store_planning_reviews.py
+++ b/shopping/domain/service/store_planning_reviews.py
@@ -9,8 +9,13 @@ from shopping.domain.dataprovider.google_maps_review_analysis import (
     GoogleMapsReviewAnalysisClient,
 )
 from shopping.domain.dataprovider.google_maps_reviews import GoogleMapsReviewClient
+from shopping.domain.dataprovider.google_places_aggregate import (
+    GooglePlacesAggregateClient,
+)
 from shopping.domain.valueobject.store_planning import StorePlanningTargetLocation
 from shopping.domain.valueobject.store_planning_reviews import (
+    StorePlanningPlaceDensityHeatmap,
+    StorePlanningPlaceDensityPoint,
     StorePlanningPlaceInsight,
     StorePlanningReviewAnalysisFetchResult,
     StorePlanningReviewFetchResult,
@@ -82,6 +87,8 @@ class StorePlanningReviewService:
     MAX_DETAIL_PLACES = 10
     MAX_ANALYSIS_REVIEWS = 10
     MAX_PLACE_INSIGHTS = 10
+    PLACE_DENSITY_TYPES = ["restaurant", "cafe", "bar", "bakery"]
+    PLACE_DENSITY_CELL_RADIUS_METER = 170
     GCP_CREDENTIALS_URL = "https://console.cloud.google.com/apis/credentials"
     TARGET_STORE_SCOPE = StorePlanningGoogleMapsReview.ReviewScope.TARGET_STORE
     NEARBY_SAME_BUSINESS_SCOPE = (
@@ -782,6 +789,94 @@ class StorePlanningReviewService:
                 }
             )
         return places
+
+    @classmethod
+    def build_place_density_heatmap(
+        cls, api_key: str, target_location: StorePlanningTargetLocation
+    ) -> StorePlanningPlaceDensityHeatmap:
+        """
+        対象店舗候補周辺の施設密度を3x3小領域で集計する。
+
+        Places Aggregate API の `INSIGHT_COUNT` を使い、restaurant / cafe / bar /
+        bakery の施設数を賑わい proxy として扱う。人流そのものではないため、
+        画面側では施設密度に基づく推定値として表示する。
+        """
+        empty_heatmap = StorePlanningPlaceDensityHeatmap(
+            radius_meter=cls.RADIUS_METER,
+            place_types=cls.PLACE_DENSITY_TYPES,
+            points=[],
+        )
+        if target_location.latitude is None or target_location.longitude is None:
+            return empty_heatmap
+        if not api_key:
+            return empty_heatmap
+
+        client = GooglePlacesAggregateClient(api_key)
+        points = []
+        for row in range(3):
+            for col in range(3):
+                center = cls._heatmap_cell_center(target_location, row, col)
+                count = client.count_places(
+                    center=center,
+                    radius=cls.PLACE_DENSITY_CELL_RADIUS_METER,
+                    included_types=cls.PLACE_DENSITY_TYPES,
+                )
+                if count is None:
+                    return StorePlanningPlaceDensityHeatmap(
+                        radius_meter=cls.RADIUS_METER,
+                        place_types=cls.PLACE_DENSITY_TYPES,
+                        points=[],
+                        error_message=cls._place_density_error_message(
+                            client.last_error_status_code,
+                            client.last_error_message,
+                        ),
+                    )
+                points.append(
+                    StorePlanningPlaceDensityPoint(
+                        label=cls.CELL_LABELS[row][col],
+                        latitude=center.latitude,
+                        longitude=center.longitude,
+                        radius_meter=cls.PLACE_DENSITY_CELL_RADIUS_METER,
+                        count=count,
+                        weight=count,
+                    )
+                )
+        counts = [point.count for point in points]
+        return StorePlanningPlaceDensityHeatmap(
+            radius_meter=cls.RADIUS_METER,
+            place_types=cls.PLACE_DENSITY_TYPES,
+            points=points,
+            total_count=sum(counts),
+            max_count=max(counts) if counts else 0,
+        )
+
+    @classmethod
+    def _heatmap_cell_center(
+        cls, target_location: StorePlanningTargetLocation, row: int, col: int
+    ) -> GoogleMapsCoord:
+        cell_offset_meter = cls.RADIUS_METER / 3
+        north_meter = (1 - row) * cell_offset_meter
+        east_meter = (col - 1) * cell_offset_meter
+        latitude = target_location.latitude + north_meter / 111320
+        longitude = target_location.longitude + east_meter / (
+            111320 * cos(radians(target_location.latitude))
+        )
+        return GoogleMapsCoord(latitude=latitude, longitude=longitude)
+
+    @staticmethod
+    def _place_density_error_message(status_code: int | None, detail: str = "") -> str:
+        detail_message = f" Google API応答: {detail}" if detail else ""
+        if status_code == 403:
+            return (
+                "Places Aggregate API の利用が拒否されたため、"
+                "周辺賑わいヒートマップは未表示です。"
+                "APIキーの制限、Places Aggregate APIの有効化、課金状態を確認してください。"
+                f"{detail_message}"
+            )
+        return (
+            "Places Aggregate API から周辺賑わいヒートマップを取得できませんでした。"
+            f"{detail_message}"
+        )
 
     @classmethod
     def _target_review_map_place(

--- a/shopping/domain/valueobject/store_planning_reviews.py
+++ b/shopping/domain/valueobject/store_planning_reviews.py
@@ -107,6 +107,50 @@ class StorePlanningReviewFetchResult:
 
 
 @dataclass(frozen=True)
+class StorePlanningPlaceDensityPoint:
+    """
+    Places Aggregate API の件数を地図ヒートマップ用に変換した小領域。
+
+    Attributes:
+        label: 小領域の方角ラベル。
+        latitude: 小領域中心の緯度。
+        longitude: 小領域中心の経度。
+        radius_meter: 集計円の半径メートル。
+        count: 小領域内の施設数。
+        weight: Google Maps ヒートマップへ渡す重み。
+    """
+
+    label: str
+    latitude: float
+    longitude: float
+    radius_meter: int
+    count: int
+    weight: int
+
+
+@dataclass(frozen=True)
+class StorePlanningPlaceDensityHeatmap:
+    """
+    出店候補地周辺の賑わい proxy を表す施設密度ヒートマップ。
+
+    Attributes:
+        radius_meter: 対象店舗候補から集計対象にする半径。
+        place_types: Places Aggregate API で集計した Place Type。
+        points: 地図ヒートマップに渡す小領域別の施設件数。
+        total_count: 小領域件数の合計。
+        max_count: 小領域内の最大件数。
+        error_message: 集計できなかった場合に画面で補足するメッセージ。
+    """
+
+    radius_meter: int
+    place_types: list[str]
+    points: list[StorePlanningPlaceDensityPoint]
+    total_count: int = 0
+    max_count: int = 0
+    error_message: str = ""
+
+
+@dataclass(frozen=True)
 class StorePlanningReviewAnalysisResult:
     """
     LLMがレビュー1件に付与した分析結果。

--- a/shopping/templates/shopping/store_planning.html
+++ b/shopping/templates/shopping/store_planning.html
@@ -418,6 +418,20 @@
                             <div class="d-flex flex-wrap gap-3 small text-muted mt-2">
                                 <span><span class="badge" style="background-color: #0d6efd;">&nbsp;</span> 対象店舗</span>
                                 <span><span class="badge" style="background-color: #dc3545;">&nbsp;</span> 周辺同業</span>
+                                <span><span class="badge" style="background-color: #f28b30;">&nbsp;</span> 周辺賑わい proxy</span>
+                            </div>
+                            <div class="small text-muted mt-2">
+                                周辺賑わい proxy は Places Aggregate API の INSIGHT_COUNT で
+                                restaurant / cafe / bar / bakery の施設密度を集計した目安です。
+                                人流や通行量そのものではありません。
+                                {% if place_density_heatmap.points %}
+                                    集計範囲 {{ place_density_heatmap.radius_meter|intcomma }}m /
+                                    最大 {{ place_density_heatmap.max_count|intcomma }}件。
+                                {% elif place_density_heatmap.error_message %}
+                                    {{ place_density_heatmap.error_message }}
+                                {% else %}
+                                    API未設定または未取得のため、ヒートマップは未表示です。
+                                {% endif %}
                             </div>
                         {% elif not google_maps_fe_api_key %}
                             <div class="alert alert-warning mb-0">
@@ -714,6 +728,19 @@
                     );
                     const infoWindow = new google.maps.InfoWindow();
                     const bounds = new google.maps.LatLngBounds();
+                    const heatmapPoints = mapData.placeDensityHeatmap.points.map((point) => ({
+                        location: new google.maps.LatLng(point.location.lat, point.location.lng),
+                        weight: point.weight,
+                    }));
+                    if (heatmapPoints.length) {
+                        const heatmap = new google.maps.visualization.HeatmapLayer({
+                            data: heatmapPoints,
+                            dissipating: true,
+                            radius: 48,
+                            opacity: 0.58,
+                        });
+                        heatmap.setMap(map);
+                    }
                     mapData.places.forEach((place) => {
                         bounds.extend(place.location);
                         const pin = new google.maps.marker.PinElement({
@@ -748,7 +775,7 @@
                 });
             };
         </script>
-        <script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_fe_api_key }}&callback=storePlanningReviewMapInit&libraries=places,marker&v=weekly"
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_fe_api_key }}&callback=storePlanningReviewMapInit&libraries=places,marker,visualization&v=weekly"
                 defer onerror="console.error('Google Maps API failed to load.');"></script>
     {% endif %}
 {% endblock %}

--- a/shopping/tests/service/test_store_planning_reviews.py
+++ b/shopping/tests/service/test_store_planning_reviews.py
@@ -1155,6 +1155,84 @@ class StorePlanningReviewServiceTest(TestCase):
         )
         self.assertEqual("近隣カフェ09", map_places[-1]["name"])
 
+    def test_build_place_density_heatmap_counts_nine_cells_with_aggregate_api(self):
+        """
+        シナリオ:
+        - 入力: 対象店舗候補の座標と、Places Aggregate API の小領域別件数。
+        - 処理: 周辺賑わいヒートマップ用データを作成する。
+        - 期待値: 500m圏内を3x3小領域に分け、INSIGHT_COUNTの件数を地図用ポイントへ変換すること。
+        """
+        target_location = StorePlanningTargetLocation(
+            slug="chapter-table",
+            name="Chapter Table",
+            address="東京都足立区東保木間二丁目",
+            latitude=35.792822,
+            longitude=139.8143238,
+            city_code="13121",
+            town_code="073002",
+            population_area="東京都足立区東保木間二丁目",
+        )
+
+        with patch(
+            "shopping.domain.service.store_planning_reviews.GooglePlacesAggregateClient"
+        ) as mock_client_class:
+            mock_client = mock_client_class.return_value
+            mock_client.count_places.side_effect = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+            heatmap = StorePlanningReviewService.build_place_density_heatmap(
+                api_key="dummy-key",
+                target_location=target_location,
+            )
+
+        mock_client_class.assert_called_once_with("dummy-key")
+        self.assertEqual(9, mock_client.count_places.call_count)
+        first_kwargs = mock_client.count_places.call_args_list[0].kwargs
+        self.assertEqual(170, first_kwargs["radius"])
+        self.assertEqual(
+            ["restaurant", "cafe", "bar", "bakery"],
+            first_kwargs["included_types"],
+        )
+        self.assertEqual(9, len(heatmap.points))
+        self.assertEqual("北西", heatmap.points[0].label)
+        self.assertEqual(45, heatmap.total_count)
+        self.assertEqual(9, heatmap.max_count)
+        self.assertEqual(9, heatmap.points[-1].weight)
+
+    def test_build_place_density_heatmap_returns_empty_when_aggregate_api_fails(self):
+        """
+        シナリオ:
+        - 入力: Places Aggregate API が403で拒否された状態。
+        - 処理: 周辺賑わいヒートマップ用データを作成する。
+        - 期待値: 例外で画面を壊さず、空ポイントと説明用エラーメッセージを返すこと。
+        """
+        target_location = StorePlanningTargetLocation(
+            slug="chapter-table",
+            name="Chapter Table",
+            address="東京都足立区東保木間二丁目",
+            latitude=35.792822,
+            longitude=139.8143238,
+            city_code="13121",
+            town_code="073002",
+            population_area="東京都足立区東保木間二丁目",
+        )
+
+        with patch(
+            "shopping.domain.service.store_planning_reviews.GooglePlacesAggregateClient"
+        ) as mock_client_class:
+            mock_client = mock_client_class.return_value
+            mock_client.count_places.return_value = None
+            mock_client.last_error_status_code = 403
+            mock_client.last_error_message = "PERMISSION_DENIED"
+
+            heatmap = StorePlanningReviewService.build_place_density_heatmap(
+                api_key="dummy-key",
+                target_location=target_location,
+            )
+
+        self.assertEqual([], heatmap.points)
+        self.assertIn("Places Aggregate API の利用が拒否", heatmap.error_message)
+        self.assertIn("PERMISSION_DENIED", heatmap.error_message)
+
     def test_analyze_all_reviews_saves_one_target_and_ten_nearby_place_summaries(
         self,
     ):

--- a/shopping/tests/test_views.py
+++ b/shopping/tests/test_views.py
@@ -14,6 +14,10 @@ from shopping.models import (
     StorePlanningGoogleMapsPlaceSummary,
     StorePlanningTargetStore,
 )
+from shopping.domain.valueobject.store_planning_reviews import (
+    StorePlanningPlaceDensityHeatmap,
+    StorePlanningPlaceDensityPoint,
+)
 
 
 class TestView(TestCase):
@@ -39,6 +43,12 @@ class TestView(TestCase):
 
     def setUp(self):
         self.client.force_login(self.superuser)
+        self.google_maps_env_patcher = patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_BE_API_KEY": "", "GOOGLE_MAPS_FE_API_KEY": ""},
+        )
+        self.google_maps_env_patcher.start()
+        self.addCleanup(self.google_maps_env_patcher.stop)
 
     def test_get_top_page_200(self):
         """
@@ -230,7 +240,10 @@ class TestView(TestCase):
             publish_time=timezone.now(),
         )
 
-        with patch.dict("os.environ", {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key"}):
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key", "GOOGLE_MAPS_BE_API_KEY": ""},
+        ):
             response = self.client.get(reverse("shp:store_planning"))
 
         self.assertEqual(200, response.status_code)
@@ -255,10 +268,54 @@ class TestView(TestCase):
         self.assertContains(response, "近隣カフェ")
         self.assertContains(response, "店舗レビュー比較")
         self.assertContains(response, "fitBounds")
+        self.assertContains(response, "周辺賑わい proxy")
+        self.assertContains(response, "HeatmapLayer")
+        self.assertContains(response, "libraries=places,marker,visualization")
         self.assertContains(response, "強み")
         self.assertContains(response, "弱み")
         self.assertContains(response, "分析待ち")
         self.assertNotContains(response, "Google Maps レビューはまだ取得されていません")
+
+    @patch("shopping.views.StorePlanningReviewService.build_place_density_heatmap")
+    def test_store_planning_page_overlays_places_aggregate_heatmap(
+        self, mock_build_heatmap
+    ):
+        """
+        シナリオ:
+        - 入力: Places Aggregate API 由来の施設密度ポイントと、Google Maps JS APIキー。
+        - 処理: 出店計画画面をGETする。
+        - 期待値: レビュー取得店舗マップにヒートマップデータと施設密度proxyの注記が含まれること。
+        """
+        mock_build_heatmap.return_value = StorePlanningPlaceDensityHeatmap(
+            radius_meter=500,
+            place_types=["restaurant", "cafe", "bar", "bakery"],
+            points=[
+                StorePlanningPlaceDensityPoint(
+                    label="中心",
+                    latitude=35.792822,
+                    longitude=139.8143238,
+                    radius_meter=170,
+                    count=7,
+                    weight=7,
+                )
+            ],
+            total_count=7,
+            max_count=7,
+        )
+
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key", "GOOGLE_MAPS_BE_API_KEY": ""},
+        ):
+            response = self.client.get(reverse("shp:store_planning"))
+
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, "周辺賑わい proxy")
+        self.assertContains(response, "人流や通行量そのものではありません")
+        self.assertContains(response, "最大 7件")
+        self.assertContains(response, "placeDensityHeatmap")
+        self.assertContains(response, "count\\u0022: 7")
+        self.assertContains(response, "HeatmapLayer")
 
     def test_store_planning_page_displays_nearby_same_business_reviews(self):
         """
@@ -283,7 +340,10 @@ class TestView(TestCase):
             google_maps_uri="https://maps.google.com/nearby-place-1",
         )
 
-        with patch.dict("os.environ", {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key"}):
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key", "GOOGLE_MAPS_BE_API_KEY": ""},
+        ):
             response = self.client.get(reverse("shp:store_planning"))
 
         self.assertEqual(200, response.status_code)
@@ -353,7 +413,10 @@ class TestView(TestCase):
             publish_time=timezone.now(),
         )
 
-        with patch.dict("os.environ", {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key"}):
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key", "GOOGLE_MAPS_BE_API_KEY": ""},
+        ):
             response = self.client.get(reverse("shp:store_planning"))
 
         self.assertEqual(200, response.status_code)
@@ -383,7 +446,10 @@ class TestView(TestCase):
             publish_time=timezone.now(),
         )
 
-        with patch.dict("os.environ", {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key"}):
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key", "GOOGLE_MAPS_BE_API_KEY": ""},
+        ):
             response = self.client.get(reverse("shp:store_planning"))
 
         self.assertEqual(200, response.status_code)
@@ -430,7 +496,10 @@ class TestView(TestCase):
             prompt_version="test-prompt",
         )
 
-        with patch.dict("os.environ", {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key"}):
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_MAPS_FE_API_KEY": "dummy-fe-key", "GOOGLE_MAPS_BE_API_KEY": ""},
+        ):
             response = self.client.get(reverse("shp:store_planning"))
 
         self.assertEqual(200, response.status_code)

--- a/shopping/views.py
+++ b/shopping/views.py
@@ -237,6 +237,7 @@ class StorePlanningView(TemplateView):
         review_map_places = StorePlanningReviewService.build_review_map_places(
             selected_location
         )
+        place_density_heatmap = self._build_place_density_heatmap(selected_location)
         context["review_map_data"] = json.dumps(
             {
                 "center": {
@@ -244,10 +245,27 @@ class StorePlanningView(TemplateView):
                     "lng": selected_location.longitude,
                 },
                 "places": review_map_places,
+                "placeDensityHeatmap": {
+                    "points": [
+                        {
+                            "label": point.label,
+                            "location": {
+                                "lat": point.latitude,
+                                "lng": point.longitude,
+                            },
+                            "count": point.count,
+                            "weight": point.weight,
+                        }
+                        for point in place_density_heatmap.points
+                    ],
+                    "radiusMeter": place_density_heatmap.radius_meter,
+                    "placeTypes": place_density_heatmap.place_types,
+                },
                 "mapId": os.getenv("GOOGLE_MAPS_MAP_ID", "8f6a4cf0806f4732"),
             },
             ensure_ascii=False,
         )
+        context["place_density_heatmap"] = place_density_heatmap
         context["google_maps_fe_api_key"] = os.getenv("GOOGLE_MAPS_FE_API_KEY")
         context["has_review_map_places"] = bool(review_map_places)
         context["has_any_google_maps_reviews"] = (
@@ -256,6 +274,21 @@ class StorePlanningView(TemplateView):
             > 0
         )
         return context
+
+    def _build_place_density_heatmap(self, selected_location):
+        if not os.getenv("GOOGLE_MAPS_FE_API_KEY"):
+            return StorePlanningReviewService.build_place_density_heatmap(
+                api_key="", target_location=selected_location
+            )
+        api_key = os.getenv("GOOGLE_MAPS_BE_API_KEY")
+        if not api_key:
+            return StorePlanningReviewService.build_place_density_heatmap(
+                api_key="", target_location=selected_location
+            )
+        return StorePlanningReviewService.build_place_density_heatmap(
+            api_key=api_key,
+            target_location=selected_location,
+        )
 
     def post(self, request, *args, **kwargs):
         action = request.POST.get("action")


### PR DESCRIPTION
## Summary
出店計画画面のレビュー取得店舗マップに、Places Aggregate API の `INSIGHT_COUNT` を使った周辺賑わいヒートマップを重ねました。

- Places Aggregate API 用の軽量 dataprovider を追加し、500m圏内を3x3小領域に分けて restaurant / cafe / bar / bakery の施設数を集計
- 取得した施設数を Google Maps JavaScript API の HeatmapLayer に渡し、既存の対象店舗・周辺同業ピンの上に濃淡表示
- API未設定・取得失敗時はヒートマップだけ未表示にし、既存のレビュー地図表示は維持
- 画面上に「施設密度による賑わい proxy であり、人流や通行量そのものではない」旨を明記
- サービス・画面テストを追加し、テスト中はローカルのGoogle APIキーを拾って外部通信しないよう整理

## 目検による動作確認手順
- [ ] `/shopping/store-planning/` を開き、Google Maps レビューの地図に対象店舗ピンと周辺同業ピンが表示されること
- [ ] `GOOGLE_MAPS_BE_API_KEY` と `GOOGLE_MAPS_FE_API_KEY` が設定された環境で、周辺賑わい proxy のヒートマップが地図に重なること
- [ ] API未設定または取得失敗時でも、レビュー取得店舗マップと店舗レビュー比較が壊れないこと

## 自動テストでカバーできた範囲
`python -m black shopping\domain\dataprovider\google_places_aggregate.py shopping\domain\service\store_planning_reviews.py shopping\domain\valueobject\store_planning_reviews.py shopping\views.py shopping\tests\service\test_store_planning_reviews.py shopping\tests\test_views.py`

`python manage.py test shopping.tests.test_views shopping.tests.service.test_store_planning_reviews --keepdb`

`python manage.py test shopping --keepdb`

`python manage.py makemigrations --check --dry-run`

`git diff --check`

- Places Aggregate API の 3x3 小領域集計とAPI失敗時の空ヒートマップ
- Google Mapsレビュー地図への HeatmapLayer 用データ埋め込み
- API未設定時に既存レビュー地図が表示できること
- shopping アプリ既存テストの維持
- モデル変更がなく migration 不要であること

## 関連Issue
Closes #813
https://github.com/duri0214/portfolio/issues/813
