### PR TITLE
#834 詳細ページをつくって CRUD の RUDを完成させる

### DIFF
--- a/taxonomy/forms.py
+++ b/taxonomy/forms.py
@@ -240,3 +240,66 @@ class TaxonomyBreedCreateForm(forms.Form):
             defaults={"name_en": name_en},
         )
         return instance
+
+
+class BreedForm(forms.ModelForm):
+    """
+    既存の品種情報を編集するフォーム。
+    """
+
+    class Meta:
+        model = Breed
+        fields = [
+            "species",
+            "name",
+            "name_kana",
+            "image",
+            "natural_monument",
+            "remark",
+        ]
+        labels = {
+            "species": "種",
+            "name": "品種・系統・分類対象名",
+            "name_kana": "よみがな",
+            "image": "画像",
+            "natural_monument": "天然記念物区分",
+            "remark": "メモ",
+        }
+        widgets = {
+            "remark": forms.Textarea(attrs={"rows": 3}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["species"].queryset = Species.objects.select_related(
+            "genus__family__classification__phylum__kingdom"
+        ).order_by(
+            "genus__family__classification__phylum__kingdom__name",
+            "genus__family__classification__phylum__name",
+            "genus__family__classification__name",
+            "genus__family__name",
+            "genus__name",
+            "name",
+        )
+        self.fields["natural_monument"].queryset = NaturalMonument.objects.order_by(
+            "name"
+        )
+        self.fields["species"].label_from_instance = self._species_label
+        self.fields["natural_monument"].label_from_instance = lambda obj: obj.name
+
+        for field in self.fields.values():
+            if isinstance(field.widget, forms.Select):
+                field.widget.attrs["class"] = "form-select"
+            else:
+                field.widget.attrs["class"] = "form-control"
+
+    def _species_label(self, species):
+        genus = species.genus
+        family = genus.family
+        classification = family.classification
+        phylum = classification.phylum
+        kingdom = phylum.kingdom
+        return (
+            f"{kingdom.name} > {phylum.name} > {classification.name} > "
+            f"{family.name} > {genus.name} > {species.name}"
+        )

--- a/taxonomy/templates/taxonomy/breed_confirm_delete.html
+++ b/taxonomy/templates/taxonomy/breed_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends "taxonomy/base.html" %}
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'txo:index' %}">分類学</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'txo:breed_list' %}">品種一覧</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'txo:breed_detail' breed.pk %}">{{ breed.name }}</a></li>
+                <li class="breadcrumb-item active" aria-current="page">削除確認</li>
+            </ol>
+        </nav>
+
+        <div class="alert alert-warning" role="alert">
+            <h1 class="h4 alert-heading">削除確認</h1>
+            <p class="mb-0">{{ breed.name }} を削除します。この操作は取り消せません。</p>
+        </div>
+
+        <form method="post" class="d-flex gap-2 justify-content-end">
+            {% csrf_token %}
+            <a class="btn btn-outline-secondary" href="{% url 'txo:breed_detail' breed.pk %}">戻る</a>
+            <button class="btn btn-danger" type="submit">削除</button>
+        </form>
+    </div>
+{% endblock %}

--- a/taxonomy/templates/taxonomy/breed_detail.html
+++ b/taxonomy/templates/taxonomy/breed_detail.html
@@ -1,0 +1,69 @@
+{% extends "taxonomy/base.html" %}
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'txo:index' %}">分類学</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'txo:breed_list' %}">品種一覧</a></li>
+                <li class="breadcrumb-item active" aria-current="page">{{ breed.name }}</li>
+            </ol>
+        </nav>
+
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-4">
+            <div>
+                <h1 class="h3 mb-1">{{ breed.name }}</h1>
+                <p class="text-muted mb-0">{{ breed.name_kana }}</p>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                <a class="btn btn-outline-secondary" href="{% url 'txo:breed_list' %}">一覧へ戻る</a>
+                <a class="btn btn-primary" href="{% url 'txo:breed_edit' breed.pk %}">編集</a>
+            </div>
+        </div>
+
+        <div class="row g-4">
+            <div class="col-lg-8">
+                <div class="card shadow-sm">
+                    <div class="card-header bg-white">
+                        <h2 class="h5 mb-0">分類階層</h2>
+                    </div>
+                    <div class="card-body">
+                        <dl class="row mb-0">
+                            <dt class="col-sm-3">界</dt>
+                            <dd class="col-sm-9">{{ breed.species.genus.family.classification.phylum.kingdom.name }}</dd>
+                            <dt class="col-sm-3">門</dt>
+                            <dd class="col-sm-9">{{ breed.species.genus.family.classification.phylum.name }}</dd>
+                            <dt class="col-sm-3">綱</dt>
+                            <dd class="col-sm-9">{{ breed.species.genus.family.classification.name }}</dd>
+                            <dt class="col-sm-3">科</dt>
+                            <dd class="col-sm-9">{{ breed.species.genus.family.name }}</dd>
+                            <dt class="col-sm-3">属</dt>
+                            <dd class="col-sm-9">{{ breed.species.genus.name }}</dd>
+                            <dt class="col-sm-3">種</dt>
+                            <dd class="col-sm-9">{{ breed.species.name }}</dd>
+                            <dt class="col-sm-3">品種</dt>
+                            <dd class="col-sm-9">{{ breed.name }}</dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="card shadow-sm">
+                    <div class="card-header bg-white">
+                        <h2 class="h5 mb-0">補足情報</h2>
+                    </div>
+                    <div class="card-body">
+                        {% if breed.image %}
+                            <img class="img-fluid rounded mb-3" src="{{ breed.image.url }}" alt="{{ breed.name }}">
+                        {% endif %}
+                        <dl class="mb-0">
+                            <dt>天然記念物区分</dt>
+                            <dd>{{ breed.natural_monument.name|default:"指定なし" }}</dd>
+                            <dt>メモ</dt>
+                            <dd>{{ breed.remark|default:"-" }}</dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/taxonomy/templates/taxonomy/breed_edit.html
+++ b/taxonomy/templates/taxonomy/breed_edit.html
@@ -1,0 +1,32 @@
+{% extends "taxonomy/base.html" %}
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'txo:index' %}">分類学</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'txo:breed_list' %}">品種一覧</a></li>
+                <li class="breadcrumb-item"><a href="{% url 'txo:breed_detail' breed.pk %}">{{ breed.name }}</a></li>
+                <li class="breadcrumb-item active" aria-current="page">編集</li>
+            </ol>
+        </nav>
+
+        <h1 class="h3 mb-4">品種を編集</h1>
+
+        <form method="post" enctype="multipart/form-data" class="mb-5">
+            {% csrf_token %}
+            <div class="row g-4">
+                {% for field in form %}
+                    <div class="{% if field.name == 'remark' %}col-12{% else %}col-md-6{% endif %}">
+                        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                        {{ field }}
+                        <div class="text-danger small mt-1">{{ field.errors }}</div>
+                    </div>
+                {% endfor %}
+                <div class="col-12 d-flex gap-2 justify-content-end">
+                    <a class="btn btn-outline-secondary" href="{% url 'txo:breed_detail' breed.pk %}">戻る</a>
+                    <button class="btn btn-primary" type="submit">更新</button>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/taxonomy/templates/taxonomy/breed_list.html
+++ b/taxonomy/templates/taxonomy/breed_list.html
@@ -1,0 +1,54 @@
+{% extends "taxonomy/base.html" %}
+{% block content %}
+    <div class="container mt-4">
+        <nav aria-label="breadcrumb" class="mb-4 border-bottom pb-2">
+            <ol class="breadcrumb mb-0 small">
+                <li class="breadcrumb-item"><a href="{% url 'txo:index' %}">分類学</a></li>
+                <li class="breadcrumb-item active" aria-current="page">品種一覧</li>
+            </ol>
+        </nav>
+
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+            <h1 class="h3 mb-0">品種一覧</h1>
+            <a class="btn btn-primary" href="{% url 'txo:breed_new' %}">分類を登録</a>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead class="table-light">
+                <tr>
+                    <th scope="col">品種</th>
+                    <th scope="col">種</th>
+                    <th scope="col">属</th>
+                    <th scope="col">科</th>
+                    <th scope="col">操作</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for breed in breeds %}
+                    <tr>
+                        <td>
+                            <div class="fw-semibold">{{ breed.name }}</div>
+                            <div class="text-muted small">{{ breed.name_kana }}</div>
+                        </td>
+                        <td>{{ breed.species.name }}</td>
+                        <td>{{ breed.species.genus.name }}</td>
+                        <td>{{ breed.species.genus.family.name }}</td>
+                        <td>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a class="btn btn-sm btn-outline-primary" href="{% url 'txo:breed_detail' breed.pk %}">詳細</a>
+                                <a class="btn btn-sm btn-outline-secondary" href="{% url 'txo:breed_edit' breed.pk %}">編集</a>
+                                <a class="btn btn-sm btn-outline-danger" href="{% url 'txo:breed_delete' breed.pk %}">削除</a>
+                            </div>
+                        </td>
+                    </tr>
+                {% empty %}
+                    <tr>
+                        <td colspan="5" class="text-muted text-center py-4">登録済みの品種はありません。</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -30,6 +30,7 @@
                     <hr class="my-4">
                     <div class="d-flex flex-wrap gap-2">
                         <a class="btn btn-primary" href="{% url 'txo:breed_new' %}">分類を登録</a>
+                        <a class="btn btn-outline-primary" href="{% url 'txo:breed_list' %}">品種一覧</a>
                         <a class="btn btn-outline-primary" href="{% url 'txo:observation' %}">鶏の観察グラフ</a>
                     </div>
                 </div>

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -12,6 +12,7 @@ from taxonomy.models import (
     Family,
     Genus,
     Kingdom,
+    NaturalMonument,
     Phylum,
     Species,
 )
@@ -59,6 +60,7 @@ class TaxonomyBreedCreateViewTest(TestCase):
         self.species = Species.objects.create(
             name="ニワトリ", name_en="Gallus gallus domesticus", genus=self.genus
         )
+        self.natural_monument = NaturalMonument.objects.create(name="天然記念物")
 
     def test_create_page_shows_hierarchy_and_breed_fields(self):
         """
@@ -91,8 +93,8 @@ class TaxonomyBreedCreateViewTest(TestCase):
             data=self._base_post_data({"breed_name": "名古屋種"}),
         )
 
-        self.assertRedirects(response, reverse("txo:index"))
         breed = Breed.objects.get(name="名古屋種")
+        self.assertRedirects(response, reverse("txo:breed_detail", args=[breed.pk]))
         self.assertEqual(breed.species, self.species)
 
     def test_create_breed_without_image(self):
@@ -107,8 +109,8 @@ class TaxonomyBreedCreateViewTest(TestCase):
 
         response = self.client.post(reverse("txo:breed_new"), data=data)
 
-        self.assertRedirects(response, reverse("txo:index"))
         breed = Breed.objects.get(name="写真なし系統")
+        self.assertRedirects(response, reverse("txo:breed_detail", args=[breed.pk]))
         self.assertEqual(breed.image.name, "")
 
     def test_create_breed_with_new_hierarchy(self):
@@ -139,10 +141,108 @@ class TaxonomyBreedCreateViewTest(TestCase):
             },
         )
 
-        self.assertRedirects(response, reverse("txo:index"))
         breed = Breed.objects.select_related("species__genus").get(name="畑土系統")
+        self.assertRedirects(response, reverse("txo:breed_detail", args=[breed.pk]))
         self.assertEqual(breed.species.name, "フトミミズ")
         self.assertEqual(breed.species.genus.name, "フトミミズ属")
+
+    def test_index_page_links_to_breed_list(self):
+        """
+        シナリオ:
+        - 入力: taxonomyトップページを表示できるDB状態。
+        - 処理: taxonomyトップページを表示する。
+        - 期待値: 品種一覧ページへの導線が表示されること。
+        """
+        response = self.client.get(reverse("txo:index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("txo:breed_list"))
+        self.assertContains(response, "品種一覧")
+
+    def test_breed_list_shows_action_links(self):
+        """
+        シナリオ:
+        - 入力: 品種が1件登録済みのDB状態。
+        - 処理: 品種一覧ページを表示する。
+        - 期待値: 詳細・編集・削除の操作導線が表示されること。
+        """
+        breed = self._create_breed(name="烏骨鶏")
+
+        response = self.client.get(reverse("txo:breed_list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "烏骨鶏")
+        self.assertContains(response, reverse("txo:breed_detail", args=[breed.pk]))
+        self.assertContains(response, reverse("txo:breed_edit", args=[breed.pk]))
+        self.assertContains(response, reverse("txo:breed_delete", args=[breed.pk]))
+
+    def test_breed_detail_shows_hierarchy_and_navigation(self):
+        """
+        シナリオ:
+        - 入力: 分類階層に紐づく品種が登録済みのDB状態。
+        - 処理: 品種詳細ページを表示する。
+        - 期待値: 界から品種までの階層情報と一覧・編集への導線が表示されること。
+        """
+        breed = self._create_breed(name="名古屋種")
+
+        response = self.client.get(reverse("txo:breed_detail", args=[breed.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "動物界")
+        self.assertContains(response, "脊索動物門")
+        self.assertContains(response, "鳥綱")
+        self.assertContains(response, "キジ科")
+        self.assertContains(response, "ヤケイ属")
+        self.assertContains(response, "ニワトリ")
+        self.assertContains(response, "名古屋種")
+        self.assertContains(response, reverse("txo:breed_list"))
+        self.assertContains(response, reverse("txo:breed_edit", args=[breed.pk]))
+
+    def test_edit_breed_updates_record_and_redirects_to_detail(self):
+        """
+        シナリオ:
+        - 入力: 登録済みの品種と更新後の品種情報。
+        - 処理: 品種編集フォームをPOSTする。
+        - 期待値: 品種情報が更新され、詳細ページへ戻ること。
+        """
+        breed = self._create_breed(name="烏骨鶏")
+
+        response = self.client.post(
+            reverse("txo:breed_edit", args=[breed.pk]),
+            data={
+                "species": self.species.pk,
+                "name": "更新した烏骨鶏",
+                "name_kana": "こうしんしたうこっけい",
+                "natural_monument": self.natural_monument.pk,
+                "remark": "編集済み",
+            },
+        )
+
+        self.assertRedirects(response, reverse("txo:breed_detail", args=[breed.pk]))
+        breed.refresh_from_db()
+        self.assertEqual(breed.name, "更新した烏骨鶏")
+        self.assertEqual(breed.name_kana, "こうしんしたうこっけい")
+        self.assertEqual(breed.natural_monument, self.natural_monument)
+        self.assertEqual(breed.remark, "編集済み")
+
+    def test_delete_breed_uses_confirm_page_and_redirects_to_list(self):
+        """
+        シナリオ:
+        - 入力: 登録済みの品種。
+        - 処理: 削除確認ページを表示し、削除フォームをPOSTする。
+        - 期待値: 確認ステップを挟んだ後に品種が削除され、一覧へ戻ること。
+        """
+        breed = self._create_breed(name="削除対象")
+
+        confirm_response = self.client.get(reverse("txo:breed_delete", args=[breed.pk]))
+        self.assertEqual(confirm_response.status_code, 200)
+        self.assertContains(confirm_response, "削除確認")
+        self.assertContains(confirm_response, "削除対象")
+
+        response = self.client.post(reverse("txo:breed_delete", args=[breed.pk]))
+
+        self.assertRedirects(response, reverse("txo:breed_list"))
+        self.assertFalse(Breed.objects.filter(pk=breed.pk).exists())
 
     def test_rejects_duplicate_breed_name(self):
         """
@@ -165,7 +265,9 @@ class TaxonomyBreedCreateViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "alert alert-danger")
-        self.assertContains(response, "登録できませんでした。入力内容を確認してください。")
+        self.assertContains(
+            response, "登録できませんでした。入力内容を確認してください。"
+        )
         self.assertContains(response, "text-danger")
         self.assertContains(response, "この名前の品種は登録済みです。")
         self.assertEqual(Breed.objects.filter(name="名古屋種").count(), 1)
@@ -192,3 +294,11 @@ class TaxonomyBreedCreateViewTest(TestCase):
             b"\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
         )
         return SimpleUploadedFile(name, image, content_type="image/gif")
+
+    def _create_breed(self, name):
+        return Breed.objects.create(
+            name=name,
+            name_kana="てすと",
+            image=self._image(f"{name}.gif"),
+            species=self.species,
+        )

--- a/taxonomy/urls.py
+++ b/taxonomy/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
 
 from taxonomy.views import (
+    BreedDeleteView,
+    BreedDetailView,
+    BreedListView,
+    BreedUpdateView,
     IndexView,
     KingdomCreateView,
     PhylumCreateView,
@@ -18,7 +22,11 @@ from taxonomy.views import (
 app_name = "txo"
 urlpatterns = [
     path("", IndexView.as_view(), name="index"),
+    path("breeds/", BreedListView.as_view(), name="breed_list"),
     path("breeds/new/", TaxonomyBreedCreateView.as_view(), name="breed_new"),
+    path("breeds/<int:pk>/", BreedDetailView.as_view(), name="breed_detail"),
+    path("breeds/<int:pk>/edit/", BreedUpdateView.as_view(), name="breed_edit"),
+    path("breeds/<int:pk>/delete/", BreedDeleteView.as_view(), name="breed_delete"),
     path("kingdom/create/", KingdomCreateView.as_view(), name="kingdom_create"),
     path("phylum/create/", PhylumCreateView.as_view(), name="phylum_create"),
     path(

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -3,7 +3,15 @@ import json
 from django.contrib import messages
 from django.urls import reverse_lazy
 from django.utils.safestring import mark_safe
-from django.views.generic import CreateView, FormView, UpdateView, TemplateView
+from django.views.generic import (
+    CreateView,
+    DeleteView,
+    DetailView,
+    FormView,
+    ListView,
+    TemplateView,
+    UpdateView,
+)
 
 from taxonomy.domain.breed_entity import BreedEntity
 from taxonomy.domain.node import NodeTree
@@ -11,8 +19,8 @@ from taxonomy.domain.repository.breed import BreedRepository
 from taxonomy.domain.repository.chicken_observations import (
     ChickenObservationsRepository,
 )
-from taxonomy.forms import TaxonomyBreedCreateForm
-from taxonomy.models import Classification, Family, Genus, Phylum, Species
+from taxonomy.forms import BreedForm, TaxonomyBreedCreateForm
+from taxonomy.models import Breed, Classification, Family, Genus, Phylum, Species
 
 
 class IndexView(TemplateView):
@@ -61,20 +69,24 @@ class TaxonomyBreedCreateView(FormView):
     分類階層と品種を1画面で登録するビュー。
 
     既存階層の選択と不足階層の追加を同じフォームで扱い、保存後は
-    分類ツリーを確認できるトップページへ戻す。
+    登録した品種の詳細ページへ遷移する。
     """
 
     form_class = TaxonomyBreedCreateForm
     template_name = "taxonomy/breed_form.html"
-    success_url = reverse_lazy("txo:index")
 
     def form_valid(self, form):
-        breed = form.save()
-        messages.success(self.request, f"{breed.name} を登録しました。")
+        self.breed = form.save()
+        messages.success(self.request, f"{self.breed.name} を登録しました。")
         return super().form_valid(form)
 
+    def get_success_url(self):
+        return reverse_lazy("txo:breed_detail", kwargs={"pk": self.breed.pk})
+
     def form_invalid(self, form):
-        messages.error(self.request, "登録できませんでした。入力内容を確認してください。")
+        messages.error(
+            self.request, "登録できませんでした。入力内容を確認してください。"
+        )
         return super().form_invalid(form)
 
     def get_context_data(self, **kwargs):
@@ -107,6 +119,83 @@ class TaxonomyBreedCreateView(FormView):
                 for item in Species.objects.order_by("genus_id", "name")
             ],
         }
+
+
+class BreedListView(ListView):
+    """
+    品種レコードを分類階層付きで一覧表示するビュー。
+    """
+
+    model = Breed
+    template_name = "taxonomy/breed_list.html"
+    context_object_name = "breeds"
+
+    def get_queryset(self):
+        return Breed.objects.select_related(
+            "species__genus__family__classification__phylum__kingdom",
+            "natural_monument",
+        ).order_by(
+            "species__genus__family__classification__phylum__kingdom__name",
+            "species__genus__family__classification__phylum__name",
+            "species__genus__family__classification__name",
+            "species__genus__family__name",
+            "species__genus__name",
+            "species__name",
+            "name",
+        )
+
+
+class BreedDetailView(DetailView):
+    """
+    1件の品種レコードと分類階層を表示するビュー。
+    """
+
+    model = Breed
+    template_name = "taxonomy/breed_detail.html"
+    context_object_name = "breed"
+    queryset = Breed.objects.select_related(
+        "species__genus__family__classification__phylum__kingdom",
+        "natural_monument",
+    )
+
+
+class BreedUpdateView(UpdateView):
+    """
+    既存の品種レコードを編集するビュー。
+    """
+
+    model = Breed
+    form_class = BreedForm
+    template_name = "taxonomy/breed_edit.html"
+    context_object_name = "breed"
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        messages.success(self.request, f"{self.object.name} を更新しました。")
+        return response
+
+    def get_success_url(self):
+        return reverse_lazy("txo:breed_detail", kwargs={"pk": self.object.pk})
+
+
+class BreedDeleteView(DeleteView):
+    """
+    品種レコードを確認画面経由で削除するビュー。
+    """
+
+    model = Breed
+    template_name = "taxonomy/breed_confirm_delete.html"
+    context_object_name = "breed"
+    success_url = reverse_lazy("txo:breed_list")
+    queryset = Breed.objects.select_related(
+        "species__genus__family__classification__phylum__kingdom"
+    )
+
+    def form_valid(self, form):
+        name = self.object.name
+        response = super().form_valid(form)
+        messages.success(self.request, f"{name} を削除しました。")
+        return response
 
 
 class KingdomCreateView(CreateView):


### PR DESCRIPTION
## Summary
Taxonomy の品種レコードについて、作成後の確認から一覧・詳細・編集・削除までの RUD 導線を追加しました。

- 品種作成後の遷移先をトップページから作成した品種の詳細ページへ変更
- taxonomy トップに品種一覧への導線を追加
- 品種一覧、詳細、編集、削除確認画面と URL/View/Form を追加
- 品種一覧から詳細・編集・削除へ移動できる操作導線を追加
- 削除後は品種一覧へ戻り、対象レコードが消える流れをテストで確認
- 樹形図ノードから詳細ページへの遷移は、現状のD3用データに品種ID/URLが含まれていないため今回のRUD導線完成範囲では見送り。後続ではツリー出力へ leaf の URL を含める形で対応する想定です。

## 目検による動作確認手順
- [x] taxonomy トップで「品種一覧」ボタンが表示されること
- [x] 品種一覧から詳細・編集・削除確認へ移動できること
- [x] 新規作成後に作成した品種の詳細ページへ遷移すること
- [x] 削除確認後、一覧へ戻り削除済み品種が表示されないこと

## 自動テストでカバーできた範囲
- `python manage.py test taxonomy.tests.test_views --keepdb`
  - 新規作成後の詳細ページ遷移、一覧導線、詳細表示、編集、削除確認から削除までを確認
- `python manage.py test taxonomy --keepdb`
  - taxonomy アプリ全体の既存テストを含めて確認

## 関連Issue
Closes #834
https://github.com/duri0214/portfolio/issues/834
