### PR TITLE
#845 Taxonomyトップの畜産統計ダッシュボードを鶏の観察ページへ移動する

### DIFF
--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -31,7 +31,9 @@
                     <div class="d-flex flex-wrap gap-2">
                         <a class="btn btn-primary" href="{% url 'txo:breed_new' %}">分類を登録</a>
                         <a class="btn btn-outline-primary" href="{% url 'txo:breed_list' %}">品種一覧</a>
-                        <a class="btn btn-outline-primary" href="{% url 'txo:observation' %}">鶏の観察グラフ</a>
+                        <a class="btn btn-outline-primary" href="{% url 'txo:observation' %}">
+                            <i class="fas fa-chart-area me-1"></i>鶏の観察グラフ
+                        </a>
                     </div>
                 </div>
             </div>
@@ -51,11 +53,6 @@
                             分類ツリーとして確認できるようにしています。鶏の飼養分布や観察記録は、
                             鶏の観察グラフページに分けて確認できます。
                         </p>
-                        <div class="mt-3">
-                            <a class="btn btn-outline-primary" href="{% url 'txo:observation' %}">
-                                <i class="fas fa-chart-area me-1"></i>鶏の観察グラフへ
-                            </a>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -1,8 +1,5 @@
 {% extends "taxonomy/base.html" %}
 {% load static %}
-{% block extra_css %}
-    <link rel="stylesheet" href="{% static 'taxonomy/css/livestock_distribution.css' %}">
-{% endblock %}
 {% block content %}
     <style>
         .taxonomy-chart-scroll {
@@ -42,133 +39,22 @@
             <div class="col-12">
                 <div class="card shadow-sm border-0">
                     <div class="card-header bg-white border-bottom-0 pt-3">
-                        <h2 class="h5 mb-0">畜産統計CSV登録</h2>
+                        <h2 class="h5 mb-0">分類体系の入れ子構造</h2>
                     </div>
                     <div class="card-body">
-                        {% if not livestock_dashboard %}
-                            <div class="alert alert-warning" role="alert">
-                                畜産統計CSVが未登録です。
-                            </div>
-                        {% endif %}
-                        <form method="post" enctype="multipart/form-data" class="row g-3">
-                            {% csrf_token %}
-                            {% for field in livestock_dataset_form %}
-                                <div class="{% if field.name == 'note' %}col-12{% elif field.name == 'is_active' %}col-12{% else %}col-md-6{% endif %}">
-                                    {% if field.name == 'is_active' %}
-                                        <div class="form-check">
-                                            {{ field }}
-                                            <label class="form-check-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-                                        </div>
-                                    {% else %}
-                                        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-                                        {{ field }}
-                                    {% endif %}
-                                    {% if field.errors %}
-                                        <div class="text-danger small mt-1">{{ field.errors|join:", " }}</div>
-                                    {% endif %}
-                                </div>
-                            {% endfor %}
-                            {% if livestock_dataset_form.non_field_errors %}
-                                <div class="col-12 text-danger small">
-                                    {{ livestock_dataset_form.non_field_errors|join:", " }}
-                                </div>
-                            {% endif %}
-                            <div class="col-12">
-                                {% if request.user.is_superuser %}
-                                    <button type="submit" class="btn btn-primary">
-                                        <i class="fas fa-upload me-1"></i>登録
-                                    </button>
-                                {% else %}
-                                    <button type="button" class="btn btn-primary" disabled>
-                                        <i class="fas fa-upload me-1"></i>登録
-                                    </button>
-                                {% endif %}
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-12">
-                <div class="card shadow-sm border-0">
-                    <div class="card-header bg-white border-bottom-0 pt-3">
-                        <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
-                            <div>
-                                <h2 class="h5 mb-1">e-Stat 畜産統計による鶏の地域別飼養分布</h2>
-                                <p class="small text-muted mb-0">
-                                    {% if livestock_dashboard %}
-                                        {{ livestock_dashboard.source_name }} /
-                                        政府統計コード {{ livestock_dashboard.source_stat_code }} /
-                                        {{ livestock_dashboard.survey_year }}年 /
-                                        取得日 {{ livestock_dashboard.retrieved_at }}
-                                    {% else %}
-                                        畜産統計CSV未登録
-                                    {% endif %}
-                                </p>
-                            </div>
-                            {% if livestock_dashboard %}
-                                <a class="small text-decoration-none"
-                                   href="{{ livestock_dashboard.source_url }}"
-                                   target="_blank"
-                                   rel="noopener noreferrer">
-                                    <i class="fas fa-external-link-alt me-1"></i>e-Stat統計表
-                                </a>
-                            {% endif %}
-                        </div>
-                    </div>
-                    <div class="card-body">
-                        {{ livestock_distribution_json|json_script:"livestock-distribution-data" }}
-                        <div class="livestock-dashboard">
-                            <div class="border rounded p-3 bg-light">
-                                <p class="fw-semibold mb-2">採卵鶏とブロイラーは、飼育目的が異なる統計分類です。</p>
-                                <p class="small text-muted mb-0">
-                                    採卵鶏は卵を産ませるための鶏、ブロイラーは肉用に短期間で大きく育つよう改良された鶏です。
-                                    ブロイラーの雌も生物として卵を産めますが、採卵を目的に飼育される鶏ではないため、
-                                    この統計では採卵鶏とは別の分類として扱われます。
-                                </p>
-                            </div>
-                            <div class="livestock-summary" id="livestock-summary"></div>
-                            <div class="livestock-map-panel">
-                                <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-                                    <div class="btn-group btn-group-sm" role="group" aria-label="統計分類の切り替え">
-                                        {% if livestock_dashboard %}
-                                            {% for category in livestock_dashboard.categories %}
-                                                <button type="button"
-                                                        class="btn btn-outline-primary livestock-category-button{% if forloop.first %} active{% endif %}"
-                                                        data-category="{{ category.key }}">
-                                                    {{ category.label }}
-                                                </button>
-                                            {% endfor %}
-                                        {% else %}
-                                            <button type="button" class="btn btn-outline-secondary active" disabled>
-                                                未登録
-                                            </button>
-                                        {% endif %}
-                                    </div>
-                                    <div class="livestock-legend">
-                                        <span><i class="livestock-legend-dot livestock-low"></i>少ない</span>
-                                        <span><i class="livestock-legend-dot livestock-mid"></i>中位</span>
-                                        <span><i class="livestock-legend-dot livestock-high"></i>多い</span>
-                                        <span><i class="livestock-legend-dot livestock-secret"></i>秘匿・該当なし</span>
-                                    </div>
-                                </div>
-                                <div class="livestock-map-layout">
-                                    <div id="livestock-prefecture-map"
-                                         class="livestock-prefecture-map"
-                                         aria-label="採卵鶏・ブロイラーの都道府県別飼養羽数マップ"></div>
-                                    <div class="livestock-map-detail" id="livestock-map-detail" aria-live="polite">
-                                        <strong>地図から都道府県を選択</strong>
-                                        <span>選択中の統計分類について、飼養羽数・飼養戸数・分類内の全国比を確認できます。</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <p class="small text-muted mb-0">
-                                {% if livestock_dashboard %}
-                                    {{ livestock_dashboard.note }}
-                                {% else %}
-                                    CSV登録後に、都道府県別の飼養羽数・飼養戸数が地図へ反映されます。
-                                {% endif %}
-                            </p>
+                        <p>
+                            生物分類は、界の中に門、門の中に綱、綱の中に科・属・種が入る階層構造です。
+                            たとえば霊長類の下にヒトが紐づくように、個別の生き物は上位分類の中へ段階的に収まります。
+                        </p>
+                        <p class="mb-0">
+                            この画面では、その入れ子構造を Value Object として扱いやすい形に整理し、
+                            分類ツリーとして確認できるようにしています。鶏の飼養分布や観察記録は、
+                            鶏の観察グラフページに分けて確認できます。
+                        </p>
+                        <div class="mt-3">
+                            <a class="btn btn-outline-primary" href="{% url 'txo:observation' %}">
+                                <i class="fas fa-chart-area me-1"></i>鶏の観察グラフへ
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -222,15 +108,4 @@
             </div>
         </div>
     </div>
-{% endblock %}
-{% block extra_js %}
-    <script>
-        window.nativeMapBeforeJpmap = window.Map;
-    </script>
-    <script src="https://unpkg.com/japan-map-js@1.0.1/dist/jpmap.min.js"></script>
-    <script>
-        window.jpmapInternalMap = window.Map;
-        window.Map = window.nativeMapBeforeJpmap;
-    </script>
-    <script src="{% static 'taxonomy/js/livestock_distribution.js' %}"></script>
 {% endblock %}

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -1,5 +1,8 @@
 {% extends "taxonomy/base.html" %}
 {% load static %}
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'taxonomy/css/livestock_distribution.css' %}">
+{% endblock %}
 {% block content %}
     <div class="container mt-4">
         <!-- Breadcrumb -->
@@ -16,6 +19,141 @@
                 <div class="bg-light p-5 rounded shadow-sm">
                     <h1 class="display-5"><i class="fas fa-egg me-2 text-warning"></i>鶏の観察データ</h1>
                     <p class="lead mb-0">長野県で鶏を飼っていたころの記録</p>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="card shadow-sm border-0">
+                    <div class="card-header bg-white border-bottom-0 pt-3">
+                        <h2 class="h5 mb-0">畜産統計データ取得</h2>
+                    </div>
+                    <div class="card-body">
+                        {% if not livestock_dashboard %}
+                            <div class="alert alert-warning" role="alert">
+                                畜産統計CSVが未登録です。
+                            </div>
+                        {% endif %}
+                        <form method="post" enctype="multipart/form-data" class="row g-3">
+                            {% csrf_token %}
+                            {% for field in livestock_dataset_form %}
+                                <div class="{% if field.name == 'note' %}col-12{% elif field.name == 'is_active' %}col-12{% else %}col-md-6{% endif %}">
+                                    {% if field.name == 'is_active' %}
+                                        <div class="form-check">
+                                            {{ field }}
+                                            <label class="form-check-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                        </div>
+                                    {% else %}
+                                        <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                        {{ field }}
+                                    {% endif %}
+                                    {% if field.errors %}
+                                        <div class="text-danger small mt-1">{{ field.errors|join:", " }}</div>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                            {% if livestock_dataset_form.non_field_errors %}
+                                <div class="col-12 text-danger small">
+                                    {{ livestock_dataset_form.non_field_errors|join:", " }}
+                                </div>
+                            {% endif %}
+                            <div class="col-12">
+                                {% if request.user.is_superuser %}
+                                    <button type="submit" class="btn btn-primary">
+                                        <i class="fas fa-download me-1"></i>e-Stat畜産統計データを取得
+                                    </button>
+                                {% else %}
+                                    <button type="button" class="btn btn-primary" disabled>
+                                        <i class="fas fa-download me-1"></i>e-Stat畜産統計データを取得
+                                    </button>
+                                {% endif %}
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="card shadow-sm border-0">
+                    <div class="card-header bg-white border-bottom-0 pt-3">
+                        <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
+                            <div>
+                                <h2 class="h5 mb-1">e-Stat 畜産統計による鶏の地域別飼養分布</h2>
+                                <p class="small text-muted mb-0">
+                                    {% if livestock_dashboard %}
+                                        {{ livestock_dashboard.source_name }} /
+                                        政府統計コード {{ livestock_dashboard.source_stat_code }} /
+                                        {{ livestock_dashboard.survey_year }}年 /
+                                        取得日 {{ livestock_dashboard.retrieved_at }}
+                                    {% else %}
+                                        畜産統計CSV未登録
+                                    {% endif %}
+                                </p>
+                            </div>
+                            {% if livestock_dashboard %}
+                                <a class="small text-decoration-none"
+                                   href="{{ livestock_dashboard.source_url }}"
+                                   target="_blank"
+                                   rel="noopener noreferrer">
+                                    <i class="fas fa-external-link-alt me-1"></i>e-Stat統計表
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        {{ livestock_distribution_json|json_script:"livestock-distribution-data" }}
+                        <div class="livestock-dashboard">
+                            <div class="border rounded p-3 bg-light">
+                                <p class="fw-semibold mb-2">採卵鶏とブロイラーは、飼育目的が異なる統計分類です。</p>
+                                <p class="small text-muted mb-0">
+                                    採卵鶏は卵を産ませるための鶏、ブロイラーは肉用に短期間で大きく育つよう改良された鶏です。
+                                    ブロイラーの雌も生物として卵を産めますが、採卵を目的に飼育される鶏ではないため、
+                                    この統計では採卵鶏とは別の分類として扱われます。
+                                </p>
+                            </div>
+                            <div class="livestock-summary" id="livestock-summary"></div>
+                            <div class="livestock-map-panel">
+                                <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+                                    <div class="btn-group btn-group-sm" role="group" aria-label="統計分類の切り替え">
+                                        {% if livestock_dashboard %}
+                                            {% for category in livestock_dashboard.categories %}
+                                                <button type="button"
+                                                        class="btn btn-outline-primary livestock-category-button{% if forloop.first %} active{% endif %}"
+                                                        data-category="{{ category.key }}">
+                                                    {{ category.label }}
+                                                </button>
+                                            {% endfor %}
+                                        {% else %}
+                                            <button type="button" class="btn btn-outline-secondary active" disabled>
+                                                未登録
+                                            </button>
+                                        {% endif %}
+                                    </div>
+                                    <div class="livestock-legend">
+                                        <span><i class="livestock-legend-dot livestock-low"></i>少ない</span>
+                                        <span><i class="livestock-legend-dot livestock-mid"></i>中位</span>
+                                        <span><i class="livestock-legend-dot livestock-high"></i>多い</span>
+                                        <span><i class="livestock-legend-dot livestock-secret"></i>秘匿・該当なし</span>
+                                    </div>
+                                </div>
+                                <div class="livestock-map-layout">
+                                    <div id="livestock-prefecture-map"
+                                         class="livestock-prefecture-map"
+                                         aria-label="採卵鶏・ブロイラーの都道府県別飼養羽数マップ"></div>
+                                    <div class="livestock-map-detail" id="livestock-map-detail" aria-live="polite">
+                                        <strong>地図から都道府県を選択</strong>
+                                        <span>選択中の統計分類について、飼養羽数・飼養戸数・分類内の全国比を確認できます。</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <p class="small text-muted mb-0">
+                                {% if livestock_dashboard %}
+                                    {{ livestock_dashboard.note }}
+                                {% else %}
+                                    CSV登録後に、都道府県別の飼養羽数・飼養戸数が地図へ反映されます。
+                                {% endif %}
+                            </p>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -90,4 +228,15 @@
         </div>
     </div>
 {% endblock %}
-<script src="{% static 'taxonomy/js/feed_vs_egg_chart.js' %}"></script>
+{% block extra_js %}
+    <script>
+        window.nativeMapBeforeJpmap = window.Map;
+    </script>
+    <script src="https://unpkg.com/japan-map-js@1.0.1/dist/jpmap.min.js"></script>
+    <script>
+        window.jpmapInternalMap = window.Map;
+        window.Map = window.nativeMapBeforeJpmap;
+    </script>
+    <script src="{% static 'taxonomy/js/livestock_distribution.js' %}"></script>
+    <script src="{% static 'taxonomy/js/feed_vs_egg_chart.js' %}"></script>
+{% endblock %}

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -58,8 +58,12 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "分類体系の入れ子構造")
         self.assertContains(response, "霊長類の下にヒトが紐づく")
         self.assertContains(response, "Value Object")
+        self.assertContains(
+            response, '<i class="fas fa-chart-area me-1"></i>鶏の観察グラフ'
+        )
         self.assertNotContains(response, "e-Stat 畜産統計による鶏の地域別飼養分布")
         self.assertNotContains(response, "livestock-prefecture-map")
+        self.assertNotContains(response, "鶏の観察グラフへ")
 
     def test_observation_page_shows_livestock_distribution_upload_form(self):
         """

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -45,41 +45,60 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "countClassificationNodes")
         self.assertContains(response, "fitClassificationChartHeight")
 
-    def test_index_page_shows_livestock_distribution_upload_form(self):
+    def test_index_page_shows_taxonomy_hierarchy_guidance(self):
         """
         シナリオ:
-        - 入力: 畜産統計CSVが未登録のDB状態。
+        - 入力: taxonomyトップページを表示できるDB状態。
         - 処理: taxonomyトップページを表示する。
-        - 期待値: 初回データ登録フォームと、空の日本地図用コンテナが表示されること。
+        - 期待値: 分類体系の入れ子構造とValue Objectの説明が表示されること。
         """
         response = self.client.get(reverse("txo:index"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "畜産統計CSV登録")
+        self.assertContains(response, "分類体系の入れ子構造")
+        self.assertContains(response, "霊長類の下にヒトが紐づく")
+        self.assertContains(response, "Value Object")
+        self.assertNotContains(response, "e-Stat 畜産統計による鶏の地域別飼養分布")
+        self.assertNotContains(response, "livestock-prefecture-map")
+
+    def test_observation_page_shows_livestock_distribution_upload_form(self):
+        """
+        シナリオ:
+        - 入力: 畜産統計CSVが未登録のDB状態。
+        - 処理: 鶏の観察グラフページを表示する。
+        - 期待値: 初回データ取得フォームと、空の日本地図用コンテナが表示されること。
+        """
+        response = self.client.get(reverse("txo:observation"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "畜産統計データ取得")
         self.assertContains(response, "畜産統計CSVが未登録です。")
         self.assertContains(response, 'name="csv_file"')
         self.assertContains(response, "disabled")
         self.assertContains(response, "畜産統計CSV未登録")
         self.assertContains(response, "livestock-distribution-data")
         self.assertContains(response, "livestock-prefecture-map")
+        self.assertContains(response, "e-Stat畜産統計データを取得")
 
-    def test_index_page_displays_livestock_distribution_dashboard(self):
+    def test_observation_page_displays_livestock_distribution_dashboard(self):
         """
         シナリオ:
-        - 入力: taxonomyトップページを表示できるDB状態。
-        - 処理: taxonomyトップページを表示する。
+        - 入力: 畜産統計CSVが登録済みのDB状態。
+        - 処理: 鶏の観察グラフページを表示する。
         - 期待値: e-Stat畜産統計の採卵鶏・ブロイラー可視化に必要なメタ情報とJSONが表示されること。
         """
         self._create_livestock_dataset()
 
-        response = self.client.get(reverse("txo:index"))
+        response = self.client.get(reverse("txo:observation"))
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "e-Stat 畜産統計による鶏の地域別飼養分布")
         self.assertContains(response, "政府統計コード 00500222")
         self.assertContains(response, "採卵鶏")
         self.assertContains(response, "ブロイラー")
-        self.assertContains(response, "採卵鶏とブロイラーは、飼育目的が異なる統計分類です。")
+        self.assertContains(
+            response, "採卵鶏とブロイラーは、飼育目的が異なる統計分類です。"
+        )
         self.assertContains(response, "ブロイラーの雌も生物として卵を産めます")
         self.assertContains(response, "livestock-distribution-data")
         self.assertContains(response, "livestock-prefecture-map")
@@ -90,8 +109,8 @@ class TaxonomyIndexViewTest(TestCase):
         """
         シナリオ:
         - 入力: スーパーユーザーと畜産統計CSV登録フォームのPOSTデータ。
-        - 処理: taxonomyトップページへCSVをPOSTする。
-        - 期待値: データセットが作成され、トップページで畜産統計ダッシュボードが表示されること。
+        - 処理: 鶏の観察グラフページへCSVをPOSTする。
+        - 期待値: データセットが作成され、観察ページで畜産統計ダッシュボードが表示されること。
         """
         user = get_user_model().objects.create_superuser(
             username="taxonomy_admin",
@@ -101,32 +120,32 @@ class TaxonomyIndexViewTest(TestCase):
         self.client.force_login(user)
 
         response = self.client.post(
-            reverse("txo:index"),
+            reverse("txo:observation"),
             data=self._livestock_dataset_post_data(),
             follow=True,
         )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(LivestockDistributionDataset.objects.count(), 1)
-        self.assertContains(response, "畜産統計CSVを登録しました。")
+        self.assertContains(response, "畜産統計データを取得しました。")
         self.assertContains(response, "e-Stat 畜産統計による鶏の地域別飼養分布")
 
     def test_rejects_livestock_distribution_upload_without_permission(self):
         """
         シナリオ:
         - 入力: 未ログインユーザーと畜産統計CSV登録フォームのPOSTデータ。
-        - 処理: taxonomyトップページへCSVをPOSTする。
+        - 処理: 鶏の観察グラフページへCSVをPOSTする。
         - 期待値: データセットは作成されず、権限エラーが表示されること。
         """
         response = self.client.post(
-            reverse("txo:index"),
+            reverse("txo:observation"),
             data=self._livestock_dataset_post_data(),
             follow=True,
         )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(LivestockDistributionDataset.objects.count(), 0)
-        self.assertContains(response, "畜産統計CSVを登録する権限がありません。")
+        self.assertContains(response, "畜産統計データを取得する権限がありません。")
 
     def _create_livestock_dataset(self):
         return LivestockDistributionDataset.objects.create(

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -34,24 +34,6 @@ from taxonomy.models import Breed, Classification, Family, Genus, Phylum, Specie
 class IndexView(TemplateView):
     template_name = "taxonomy/index.html"
 
-    def post(self, request, *args, **kwargs):
-        """
-        Taxonomyトップから畜産統計CSVを登録します。
-        """
-        if not request.user.is_superuser:
-            messages.error(request, "畜産統計CSVを登録する権限がありません。")
-            return redirect("txo:index")
-
-        form = LivestockDistributionDatasetForm(request.POST, request.FILES)
-        if form.is_valid():
-            form.save()
-            messages.success(request, "畜産統計CSVを登録しました。")
-            return redirect("txo:index")
-
-        context = self.get_context_data(**kwargs)
-        context["livestock_dataset_form"] = form
-        return self.render_to_response(context)
-
     def get_context_data(self, **kwargs):
         """
         コンテキストデータを設定。
@@ -65,24 +47,30 @@ class IndexView(TemplateView):
             [BreedEntity(record) for record in BreedRepository.get_breed_hierarchy()]
         )
         context["data"] = json.dumps(tree.export(), ensure_ascii=False)
-        context["livestock_dataset_form"] = LivestockDistributionDatasetForm()
-        livestock_dashboard = (
-            LivestockDistributionDatasetRepository.get_latest_dashboard()
-        )
-        context["livestock_dashboard"] = livestock_dashboard
-        if livestock_dashboard is not None:
-            context["livestock_distribution_json"] = livestock_dashboard.to_payload()
-        else:
-            context["livestock_distribution_json"] = {
-                "categories": [],
-                "maps": {},
-            }
 
         return context
 
 
 class ObservationView(TemplateView):
     template_name = "taxonomy/observation.html"
+
+    def post(self, request, *args, **kwargs):
+        """
+        鶏の観察ページから畜産統計CSVを登録します。
+        """
+        if not request.user.is_superuser:
+            messages.error(request, "畜産統計データを取得する権限がありません。")
+            return redirect("txo:observation")
+
+        form = LivestockDistributionDatasetForm(request.POST, request.FILES)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "畜産統計データを取得しました。")
+            return redirect("txo:observation")
+
+        context = self.get_context_data(**kwargs)
+        context["livestock_dataset_form"] = form
+        return self.render_to_response(context)
 
     def get_context_data(self, **kwargs):
         """
@@ -98,6 +86,18 @@ class ObservationView(TemplateView):
         context["feed_group_laying_rate"] = (
             ChickenObservationsRepository.get_feed_group_laying_rates_table()
         )
+        context["livestock_dataset_form"] = LivestockDistributionDatasetForm()
+        livestock_dashboard = (
+            LivestockDistributionDatasetRepository.get_latest_dashboard()
+        )
+        context["livestock_dashboard"] = livestock_dashboard
+        if livestock_dashboard is not None:
+            context["livestock_distribution_json"] = livestock_dashboard.to_payload()
+        else:
+            context["livestock_distribution_json"] = {
+                "categories": [],
+                "maps": {},
+            }
 
         return context
 


### PR DESCRIPTION
## Summary
Taxonomyトップから畜産統計ダッシュボードを撤去し、鶏の観察グラフページへ移動しました。

- Taxonomyトップは分類体系の入れ子構造とValue Objectとして扱う技術テーマを説明する構成へ整理
- 畜産統計CSV登録、未登録時の空地図、e-Stat出典・統計コード・対象年・取得日・秘匿値説明を鶏の観察ページへ移動
- 畜産統計データ取得ボタンを観察ページに配置し、権限なしユーザーには disabled で表示
- 移動後の表示先と権限制御に合わせてビュー・テストを更新

## 目検による動作確認手順
- [x] Taxonomyトップに畜産統計ダッシュボードが表示されず、分類体系の入れ子構造説明が表示されること
- [x] 鶏の観察グラフページで畜産統計データ取得フォームと地域別飼養分布ダッシュボードが表示されること
- [x] 畜産統計CSV未登録時も、鶏の観察グラフページ上で未登録状態と空の日本地図コンテナが表示されること
- [x] 登録済みデータの出典、政府統計コード、対象年、取得日、秘匿値の扱いが鶏の観察グラフページで確認できること

## 自動テストでカバーできた範囲
- `black taxonomy/views.py taxonomy/tests/test_views.py`
- `python manage.py test taxonomy.tests.domain.test_livestock_distribution --keepdb`
  - 畜産統計ダッシュボードVOの組み立てと秘匿値の扱いを確認
- `python manage.py test taxonomy.tests.test_views --keepdb`
  - Taxonomyトップからの撤去、観察ページへの移動、未登録状態、登録POST、権限エラーを確認
- `python manage.py test taxonomy --keepdb`
  - taxonomy アプリ全体の既存テストを含めて確認

## 関連Issue
Closes #845
https://github.com/duri0214/portfolio/issues/845
