### PR TITLE
#846 畜産統計ダッシュボードで蓄積済み年次データを切り替え表示できるようにする

### DIFF
--- a/taxonomy/domain/repository/livestock_distribution.py
+++ b/taxonomy/domain/repository/livestock_distribution.py
@@ -20,6 +20,38 @@ class LivestockDistributionDatasetRepository:
         最新の有効な畜産統計CSVからダッシュボードを返します。
         """
         dataset = LivestockDistributionDataset.objects.filter(is_active=True).first()
+        return LivestockDistributionDatasetRepository._build_dashboard(dataset)
+
+    @staticmethod
+    def get_dashboard_by_survey_year(
+        survey_year: int,
+    ) -> LivestockDistributionDashboard | None:
+        """
+        指定した対象年の有効な畜産統計CSVからダッシュボードを返します。
+        """
+        dataset = LivestockDistributionDataset.objects.filter(
+            is_active=True,
+            survey_year=survey_year,
+        ).first()
+        return LivestockDistributionDatasetRepository._build_dashboard(dataset)
+
+    @staticmethod
+    def get_active_survey_years() -> list[int]:
+        """
+        画面で切り替え可能な有効データセットの対象年一覧を返します。
+        """
+        years = LivestockDistributionDataset.objects.filter(is_active=True).values_list(
+            "survey_year", flat=True
+        )
+        return sorted(set(years), reverse=True)
+
+    @staticmethod
+    def _build_dashboard(
+        dataset: LivestockDistributionDataset | None,
+    ) -> LivestockDistributionDashboard | None:
+        """
+        畜産統計CSVデータセットから表示用ダッシュボードを組み立てます。
+        """
         if dataset is None:
             return None
 

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -89,17 +89,50 @@
                                     {% endif %}
                                 </p>
                             </div>
-                            {% if livestock_dashboard %}
-                                <a class="small text-decoration-none"
-                                   href="{{ livestock_dashboard.source_url }}"
-                                   target="_blank"
-                                   rel="noopener noreferrer">
-                                    <i class="fas fa-external-link-alt me-1"></i>e-Stat統計表
-                                </a>
-                            {% endif %}
+                            <div class="d-flex flex-wrap align-items-center gap-2">
+                                <form method="get" class="d-flex align-items-center gap-2">
+                                    <label class="small text-muted mb-0" for="livestock-year-select">対象年</label>
+                                    <select id="livestock-year-select"
+                                            name="livestock_year"
+                                            class="form-select form-select-sm w-auto"
+                                            {% if not livestock_survey_years %}disabled{% endif %}
+                                            onchange="this.form.submit()">
+                                        {% if selected_livestock_survey_year and not livestock_dashboard %}
+                                            <option value="{{ selected_livestock_survey_year }}" selected>
+                                                {{ selected_livestock_survey_year }}年
+                                            </option>
+                                        {% endif %}
+                                        {% for survey_year in livestock_survey_years %}
+                                            <option value="{{ survey_year }}"
+                                                    {% if selected_livestock_survey_year == survey_year or livestock_dashboard.survey_year == survey_year %}selected{% endif %}>
+                                                {{ survey_year }}年
+                                            </option>
+                                        {% empty %}
+                                            <option>未登録</option>
+                                        {% endfor %}
+                                    </select>
+                                    <button type="submit" class="btn btn-outline-secondary btn-sm"
+                                            {% if not livestock_survey_years %}disabled{% endif %}>
+                                        表示
+                                    </button>
+                                </form>
+                                {% if livestock_dashboard %}
+                                    <a class="small text-decoration-none"
+                                       href="{{ livestock_dashboard.source_url }}"
+                                       target="_blank"
+                                       rel="noopener noreferrer">
+                                        <i class="fas fa-external-link-alt me-1"></i>e-Stat統計表
+                                    </a>
+                                {% endif %}
+                            </div>
                         </div>
                     </div>
                     <div class="card-body">
+                        {% if selected_livestock_survey_year and not livestock_dashboard %}
+                            <div class="alert alert-warning" role="alert">
+                                {{ selected_livestock_survey_year }}年の畜産統計CSVは未登録または無効です。
+                            </div>
+                        {% endif %}
                         {{ livestock_distribution_json|json_script:"livestock-distribution-data" }}
                         <div class="livestock-dashboard">
                             <div class="border rounded p-3 bg-light">

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -109,6 +109,107 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "分類内の全国比")
         self.assertContains(response, "秘匿・該当なし")
 
+    def test_observation_page_displays_latest_livestock_distribution_by_default(self):
+        """
+        シナリオ:
+        - 入力: 2024年と2025年の畜産統計CSVが登録済みのDB状態。
+        - 処理: 対象年を指定せずに鶏の観察グラフページを表示する。
+        - 期待値: 最新取得日の2025年データが初期表示され、対象年選択肢が表示されること。
+        """
+        self._create_livestock_dataset(
+            title="令和6年畜産統計",
+            survey_year=2024,
+            retrieved_at="2026-07-10",
+        )
+        self._create_livestock_dataset(
+            title="令和7年畜産統計",
+            survey_year=2025,
+            retrieved_at="2026-07-11",
+        )
+
+        response = self.client.get(reverse("txo:observation"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["livestock_dashboard"].survey_year, 2025)
+        self.assertContains(response, "対象年")
+        self.assertContains(response, 'value="2025"')
+        self.assertContains(response, 'value="2024"')
+        self.assertContains(response, "2025年 /")
+
+    def test_observation_page_can_select_past_livestock_distribution_year(self):
+        """
+        シナリオ:
+        - 入力: 2024年と2025年の畜産統計CSVが登録済みのDB状態。
+        - 処理: 2024年を指定して鶏の観察グラフページを表示する。
+        - 期待値: 最新年ではなく選択した2024年データが表示されること。
+        """
+        self._create_livestock_dataset(
+            title="令和6年畜産統計",
+            survey_year=2024,
+            retrieved_at="2026-07-10",
+        )
+        self._create_livestock_dataset(
+            title="令和7年畜産統計",
+            survey_year=2025,
+            retrieved_at="2026-07-11",
+        )
+
+        response = self.client.get(
+            reverse("txo:observation"),
+            {"livestock_year": "2024"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["livestock_dashboard"].survey_year, 2024)
+        self.assertEqual(response.context["selected_livestock_survey_year"], 2024)
+        self.assertContains(response, "2024年 /")
+        self.assertContains(response, "取得日 2026-07-10")
+
+    def test_observation_page_shows_empty_map_for_unregistered_or_inactive_year(self):
+        """
+        シナリオ:
+        - 入力: 2024年の有効データと2023年の無効データが登録済みのDB状態。
+        - 処理: 無効な2023年を指定して鶏の観察グラフページを表示する。
+        - 期待値: 無効データは表示せず、空の日本地図と未登録状態が表示されること。
+        """
+        self._create_livestock_dataset(
+            title="令和6年畜産統計",
+            survey_year=2024,
+            retrieved_at="2026-07-10",
+        )
+        self._create_livestock_dataset(
+            title="令和5年畜産統計",
+            survey_year=2023,
+            retrieved_at="2026-07-09",
+            is_active=False,
+        )
+
+        response = self.client.get(
+            reverse("txo:observation"),
+            {"livestock_year": "2023"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["livestock_dashboard"])
+        self.assertEqual(response.context["selected_livestock_survey_year"], 2023)
+        self.assertContains(response, "2023年の畜産統計CSVは未登録または無効です。")
+        self.assertContains(response, "livestock-prefecture-map")
+        self.assertContains(response, "畜産統計CSV未登録")
+
+        unregistered_response = self.client.get(
+            reverse("txo:observation"),
+            {"livestock_year": "2022"},
+        )
+
+        self.assertEqual(unregistered_response.status_code, 200)
+        self.assertIsNone(unregistered_response.context["livestock_dashboard"])
+        self.assertEqual(
+            unregistered_response.context["selected_livestock_survey_year"], 2022
+        )
+        self.assertContains(
+            unregistered_response, "2022年の畜産統計CSVは未登録または無効です。"
+        )
+
     def test_superuser_can_upload_livestock_distribution_dataset(self):
         """
         シナリオ:
@@ -151,23 +252,30 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertEqual(LivestockDistributionDataset.objects.count(), 0)
         self.assertContains(response, "畜産統計データを取得する権限がありません。")
 
-    def _create_livestock_dataset(self):
+    def _create_livestock_dataset(
+        self,
+        title="令和6年畜産統計",
+        survey_year=2024,
+        retrieved_at="2026-07-11",
+        is_active=True,
+    ):
         return LivestockDistributionDataset.objects.create(
-            title="令和6年畜産統計",
+            title=title,
             csv_file=SimpleUploadedFile(
-                "livestock.csv",
+                f"livestock_{survey_year}.csv",
                 _livestock_distribution_csv().encode("utf-8"),
                 content_type="text/csv",
             ),
             source_name="e-Stat / 農林水産省 畜産統計調査",
             source_stat_code="00500222",
-            survey_year=2024,
-            retrieved_at="2026-07-11",
+            survey_year=survey_year,
+            retrieved_at=retrieved_at,
             source_url="https://www.e-stat.go.jp/stat-search/files",
             note=(
                 "令和6年2月1日現在。単位は千羽。e-Statの秘匿値 x と"
                 "該当なし - は推計せず秘匿・該当なしとして表示します。"
             ),
+            is_active=is_active,
         )
 
     def _livestock_dataset_post_data(self):

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -87,9 +87,21 @@ class ObservationView(TemplateView):
             ChickenObservationsRepository.get_feed_group_laying_rates_table()
         )
         context["livestock_dataset_form"] = LivestockDistributionDatasetForm()
-        livestock_dashboard = (
-            LivestockDistributionDatasetRepository.get_latest_dashboard()
-        )
+        survey_years = LivestockDistributionDatasetRepository.get_active_survey_years()
+        selected_survey_year = self._get_selected_livestock_survey_year()
+        if selected_survey_year is None:
+            livestock_dashboard = (
+                LivestockDistributionDatasetRepository.get_latest_dashboard()
+            )
+        else:
+            livestock_dashboard = (
+                LivestockDistributionDatasetRepository.get_dashboard_by_survey_year(
+                    selected_survey_year
+                )
+            )
+
+        context["livestock_survey_years"] = survey_years
+        context["selected_livestock_survey_year"] = selected_survey_year
         context["livestock_dashboard"] = livestock_dashboard
         if livestock_dashboard is not None:
             context["livestock_distribution_json"] = livestock_dashboard.to_payload()
@@ -100,6 +112,15 @@ class ObservationView(TemplateView):
             }
 
         return context
+
+    def _get_selected_livestock_survey_year(self) -> int | None:
+        survey_year = self.request.GET.get("livestock_year")
+        if not survey_year:
+            return None
+        try:
+            return int(survey_year)
+        except ValueError:
+            return None
 
 
 class TaxonomyBreedCreateView(FormView):


### PR DESCRIPTION
## Summary
鶏の観察ページの畜産統計ダッシュボードで、DBに蓄積済みの対象年を切り替えて表示できるようにしました。

- `LivestockDistributionDatasetRepository` に対象年指定取得と有効な対象年一覧の取得を追加
- `?livestock_year=YYYY` で選択年の有効データセットを表示し、未指定時は従来通り最新データを表示
- ダッシュボードヘッダーに対象年セレクトを追加し、未登録年・無効データセット指定時は空地図と未登録状態を表示
- 2024年・2025年の蓄積データ切り替え、未登録年、無効年の表示テストを追加

## 目検による動作確認手順
- [x] 鶏の観察グラフページで対象年セレクトが表示されること
- [x] 2024年/2025年などの登録済み年を切り替えると、出典メタ情報と地図データが選択年に変わること
- [x] 未登録年または無効データセットの年を指定した場合、空の日本地図と未登録状態が表示されること

## 自動テストでカバーできた範囲
- `black taxonomy/views.py taxonomy/domain/repository/livestock_distribution.py taxonomy/tests/test_views.py`
- `python manage.py test taxonomy.tests.test_views.TaxonomyIndexViewTest --keepdb`
  - 観察ページの対象年切り替え、最新年の初期表示、未登録年・無効年の空状態を確認
- `python manage.py test taxonomy --keepdb`
  - taxonomy アプリ全体の既存テストを含めて確認

## 関連Issue
Closes #846
https://github.com/duri0214/portfolio/issues/846
