### PR TITLE
#838 nodes/edges 形式のグラフ構造 VO を追加する

### DIFF
--- a/taxonomy/README.md
+++ b/taxonomy/README.md
@@ -10,46 +10,6 @@ See Also: https://online-hoshujuku.info/english-classification#index_id1
 - 属(genus)
 - 種(species)
 
-## 分類体系の入れ子構造
-Taxonomy は、この portfolio の中でも技術的な側面を持つアプリとして扱う。
-分類体系そのものがマトリョーシカのような入れ子構造なので、実装でも小さな Value Object を内側に持ち、それをさらに大きな Value Object が包む形で表現する。
-
-```text
-TaxonomyGraph
-+-- nodes: TaxonomyGraphNode[]
-+-- edges: TaxonomyGraphEdge[]
-    |
-    +-- source / target は TaxonomyHierarchy の親子関係を指す
-
-BreedEntity
-+-- TaxonomyHierarchy
-    +-- TaxonomyHierarchyItem(kingdom)
-        +-- source_id
-        +-- name
-    +-- TaxonomyHierarchyItem(phylum)
-        +-- source_id
-        +-- name
-    +-- TaxonomyHierarchyItem(classification)
-        +-- source_id
-        +-- name
-    +-- TaxonomyHierarchyItem(family)
-        +-- source_id
-        +-- name
-    +-- TaxonomyHierarchyItem(genus)
-        +-- source_id
-        +-- name
-    +-- TaxonomyHierarchyItem(species)
-        +-- source_id
-        +-- name
-    +-- TaxonomyHierarchyItem(breed)
-        +-- source_id
-        +-- name
-```
-
-`id` と `name` をばらばらの値として運ぶのではなく、`TaxonomyHierarchyItem` として1つの意味を持つ値にまとめる。
-その item の並びを `TaxonomyHierarchy` として扱い、さらに nodes/edges 形式へ変換したものを `TaxonomyGraph` として扱う。
-この入れ子によって、分類階層の順序、親子関係、グラフ表示用データの責務を分ける。
-
 ## Purpose
 Taxonomy アプリは、動物分類の候補を収集し、人が確認しながら体系化して表示するためのアプリとする。
 既存のニワトリ・ミミズ分類だけでなく、蜂、メダカ、蚕、カブトムシ/クワガタ、家畜系などへ横展開できる状態を目指す。

--- a/taxonomy/README.md
+++ b/taxonomy/README.md
@@ -10,6 +10,46 @@ See Also: https://online-hoshujuku.info/english-classification#index_id1
 - 属(genus)
 - 種(species)
 
+## 分類体系の入れ子構造
+Taxonomy は、この portfolio の中でも技術的な側面を持つアプリとして扱う。
+分類体系そのものがマトリョーシカのような入れ子構造なので、実装でも小さな Value Object を内側に持ち、それをさらに大きな Value Object が包む形で表現する。
+
+```text
+TaxonomyGraph
++-- nodes: TaxonomyGraphNode[]
++-- edges: TaxonomyGraphEdge[]
+    |
+    +-- source / target は TaxonomyHierarchy の親子関係を指す
+
+BreedEntity
++-- TaxonomyHierarchy
+    +-- TaxonomyHierarchyItem(kingdom)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(phylum)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(classification)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(family)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(genus)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(species)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(breed)
+        +-- source_id
+        +-- name
+```
+
+`id` と `name` をばらばらの値として運ぶのではなく、`TaxonomyHierarchyItem` として1つの意味を持つ値にまとめる。
+その item の並びを `TaxonomyHierarchy` として扱い、さらに nodes/edges 形式へ変換したものを `TaxonomyGraph` として扱う。
+この入れ子によって、分類階層の順序、親子関係、グラフ表示用データの責務を分ける。
+
 ## Purpose
 Taxonomy アプリは、動物分類の候補を収集し、人が確認しながら体系化して表示するためのアプリとする。
 既存のニワトリ・ミミズ分類だけでなく、蜂、メダカ、蚕、カブトムシ/クワガタ、家畜系などへ横展開できる状態を目指す。

--- a/taxonomy/domain/breed_entity.py
+++ b/taxonomy/domain/breed_entity.py
@@ -1,3 +1,6 @@
+from taxonomy.domain.valueobject.taxonomy_hierarchy import TaxonomyHierarchyItem
+
+
 class BreedEntity:
     """
     kingdom界 - phylum門 - classification綱 - family科 - genus属 - species腫 - breed品種
@@ -23,37 +26,33 @@ class BreedEntity:
     """
 
     def __init__(self, record: dict):
-        self.kingdom_id: int | None = record.get("kingdom_id")
-        if self.kingdom_id is None:
-            self.kingdom_id = record.get("kingdom_id_value")
+        self.kingdom_id: int | None = self._get_record_value(record, "kingdom_id")
         self.kingdom: str = record.get("kingdom_name")
-        self.phylum_id: int | None = record.get("phylum_id")
-        if self.phylum_id is None:
-            self.phylum_id = record.get("phylum_id_value")
+        self.phylum_id: int | None = self._get_record_value(record, "phylum_id")
         self.phylum: str = record.get("phylum_name")
-        self.classification_id: int | None = record.get("classification_id")
-        if self.classification_id is None:
-            self.classification_id = record.get("classification_id_value")
+        self.classification_id: int | None = self._get_record_value(
+            record, "classification_id"
+        )
         self.classification: str = record.get("classification_name")
-        self.family_id: int | None = record.get("family_id")
-        if self.family_id is None:
-            self.family_id = record.get("family_id_value")
+        self.family_id: int | None = self._get_record_value(record, "family_id")
         self.family: str = record.get("family_name")
-        self.genus_id: int | None = record.get("genus_id")
-        if self.genus_id is None:
-            self.genus_id = record.get("genus_id_value")
+        self.genus_id: int | None = self._get_record_value(record, "genus_id")
         self.genus: str = record.get("genus_name")
-        self.species_id: int | None = record.get("species_id")
-        if self.species_id is None:
-            self.species_id = record.get("species_id_value")
+        self.species_id: int | None = self._get_record_value(record, "species_id")
         self.species: str = record.get("species_name")
-        self.breed_id: int | None = record.get("breed_id")
-        if self.breed_id is None:
-            self.breed_id = record.get("breed_id_value")
+        self.breed_id: int | None = self._get_record_value(record, "breed_id")
         self.breed: str = record.get("breed_name")
         self.breed_kana: str = record.get("breed_name_kana")
         self.natural_monument: str = record.get("natural_monument_name")
         self.breed_tag: str = record.get("breed_tag")
+
+    @staticmethod
+    def _get_record_value(record: dict, key: str):
+        for candidate_key in (key, key.replace("_id", "_source_id"), f"{key}_value"):
+            value = record.get(candidate_key)
+            if value is not None:
+                return value
+        return None
 
     def get_taxonomies(self) -> list:
         return [
@@ -66,23 +65,21 @@ class BreedEntity:
             self.breed,
         ]
 
-    def get_taxonomy_items(self) -> list[dict[str, int | str | None]]:
+    def get_taxonomy_items(self) -> list[TaxonomyHierarchyItem]:
         """
         グラフ変換で使う分類階層を上位から順に返す。
 
         Returns:
-            rank、id、name を持つ分類階層のリスト。
+            分類階層1要素を表すValue Objectのリスト。
         """
         return [
-            {"rank": "kingdom", "id": self.kingdom_id, "name": self.kingdom},
-            {"rank": "phylum", "id": self.phylum_id, "name": self.phylum},
-            {
-                "rank": "classification",
-                "id": self.classification_id,
-                "name": self.classification,
-            },
-            {"rank": "family", "id": self.family_id, "name": self.family},
-            {"rank": "genus", "id": self.genus_id, "name": self.genus},
-            {"rank": "species", "id": self.species_id, "name": self.species},
-            {"rank": "breed", "id": self.breed_id, "name": self.breed},
+            TaxonomyHierarchyItem("kingdom", self.kingdom_id, self.kingdom),
+            TaxonomyHierarchyItem("phylum", self.phylum_id, self.phylum),
+            TaxonomyHierarchyItem(
+                "classification", self.classification_id, self.classification
+            ),
+            TaxonomyHierarchyItem("family", self.family_id, self.family),
+            TaxonomyHierarchyItem("genus", self.genus_id, self.genus),
+            TaxonomyHierarchyItem("species", self.species_id, self.species),
+            TaxonomyHierarchyItem("breed", self.breed_id, self.breed),
         ]

--- a/taxonomy/domain/breed_entity.py
+++ b/taxonomy/domain/breed_entity.py
@@ -24,6 +24,33 @@ class BreedEntity:
         self.natural_monument: str = record.get("natural_monument_name")
         self.breed_tag: str = record.get("breed_tag")
 
+    @classmethod
+    def from_hierarchy_items(
+        cls,
+        hierarchy_items: list[TaxonomyHierarchyItem],
+        breed_kana: str = "",
+        natural_monument: str | None = None,
+        breed_tag: str | None = None,
+    ) -> "BreedEntity":
+        """
+        分類階層VOからBreedEntityを生成する。
+
+        Args:
+            hierarchy_items: 界から品種までの分類階層。
+            breed_kana: 品種・系統・分類対象名のよみがな。
+            natural_monument: 天然記念物区分。
+            breed_tag: 品種タグ。
+
+        Returns:
+            分類階層を保持する BreedEntity。
+        """
+        entity = cls.__new__(cls)
+        entity.hierarchy_items = tuple(hierarchy_items)
+        entity.breed_kana = breed_kana
+        entity.natural_monument = natural_monument
+        entity.breed_tag = breed_tag
+        return entity
+
     @property
     def breed_id(self) -> int | str | None:
         return self._get_hierarchy_item("breed").source_id

--- a/taxonomy/domain/breed_entity.py
+++ b/taxonomy/domain/breed_entity.py
@@ -1,5 +1,5 @@
 from taxonomy.domain.valueobject.taxonomy_hierarchy import (
-    TAXONOMY_HIERARCHY_RANKS,
+    TaxonomyHierarchy,
     TaxonomyHierarchyItem,
 )
 
@@ -9,17 +9,14 @@ class BreedEntity:
     kingdom界 - phylum門 - classification綱 - family科 - genus属 - species腫 - breed品種
 
     Attributes:
-        hierarchy_items: 界から品種までの分類階層。
+        hierarchy: 界から品種までの分類階層。
         breed_kana: 品種・系統・分類対象名のよみがな。
         natural_monument: 天然記念物区分。
         breed_tag: 品種タグ。
     """
 
     def __init__(self, record: dict):
-        self.hierarchy_items: tuple[TaxonomyHierarchyItem, ...] = tuple(
-            TaxonomyHierarchyItem.from_record(rank, record)
-            for rank in TAXONOMY_HIERARCHY_RANKS
-        )
+        self.hierarchy = TaxonomyHierarchy.from_record(record)
         self.breed_kana: str = record.get("breed_name_kana")
         self.natural_monument: str = record.get("natural_monument_name")
         self.breed_tag: str = record.get("breed_tag")
@@ -45,7 +42,7 @@ class BreedEntity:
             分類階層を保持する BreedEntity。
         """
         entity = cls.__new__(cls)
-        entity.hierarchy_items = tuple(hierarchy_items)
+        entity.hierarchy = TaxonomyHierarchy.from_items(hierarchy_items)
         entity.breed_kana = breed_kana
         entity.natural_monument = natural_monument
         entity.breed_tag = breed_tag
@@ -53,20 +50,14 @@ class BreedEntity:
 
     @property
     def breed_id(self) -> int | str | None:
-        return self._get_hierarchy_item("breed").source_id
+        return self.hierarchy.get_item("breed").source_id
 
     @property
     def breed(self) -> str:
-        return self._get_hierarchy_item("breed").name
-
-    def _get_hierarchy_item(self, rank: str) -> TaxonomyHierarchyItem:
-        for item in self.hierarchy_items:
-            if item.rank == rank:
-                return item
-        return TaxonomyHierarchyItem(rank, None, "")
+        return self.hierarchy.get_item("breed").name
 
     def get_taxonomies(self) -> list:
-        return [item.name for item in self.hierarchy_items]
+        return self.hierarchy.names()
 
     def get_taxonomy_items(self) -> list[TaxonomyHierarchyItem]:
         """
@@ -75,4 +66,4 @@ class BreedEntity:
         Returns:
             分類階層1要素を表すValue Objectのリスト。
         """
-        return list(self.hierarchy_items)
+        return list(self.hierarchy.items)

--- a/taxonomy/domain/breed_entity.py
+++ b/taxonomy/domain/breed_entity.py
@@ -1,4 +1,7 @@
-from taxonomy.domain.valueobject.taxonomy_hierarchy import TaxonomyHierarchyItem
+from taxonomy.domain.valueobject.taxonomy_hierarchy import (
+    TAXONOMY_HIERARCHY_RANKS,
+    TaxonomyHierarchyItem,
+)
 
 
 class BreedEntity:
@@ -6,64 +9,37 @@ class BreedEntity:
     kingdom界 - phylum門 - classification綱 - family科 - genus属 - species腫 - breed品種
 
     Attributes:
-        kingdom_id: 界のID。
-        kingdom: 界名。
-        phylum_id: 門のID。
-        phylum: 門名。
-        classification_id: 綱のID。
-        classification: 綱名。
-        family_id: 科のID。
-        family: 科名。
-        genus_id: 属のID。
-        genus: 属名。
-        species_id: 種のID。
-        species: 種名。
-        breed_id: 品種・系統・分類対象のID。
-        breed: 品種・系統・分類対象名。
+        hierarchy_items: 界から品種までの分類階層。
         breed_kana: 品種・系統・分類対象名のよみがな。
         natural_monument: 天然記念物区分。
         breed_tag: 品種タグ。
     """
 
     def __init__(self, record: dict):
-        self.kingdom_id: int | None = self._get_record_value(record, "kingdom_id")
-        self.kingdom: str = record.get("kingdom_name")
-        self.phylum_id: int | None = self._get_record_value(record, "phylum_id")
-        self.phylum: str = record.get("phylum_name")
-        self.classification_id: int | None = self._get_record_value(
-            record, "classification_id"
+        self.hierarchy_items: tuple[TaxonomyHierarchyItem, ...] = tuple(
+            TaxonomyHierarchyItem.from_record(rank, record)
+            for rank in TAXONOMY_HIERARCHY_RANKS
         )
-        self.classification: str = record.get("classification_name")
-        self.family_id: int | None = self._get_record_value(record, "family_id")
-        self.family: str = record.get("family_name")
-        self.genus_id: int | None = self._get_record_value(record, "genus_id")
-        self.genus: str = record.get("genus_name")
-        self.species_id: int | None = self._get_record_value(record, "species_id")
-        self.species: str = record.get("species_name")
-        self.breed_id: int | None = self._get_record_value(record, "breed_id")
-        self.breed: str = record.get("breed_name")
         self.breed_kana: str = record.get("breed_name_kana")
         self.natural_monument: str = record.get("natural_monument_name")
         self.breed_tag: str = record.get("breed_tag")
 
-    @staticmethod
-    def _get_record_value(record: dict, key: str):
-        for candidate_key in (key, key.replace("_id", "_source_id"), f"{key}_value"):
-            value = record.get(candidate_key)
-            if value is not None:
-                return value
-        return None
+    @property
+    def breed_id(self) -> int | str | None:
+        return self._get_hierarchy_item("breed").source_id
+
+    @property
+    def breed(self) -> str:
+        return self._get_hierarchy_item("breed").name
+
+    def _get_hierarchy_item(self, rank: str) -> TaxonomyHierarchyItem:
+        for item in self.hierarchy_items:
+            if item.rank == rank:
+                return item
+        return TaxonomyHierarchyItem(rank, None, "")
 
     def get_taxonomies(self) -> list:
-        return [
-            self.kingdom,
-            self.phylum,
-            self.classification,
-            self.family,
-            self.genus,
-            self.species,
-            self.breed,
-        ]
+        return [item.name for item in self.hierarchy_items]
 
     def get_taxonomy_items(self) -> list[TaxonomyHierarchyItem]:
         """
@@ -72,14 +48,4 @@ class BreedEntity:
         Returns:
             分類階層1要素を表すValue Objectのリスト。
         """
-        return [
-            TaxonomyHierarchyItem("kingdom", self.kingdom_id, self.kingdom),
-            TaxonomyHierarchyItem("phylum", self.phylum_id, self.phylum),
-            TaxonomyHierarchyItem(
-                "classification", self.classification_id, self.classification
-            ),
-            TaxonomyHierarchyItem("family", self.family_id, self.family),
-            TaxonomyHierarchyItem("genus", self.genus_id, self.genus),
-            TaxonomyHierarchyItem("species", self.species_id, self.species),
-            TaxonomyHierarchyItem("breed", self.breed_id, self.breed),
-        ]
+        return list(self.hierarchy_items)

--- a/taxonomy/domain/breed_entity.py
+++ b/taxonomy/domain/breed_entity.py
@@ -1,19 +1,88 @@
 class BreedEntity:
     """
     kingdom界 - phylum門 - classification綱 - family科 - genus属 - species腫 - breed品種
+
+    Attributes:
+        kingdom_id: 界のID。
+        kingdom: 界名。
+        phylum_id: 門のID。
+        phylum: 門名。
+        classification_id: 綱のID。
+        classification: 綱名。
+        family_id: 科のID。
+        family: 科名。
+        genus_id: 属のID。
+        genus: 属名。
+        species_id: 種のID。
+        species: 種名。
+        breed_id: 品種・系統・分類対象のID。
+        breed: 品種・系統・分類対象名。
+        breed_kana: 品種・系統・分類対象名のよみがな。
+        natural_monument: 天然記念物区分。
+        breed_tag: 品種タグ。
     """
 
     def __init__(self, record: dict):
-        self.kingdom: str = record.get('kingdom_name')
-        self.phylum: str = record.get('phylum_name')
-        self.classification: str = record.get('classification_name')
-        self.family: str = record.get('family_name')
-        self.genus: str = record.get('genus_name')
-        self.species: str = record.get('species_name')
-        self.breed: str = record.get('breed_name')
-        self.breed_kana: str = record.get('breed_name_kana')
-        self.natural_monument: str = record.get('breed_name_kana')
-        self.breed_tag: str = record.get('breed_tag')
+        self.kingdom_id: int | None = record.get("kingdom_id")
+        if self.kingdom_id is None:
+            self.kingdom_id = record.get("kingdom_id_value")
+        self.kingdom: str = record.get("kingdom_name")
+        self.phylum_id: int | None = record.get("phylum_id")
+        if self.phylum_id is None:
+            self.phylum_id = record.get("phylum_id_value")
+        self.phylum: str = record.get("phylum_name")
+        self.classification_id: int | None = record.get("classification_id")
+        if self.classification_id is None:
+            self.classification_id = record.get("classification_id_value")
+        self.classification: str = record.get("classification_name")
+        self.family_id: int | None = record.get("family_id")
+        if self.family_id is None:
+            self.family_id = record.get("family_id_value")
+        self.family: str = record.get("family_name")
+        self.genus_id: int | None = record.get("genus_id")
+        if self.genus_id is None:
+            self.genus_id = record.get("genus_id_value")
+        self.genus: str = record.get("genus_name")
+        self.species_id: int | None = record.get("species_id")
+        if self.species_id is None:
+            self.species_id = record.get("species_id_value")
+        self.species: str = record.get("species_name")
+        self.breed_id: int | None = record.get("breed_id")
+        if self.breed_id is None:
+            self.breed_id = record.get("breed_id_value")
+        self.breed: str = record.get("breed_name")
+        self.breed_kana: str = record.get("breed_name_kana")
+        self.natural_monument: str = record.get("natural_monument_name")
+        self.breed_tag: str = record.get("breed_tag")
 
     def get_taxonomies(self) -> list:
-        return [self.kingdom, self.phylum, self.classification, self.family, self.genus, self.species, self.breed]
+        return [
+            self.kingdom,
+            self.phylum,
+            self.classification,
+            self.family,
+            self.genus,
+            self.species,
+            self.breed,
+        ]
+
+    def get_taxonomy_items(self) -> list[dict[str, int | str | None]]:
+        """
+        グラフ変換で使う分類階層を上位から順に返す。
+
+        Returns:
+            rank、id、name を持つ分類階層のリスト。
+        """
+        return [
+            {"rank": "kingdom", "id": self.kingdom_id, "name": self.kingdom},
+            {"rank": "phylum", "id": self.phylum_id, "name": self.phylum},
+            {
+                "rank": "classification",
+                "id": self.classification_id,
+                "name": self.classification,
+            },
+            {"rank": "family", "id": self.family_id, "name": self.family},
+            {"rank": "genus", "id": self.genus_id, "name": self.genus},
+            {"rank": "species", "id": self.species_id, "name": self.species},
+            {"rank": "breed", "id": self.breed_id, "name": self.breed},
+        ]

--- a/taxonomy/domain/repository/breed.py
+++ b/taxonomy/domain/repository/breed.py
@@ -16,26 +16,42 @@ class BreedRepository:
         """
         return (
             Breed.objects.annotate(
+                kingdom_id_value=F(
+                    "species__genus__family__classification__phylum__kingdom__id"
+                ),
                 kingdom_name=F(
                     "species__genus__family__classification__phylum__kingdom__name"
                 ),
+                phylum_id_value=F("species__genus__family__classification__phylum__id"),
                 phylum_name=F("species__genus__family__classification__phylum__name"),
+                classification_id_value=F("species__genus__family__classification__id"),
                 classification_name=F("species__genus__family__classification__name"),
+                family_id_value=F("species__genus__family__id"),
                 family_name=F("species__genus__family__name"),
+                genus_id_value=F("species__genus__id"),
                 genus_name=F("species__genus__name"),
+                species_id_value=F("species__id"),
                 species_name=F("species__name"),
+                breed_id_value=F("id"),
                 breed_name=F("name"),
                 breed_name_kana=F("name_kana"),
                 natural_monument_name=F("natural_monument__name"),
                 breed_tag=F("breedtags__tag__name"),
             )
             .values(
+                "kingdom_id_value",
                 "kingdom_name",
+                "phylum_id_value",
                 "phylum_name",
+                "classification_id_value",
                 "classification_name",
+                "family_id_value",
                 "family_name",
+                "genus_id_value",
                 "genus_name",
+                "species_id_value",
                 "species_name",
+                "breed_id_value",
                 "breed_name",
                 "breed_name_kana",
                 "natural_monument_name",

--- a/taxonomy/domain/repository/breed.py
+++ b/taxonomy/domain/repository/breed.py
@@ -16,42 +16,46 @@ class BreedRepository:
         """
         return (
             Breed.objects.annotate(
-                kingdom_id_value=F(
+                kingdom_source_id=F(
                     "species__genus__family__classification__phylum__kingdom__id"
                 ),
                 kingdom_name=F(
                     "species__genus__family__classification__phylum__kingdom__name"
                 ),
-                phylum_id_value=F("species__genus__family__classification__phylum__id"),
+                phylum_source_id=F(
+                    "species__genus__family__classification__phylum__id"
+                ),
                 phylum_name=F("species__genus__family__classification__phylum__name"),
-                classification_id_value=F("species__genus__family__classification__id"),
+                classification_source_id=F(
+                    "species__genus__family__classification__id"
+                ),
                 classification_name=F("species__genus__family__classification__name"),
-                family_id_value=F("species__genus__family__id"),
+                family_source_id=F("species__genus__family__id"),
                 family_name=F("species__genus__family__name"),
-                genus_id_value=F("species__genus__id"),
+                genus_source_id=F("species__genus__id"),
                 genus_name=F("species__genus__name"),
-                species_id_value=F("species__id"),
+                species_source_id=F("species__id"),
                 species_name=F("species__name"),
-                breed_id_value=F("id"),
+                breed_source_id=F("id"),
                 breed_name=F("name"),
                 breed_name_kana=F("name_kana"),
                 natural_monument_name=F("natural_monument__name"),
                 breed_tag=F("breedtags__tag__name"),
             )
             .values(
-                "kingdom_id_value",
+                "kingdom_source_id",
                 "kingdom_name",
-                "phylum_id_value",
+                "phylum_source_id",
                 "phylum_name",
-                "classification_id_value",
+                "classification_source_id",
                 "classification_name",
-                "family_id_value",
+                "family_source_id",
                 "family_name",
-                "genus_id_value",
+                "genus_source_id",
                 "genus_name",
-                "species_id_value",
+                "species_source_id",
                 "species_name",
-                "breed_id_value",
+                "breed_source_id",
                 "breed_name",
                 "breed_name_kana",
                 "natural_monument_name",

--- a/taxonomy/domain/repository/breed.py
+++ b/taxonomy/domain/repository/breed.py
@@ -1,5 +1,6 @@
 from django.db.models import F
 
+from taxonomy.domain.valueobject.taxonomy_hierarchy import TAXONOMY_HIERARCHY_RANKS
 from taxonomy.models import Breed
 
 
@@ -8,69 +9,63 @@ class BreedRepository:
     Breedモデルの分類データを取得するリポジトリクラス
     """
 
+    HIERARCHY_SOURCE_FIELDS = {
+        "kingdom": "species__genus__family__classification__phylum__kingdom",
+        "phylum": "species__genus__family__classification__phylum",
+        "classification": "species__genus__family__classification",
+        "family": "species__genus__family",
+        "genus": "species__genus",
+        "species": "species",
+        "breed": "",
+    }
+
     @staticmethod
     def get_breed_hierarchy():
         """
         Breedの分類階層を取得するクエリ
         :return: 分類情報に基づいたリスト
         """
+        hierarchy_annotations = BreedRepository._build_hierarchy_annotations()
+        hierarchy_value_fields = BreedRepository._build_hierarchy_value_fields()
+        hierarchy_name_fields = [f"{rank}_name" for rank in TAXONOMY_HIERARCHY_RANKS]
         return (
             Breed.objects.annotate(
-                kingdom_source_id=F(
-                    "species__genus__family__classification__phylum__kingdom__id"
-                ),
-                kingdom_name=F(
-                    "species__genus__family__classification__phylum__kingdom__name"
-                ),
-                phylum_source_id=F(
-                    "species__genus__family__classification__phylum__id"
-                ),
-                phylum_name=F("species__genus__family__classification__phylum__name"),
-                classification_source_id=F(
-                    "species__genus__family__classification__id"
-                ),
-                classification_name=F("species__genus__family__classification__name"),
-                family_source_id=F("species__genus__family__id"),
-                family_name=F("species__genus__family__name"),
-                genus_source_id=F("species__genus__id"),
-                genus_name=F("species__genus__name"),
-                species_source_id=F("species__id"),
-                species_name=F("species__name"),
-                breed_source_id=F("id"),
-                breed_name=F("name"),
+                **hierarchy_annotations,
                 breed_name_kana=F("name_kana"),
                 natural_monument_name=F("natural_monument__name"),
                 breed_tag=F("breedtags__tag__name"),
             )
             .values(
-                "kingdom_source_id",
-                "kingdom_name",
-                "phylum_source_id",
-                "phylum_name",
-                "classification_source_id",
-                "classification_name",
-                "family_source_id",
-                "family_name",
-                "genus_source_id",
-                "genus_name",
-                "species_source_id",
-                "species_name",
-                "breed_source_id",
-                "breed_name",
+                *hierarchy_value_fields,
                 "breed_name_kana",
                 "natural_monument_name",
                 "breed_tag",
             )
             .order_by(
-                "kingdom_name",
-                "phylum_name",
-                "classification_name",
-                "family_name",
-                "genus_name",
-                "species_name",
-                "breed_name",
+                *hierarchy_name_fields,
                 "breed_name_kana",
                 "natural_monument_name",
                 "breed_tag",
             )
         )
+
+    @staticmethod
+    def _build_hierarchy_annotations():
+        annotations = {}
+        for rank in TAXONOMY_HIERARCHY_RANKS:
+            source_path = BreedRepository.HIERARCHY_SOURCE_FIELDS[rank]
+            if source_path:
+                annotations[f"{rank}_source_id"] = F(f"{source_path}__id")
+                annotations[f"{rank}_name"] = F(f"{source_path}__name")
+            else:
+                annotations[f"{rank}_source_id"] = F("id")
+                annotations[f"{rank}_name"] = F("name")
+        return annotations
+
+    @staticmethod
+    def _build_hierarchy_value_fields():
+        fields = []
+        for rank in TAXONOMY_HIERARCHY_RANKS:
+            fields.append(f"{rank}_source_id")
+            fields.append(f"{rank}_name")
+        return fields

--- a/taxonomy/domain/valueobject/taxonomy_graph.py
+++ b/taxonomy/domain/valueobject/taxonomy_graph.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass
+
+from taxonomy.domain.breed_entity import BreedEntity
+
+
+@dataclass(frozen=True)
+class TaxonomyGraphNode:
+    """
+    分類グラフの1ノードを表すValue Object。
+
+    Attributes:
+        id: グラフ内で一意になるノードID。
+        name: 画面表示や検索に使う分類名。
+        rank: root、kingdom、phylum などの階層種別。
+        detail_url: 詳細ページへ遷移できる場合のURL。
+    """
+
+    id: str
+    name: str
+    rank: str
+    detail_url: str = ""
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "rank": self.rank,
+            "detail_url": self.detail_url,
+        }
+
+
+@dataclass(frozen=True)
+class TaxonomyGraphEdge:
+    """
+    分類グラフの親子関係を表すValue Object。
+
+    Attributes:
+        source: 親ノードID。
+        target: 子ノードID。
+        relation: source と target の関係種別。
+    """
+
+    source: str
+    target: str
+    relation: str = "parent-child"
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "source": self.source,
+            "target": self.target,
+            "relation": self.relation,
+        }
+
+
+@dataclass(frozen=True)
+class TaxonomyGraph:
+    """
+    nodes/edges 形式の分類グラフ構造を表すValue Object。
+
+    Attributes:
+        nodes: グラフに含まれるノード。
+        edges: ノード同士の親子関係。
+    """
+
+    nodes: tuple[TaxonomyGraphNode, ...]
+    edges: tuple[TaxonomyGraphEdge, ...]
+
+    @classmethod
+    def from_breed_entities(
+        cls,
+        breed_entities: list[BreedEntity],
+        breed_detail_urls: dict[int, str] | None = None,
+        root_name: str = "root",
+    ) -> "TaxonomyGraph":
+        """
+        BreedEntity の分類階層から nodes/edges 形式のグラフを生成する。
+
+        Args:
+            breed_entities: 分類階層を持つ品種Entityのリスト。
+            breed_detail_urls: breed_id をキーにした詳細ページURL。
+            root_name: グラフの起点になるrootノード名。
+
+        Returns:
+            分類階層を親子関係として表した TaxonomyGraph。
+        """
+        detail_urls = breed_detail_urls or {}
+        nodes_by_id = {
+            "root:root": TaxonomyGraphNode(id="root:root", name=root_name, rank="root")
+        }
+        edges_by_key: dict[tuple[str, str], TaxonomyGraphEdge] = {}
+
+        for breed_entity in breed_entities:
+            parent_id = "root:root"
+            fallback_path: list[str] = []
+            for item in breed_entity.get_taxonomy_items():
+                name = str(item["name"] or "")
+                if not name:
+                    continue
+
+                rank = str(item["rank"])
+                source_id = item["id"]
+                fallback_path.append(name)
+                node_id = cls._build_node_id(rank, source_id, fallback_path)
+                if node_id not in nodes_by_id:
+                    detail_url = ""
+                    if rank == "breed" and isinstance(source_id, int):
+                        detail_url = detail_urls.get(source_id, "")
+                    nodes_by_id[node_id] = TaxonomyGraphNode(
+                        id=node_id,
+                        name=name,
+                        rank=rank,
+                        detail_url=detail_url,
+                    )
+
+                edge_key = (parent_id, node_id)
+                edges_by_key.setdefault(
+                    edge_key,
+                    TaxonomyGraphEdge(source=parent_id, target=node_id),
+                )
+                parent_id = node_id
+
+        return cls(
+            nodes=tuple(nodes_by_id.values()),
+            edges=tuple(edges_by_key.values()),
+        )
+
+    @staticmethod
+    def _build_node_id(
+        rank: str, source_id: int | str | None, fallback_path: list[str]
+    ) -> str:
+        if source_id is not None:
+            return f"{rank}:{source_id}"
+
+        return f"{rank}:{'/'.join(fallback_path)}"
+
+    def to_payload(self) -> dict[str, list[dict[str, str]]]:
+        return {
+            "nodes": [node.to_payload() for node in self.nodes],
+            "edges": [edge.to_payload() for edge in self.edges],
+        }

--- a/taxonomy/domain/valueobject/taxonomy_graph.py
+++ b/taxonomy/domain/valueobject/taxonomy_graph.py
@@ -93,12 +93,12 @@ class TaxonomyGraph:
             parent_id = "root:root"
             fallback_path: list[str] = []
             for item in breed_entity.get_taxonomy_items():
-                name = str(item["name"] or "")
-                if not name:
+                if not item.has_name:
                     continue
 
-                rank = str(item["rank"])
-                source_id = item["id"]
+                name = item.name
+                rank = item.rank
+                source_id = item.source_id
                 fallback_path.append(name)
                 node_id = cls._build_node_id(rank, source_id, fallback_path)
                 if node_id not in nodes_by_id:

--- a/taxonomy/domain/valueobject/taxonomy_hierarchy.py
+++ b/taxonomy/domain/valueobject/taxonomy_hierarchy.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TaxonomyHierarchyItem:
+    """
+    分類階層の1要素を表すValue Object。
+
+    Attributes:
+        rank: kingdom、phylum、breed などの階層種別。
+        source_id: DB上の分類階層ID。未保存データではNone。
+        name: 分類階層の表示名。
+    """
+
+    rank: str
+    source_id: int | str | None
+    name: str
+
+    @property
+    def has_name(self) -> bool:
+        return bool(self.name)

--- a/taxonomy/domain/valueobject/taxonomy_hierarchy.py
+++ b/taxonomy/domain/valueobject/taxonomy_hierarchy.py
@@ -1,6 +1,17 @@
 from dataclasses import dataclass
 
 
+TAXONOMY_HIERARCHY_RANKS = (
+    "kingdom",
+    "phylum",
+    "classification",
+    "family",
+    "genus",
+    "species",
+    "breed",
+)
+
+
 @dataclass(frozen=True)
 class TaxonomyHierarchyItem:
     """
@@ -15,6 +26,33 @@ class TaxonomyHierarchyItem:
     rank: str
     source_id: int | str | None
     name: str
+
+    @classmethod
+    def from_record(cls, rank: str, record: dict) -> "TaxonomyHierarchyItem":
+        """
+        Repository由来の平坦なdictから分類階層1要素を生成する。
+
+        Args:
+            rank: kingdom、phylum、breed などの階層種別。
+            record: Repositoryやテストデータが渡す分類階層dict。
+
+        Returns:
+            id/name を1つにまとめた TaxonomyHierarchyItem。
+        """
+        source_id = cls._get_record_value(record, f"{rank}_id")
+        return cls(
+            rank=rank,
+            source_id=source_id,
+            name=record.get(f"{rank}_name") or "",
+        )
+
+    @staticmethod
+    def _get_record_value(record: dict, key: str):
+        for candidate_key in (key, key.replace("_id", "_source_id"), f"{key}_value"):
+            value = record.get(candidate_key)
+            if value is not None:
+                return value
+        return None
 
     @property
     def has_name(self) -> bool:

--- a/taxonomy/domain/valueobject/taxonomy_hierarchy.py
+++ b/taxonomy/domain/valueobject/taxonomy_hierarchy.py
@@ -57,3 +57,65 @@ class TaxonomyHierarchyItem:
     @property
     def has_name(self) -> bool:
         return bool(self.name)
+
+
+@dataclass(frozen=True)
+class TaxonomyHierarchy:
+    """
+    界から品種までの分類階層全体を表すValue Object。
+
+    Attributes:
+        items: 固定順で並ぶ分類階層要素。
+    """
+
+    items: tuple[TaxonomyHierarchyItem, ...]
+
+    @classmethod
+    def from_record(cls, record: dict) -> "TaxonomyHierarchy":
+        """
+        Repository由来の平坦なdictから分類階層全体を生成する。
+
+        Args:
+            record: Repositoryが返す分類階層dict。
+
+        Returns:
+            固定順の分類階層。
+        """
+        return cls.from_items(
+            [
+                TaxonomyHierarchyItem.from_record(rank, record)
+                for rank in TAXONOMY_HIERARCHY_RANKS
+            ]
+        )
+
+    @classmethod
+    def from_items(
+        cls, items: list[TaxonomyHierarchyItem] | tuple[TaxonomyHierarchyItem, ...]
+    ) -> "TaxonomyHierarchy":
+        """
+        分類階層要素から階層全体を生成する。
+
+        Args:
+            items: 界から品種までの分類階層要素。
+
+        Returns:
+            rankの欠損、重複、順序違いを検証済みの分類階層。
+        """
+        ordered_items = tuple(items)
+        ranks = tuple(item.rank for item in ordered_items)
+        if ranks != TAXONOMY_HIERARCHY_RANKS:
+            expected = " -> ".join(TAXONOMY_HIERARCHY_RANKS)
+            actual = " -> ".join(ranks)
+            raise ValueError(
+                f"分類階層の順序が不正です: expected={expected}, actual={actual}"
+            )
+        return cls(ordered_items)
+
+    def names(self) -> list[str]:
+        return [item.name for item in self.items]
+
+    def get_item(self, rank: str) -> TaxonomyHierarchyItem:
+        for item in self.items:
+            if item.rank == rank:
+                return item
+        return TaxonomyHierarchyItem(rank, None, "")

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -18,6 +18,10 @@
             stroke: #111;
             stroke-width: 1px;
         }
+
+        .taxonomy-nesting-diagram {
+            white-space: pre-wrap;
+        }
     </style>
     <div class="container mt-4">
         <!-- Breadcrumb -->
@@ -54,10 +58,44 @@
                             生物分類は、界の中に門、門の中に綱、綱の中に科・属・種が入る階層構造です。
                             たとえば霊長類の下にヒトが紐づくように、個別の生き物は上位分類の中へ段階的に収まります。
                         </p>
+                        <p>
+                            Taxonomy は、この portfolio の中でも技術的な側面を持つアプリです。
+                            分類体系そのものがマトリョーシカのような入れ子構造なので、実装でも小さな Value Object を内側に持ち、
+                            それをさらに大きな Value Object が包む形で表現します。
+                        </p>
+                        <pre class="taxonomy-nesting-diagram bg-light border rounded p-3 small mb-3"><code>TaxonomyGraph
++-- nodes: TaxonomyGraphNode[]
++-- edges: TaxonomyGraphEdge[]
+    |
+    +-- source / target は TaxonomyHierarchy の親子関係を指す
+
+BreedEntity
++-- TaxonomyHierarchy
+    +-- TaxonomyHierarchyItem(kingdom)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(phylum)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(classification)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(family)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(genus)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(species)
+        +-- source_id
+        +-- name
+    +-- TaxonomyHierarchyItem(breed)
+        +-- source_id
+        +-- name</code></pre>
                         <p class="mb-0">
-                            この画面では、その入れ子構造を Value Object として扱いやすい形に整理し、
-                            分類ツリーとして確認できるようにしています。鶏の飼養分布や観察記録は、
-                            鶏の観察グラフページに分けて確認できます。
+                            <code>id</code> と <code>name</code> をばらばらの値として運ぶのではなく、<code>TaxonomyHierarchyItem</code> として1つの意味を持つ値にまとめます。
+                            その item の並びを <code>TaxonomyHierarchy</code> として扱い、さらに nodes/edges 形式へ変換したものを <code>TaxonomyGraph</code> として扱います。
+                            鶏の飼養分布や観察記録は、鶏の観察グラフページに分けて確認できます。
                         </p>
                     </div>
                 </div>

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -63,13 +63,12 @@
                             分類体系そのものがマトリョーシカのような入れ子構造なので、実装でも小さな Value Object を内側に持ち、
                             それをさらに大きな Value Object が包む形で表現します。
                         </p>
-                        <pre class="taxonomy-nesting-diagram bg-light border rounded p-3 small mb-3"><code>TaxonomyGraph
-+-- nodes: TaxonomyGraphNode[]
-+-- edges: TaxonomyGraphEdge[]
-    |
-    +-- source / target は TaxonomyHierarchy の親子関係を指す
-
-BreedEntity
+                        <p>
+                            <code>TaxonomyHierarchy</code> は分類ドメインの正しさを守る形です。
+                            界、門、綱、科、属、種、品種という順序を保ち、分類の親子関係を入れ子として扱います。
+                            <code>TaxonomyGraph</code> は同じ分類体系を可視化へ渡しやすい形に変換したものです。
+                        </p>
+                        <pre class="taxonomy-nesting-diagram bg-light border rounded p-3 small mb-3"><code>BreedEntity
 +-- TaxonomyHierarchy
     +-- TaxonomyHierarchyItem(kingdom)
         +-- source_id
@@ -91,7 +90,14 @@ BreedEntity
         +-- name
     +-- TaxonomyHierarchyItem(breed)
         +-- source_id
-        +-- name</code></pre>
+        +-- name
+            |
+            v
+TaxonomyGraph
++-- nodes: TaxonomyGraphNode[]
++-- edges: TaxonomyGraphEdge[]
+    |
+    +-- d3 などの表示ライブラリへ渡しやすい</code></pre>
                         <p>
                             <code>nodes</code> は分類名そのものを表す点で、<code>edges</code> は点と点をつなぐ親子関係の線です。
                             たとえば「動物界」「脊索動物門」「鳥綱」はそれぞれ node になり、
@@ -108,7 +114,7 @@ node: 脊索動物門
 node: 鳥綱</code></pre>
                         <p class="mb-0">
                             <code>id</code> と <code>name</code> をばらばらの値として運ぶのではなく、<code>TaxonomyHierarchyItem</code> として1つの意味を持つ値にまとめます。
-                            その item の並びを <code>TaxonomyHierarchy</code> として扱い、さらに nodes/edges 形式へ変換したものを <code>TaxonomyGraph</code> として扱います。
+                            その item の並びを <code>TaxonomyHierarchy</code> として扱い、必要なときだけ nodes/edges 形式の <code>TaxonomyGraph</code> へ変換します。
                             鶏の飼養分布や観察記録は、鶏の観察グラフページに分けて確認できます。
                         </p>
                     </div>

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -92,6 +92,20 @@ BreedEntity
     +-- TaxonomyHierarchyItem(breed)
         +-- source_id
         +-- name</code></pre>
+                        <p>
+                            <code>nodes</code> は分類名そのものを表す点で、<code>edges</code> は点と点をつなぐ親子関係の線です。
+                            たとえば「動物界」「脊索動物門」「鳥綱」はそれぞれ node になり、
+                            「動物界から脊索動物門へ」「脊索動物門から鳥綱へ」というつながりが edge になります。
+                        </p>
+                        <pre class="taxonomy-nesting-diagram bg-light border rounded p-3 small mb-3"><code>node: 動物界
+  |
+  | edge: 動物界 -> 脊索動物門
+  v
+node: 脊索動物門
+  |
+  | edge: 脊索動物門 -> 鳥綱
+  v
+node: 鳥綱</code></pre>
                         <p class="mb-0">
                             <code>id</code> と <code>name</code> をばらばらの値として運ぶのではなく、<code>TaxonomyHierarchyItem</code> として1つの意味を持つ値にまとめます。
                             その item の並びを <code>TaxonomyHierarchy</code> として扱い、さらに nodes/edges 形式へ変換したものを <code>TaxonomyGraph</code> として扱います。

--- a/taxonomy/templates/taxonomy/index.html
+++ b/taxonomy/templates/taxonomy/index.html
@@ -55,13 +55,14 @@
                     </div>
                     <div class="card-body">
                         <p>
-                            生物分類は、界の中に門、門の中に綱、綱の中に科・属・種が入る階層構造です。
-                            たとえば霊長類の下にヒトが紐づくように、個別の生き物は上位分類の中へ段階的に収まります。
+                            生物分類は、界、門、綱、科、属、種、品種の順に親子関係をたどる階層構造です。
+                            この画面では、その分類としての正しさを <code>TaxonomyHierarchy</code> で守り、
+                            d3 に渡しやすい nodes/edges 形式を <code>TaxonomyGraph</code> として扱います。
                         </p>
                         <p>
-                            Taxonomy は、この portfolio の中でも技術的な側面を持つアプリです。
-                            分類体系そのものがマトリョーシカのような入れ子構造なので、実装でも小さな Value Object を内側に持ち、
-                            それをさらに大きな Value Object が包む形で表現します。
+                            <code>TaxonomyHierarchyItem</code> は各階層の <code>id</code> と <code>name</code> をまとめた値です。
+                            その item を固定順で包む <code>TaxonomyHierarchy</code> がドメイン側の表現で、
+                            表示するときだけ <code>TaxonomyGraph</code> へ変換します。
                         </p>
                         <p>
                             <code>TaxonomyHierarchy</code> は分類ドメインの正しさを守る形です。

--- a/taxonomy/tests/domain/test_taxonomy_graph.py
+++ b/taxonomy/tests/domain/test_taxonomy_graph.py
@@ -1,0 +1,112 @@
+from unittest import TestCase
+
+from taxonomy.domain.breed_entity import BreedEntity
+from taxonomy.domain.valueobject.taxonomy_graph import TaxonomyGraph
+
+
+class TaxonomyGraphTest(TestCase):
+    def test_builds_nodes_and_edges_from_breed_entities(self):
+        """
+        シナリオ:
+        - 入力: 同じ上位階層を共有する2件の品種Entity。
+        - 処理: TaxonomyGraph.from_breed_entities を呼び出す。
+        - 期待値: 上位階層ノードは重複せず、品種までの親子edgeが生成されること。
+        """
+        breed_entities = [
+            BreedEntity(
+                {
+                    "kingdom_id": 1,
+                    "kingdom_name": "動物界",
+                    "phylum_id": 2,
+                    "phylum_name": "脊索動物門",
+                    "classification_id": 3,
+                    "classification_name": "鳥綱",
+                    "family_id": 4,
+                    "family_name": "キジ科",
+                    "genus_id": 5,
+                    "genus_name": "ヤケイ属",
+                    "species_id": 6,
+                    "species_name": "セキショクヤケイ種",
+                    "breed_id": 7,
+                    "breed_name": "ボリスブラウン",
+                    "breed_name_kana": "ボリスブラウン",
+                    "natural_monument_name": None,
+                    "breed_tag": None,
+                }
+            ),
+            BreedEntity(
+                {
+                    "kingdom_id": 1,
+                    "kingdom_name": "動物界",
+                    "phylum_id": 2,
+                    "phylum_name": "脊索動物門",
+                    "classification_id": 3,
+                    "classification_name": "鳥綱",
+                    "family_id": 4,
+                    "family_name": "キジ科",
+                    "genus_id": 5,
+                    "genus_name": "ヤケイ属",
+                    "species_id": 6,
+                    "species_name": "セキショクヤケイ種",
+                    "breed_id": 8,
+                    "breed_name": "アローカナ",
+                    "breed_name_kana": "アローカナ",
+                    "natural_monument_name": None,
+                    "breed_tag": None,
+                }
+            ),
+        ]
+
+        graph = TaxonomyGraph.from_breed_entities(
+            breed_entities,
+            {7: "/taxonomy/breeds/7/", 8: "/taxonomy/breeds/8/"},
+        )
+
+        payload = graph.to_payload()
+        nodes = {node["id"]: node for node in payload["nodes"]}
+        edges = {(edge["source"], edge["target"]) for edge in payload["edges"]}
+        self.assertEqual(9, len(nodes))
+        self.assertEqual(
+            {
+                "id": "breed:7",
+                "name": "ボリスブラウン",
+                "rank": "breed",
+                "detail_url": "/taxonomy/breeds/7/",
+            },
+            nodes["breed:7"],
+        )
+        self.assertIn(("root:root", "kingdom:1"), edges)
+        self.assertIn(("species:6", "breed:7"), edges)
+        self.assertIn(("species:6", "breed:8"), edges)
+
+    def test_builds_fallback_ids_when_source_ids_are_missing(self):
+        """
+        シナリオ:
+        - 入力: DB由来のIDを持たない品種Entity。
+        - 処理: TaxonomyGraph.from_breed_entities を呼び出す。
+        - 期待値: 階層パスを使った一意なfallback IDで nodes/edges が生成されること。
+        """
+        breed_entity = BreedEntity(
+            {
+                "kingdom_name": "動物界",
+                "phylum_name": "環形動物門",
+                "classification_name": "貧毛綱",
+                "family_name": "ツリミミズ科",
+                "genus_name": "シマミミズ属",
+                "species_name": "シマミミズ種",
+                "breed_name": "シマミミズ",
+                "breed_name_kana": "シマミミズ",
+                "natural_monument_name": None,
+                "breed_tag": "コンポスト",
+            }
+        )
+
+        graph = TaxonomyGraph.from_breed_entities([breed_entity])
+
+        payload = graph.to_payload()
+        node_ids = {node["id"] for node in payload["nodes"]}
+        self.assertIn("kingdom:動物界", node_ids)
+        self.assertIn(
+            "breed:動物界/環形動物門/貧毛綱/ツリミミズ科/シマミミズ属/シマミミズ種/シマミミズ",
+            node_ids,
+        )

--- a/taxonomy/tests/domain/test_taxonomy_graph.py
+++ b/taxonomy/tests/domain/test_taxonomy_graph.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from taxonomy.domain.breed_entity import BreedEntity
+from taxonomy.domain.valueobject.taxonomy_hierarchy import TaxonomyHierarchyItem
 from taxonomy.domain.valueobject.taxonomy_graph import TaxonomyGraph
 
 
@@ -109,4 +110,40 @@ class TaxonomyGraphTest(TestCase):
         self.assertIn(
             "breed:動物界/環形動物門/貧毛綱/ツリミミズ科/シマミミズ属/シマミミズ種/シマミミズ",
             node_ids,
+        )
+
+    def test_breed_entity_returns_hierarchy_items_as_value_objects(self):
+        """
+        シナリオ:
+        - 入力: phylum_id と phylum_name を持つ品種Entity。
+        - 処理: get_taxonomy_items を呼び出す。
+        - 期待値: id/name/rank が TaxonomyHierarchyItem として返されること。
+        """
+        breed_entity = BreedEntity(
+            {
+                "kingdom_id": 1,
+                "kingdom_name": "動物界",
+                "phylum_id": 2,
+                "phylum_name": "脊索動物門",
+                "classification_id": 3,
+                "classification_name": "鳥綱",
+                "family_id": 4,
+                "family_name": "キジ科",
+                "genus_id": 5,
+                "genus_name": "ヤケイ属",
+                "species_id": 6,
+                "species_name": "セキショクヤケイ種",
+                "breed_id": 7,
+                "breed_name": "ボリスブラウン",
+                "breed_name_kana": "ボリスブラウン",
+                "natural_monument_name": None,
+                "breed_tag": None,
+            }
+        )
+
+        taxonomy_items = breed_entity.get_taxonomy_items()
+
+        self.assertEqual(
+            TaxonomyHierarchyItem("phylum", 2, "脊索動物門"),
+            taxonomy_items[1],
         )

--- a/taxonomy/tests/domain/test_taxonomy_graph.py
+++ b/taxonomy/tests/domain/test_taxonomy_graph.py
@@ -6,6 +6,17 @@ from taxonomy.domain.valueobject.taxonomy_graph import TaxonomyGraph
 
 
 class TaxonomyGraphTest(TestCase):
+    def _build_chicken_hierarchy(self, breed: TaxonomyHierarchyItem):
+        return [
+            TaxonomyHierarchyItem("kingdom", 1, "動物界"),
+            TaxonomyHierarchyItem("phylum", 2, "脊索動物門"),
+            TaxonomyHierarchyItem("classification", 3, "鳥綱"),
+            TaxonomyHierarchyItem("family", 4, "キジ科"),
+            TaxonomyHierarchyItem("genus", 5, "ヤケイ属"),
+            TaxonomyHierarchyItem("species", 6, "セキショクヤケイ種"),
+            breed,
+        ]
+
     def test_builds_nodes_and_edges_from_breed_entities(self):
         """
         シナリオ:
@@ -14,47 +25,17 @@ class TaxonomyGraphTest(TestCase):
         - 期待値: 上位階層ノードは重複せず、品種までの親子edgeが生成されること。
         """
         breed_entities = [
-            BreedEntity(
-                {
-                    "kingdom_id": 1,
-                    "kingdom_name": "動物界",
-                    "phylum_id": 2,
-                    "phylum_name": "脊索動物門",
-                    "classification_id": 3,
-                    "classification_name": "鳥綱",
-                    "family_id": 4,
-                    "family_name": "キジ科",
-                    "genus_id": 5,
-                    "genus_name": "ヤケイ属",
-                    "species_id": 6,
-                    "species_name": "セキショクヤケイ種",
-                    "breed_id": 7,
-                    "breed_name": "ボリスブラウン",
-                    "breed_name_kana": "ボリスブラウン",
-                    "natural_monument_name": None,
-                    "breed_tag": None,
-                }
+            BreedEntity.from_hierarchy_items(
+                self._build_chicken_hierarchy(
+                    TaxonomyHierarchyItem("breed", 7, "ボリスブラウン")
+                ),
+                breed_kana="ボリスブラウン",
             ),
-            BreedEntity(
-                {
-                    "kingdom_id": 1,
-                    "kingdom_name": "動物界",
-                    "phylum_id": 2,
-                    "phylum_name": "脊索動物門",
-                    "classification_id": 3,
-                    "classification_name": "鳥綱",
-                    "family_id": 4,
-                    "family_name": "キジ科",
-                    "genus_id": 5,
-                    "genus_name": "ヤケイ属",
-                    "species_id": 6,
-                    "species_name": "セキショクヤケイ種",
-                    "breed_id": 8,
-                    "breed_name": "アローカナ",
-                    "breed_name_kana": "アローカナ",
-                    "natural_monument_name": None,
-                    "breed_tag": None,
-                }
+            BreedEntity.from_hierarchy_items(
+                self._build_chicken_hierarchy(
+                    TaxonomyHierarchyItem("breed", 8, "アローカナ")
+                ),
+                breed_kana="アローカナ",
             ),
         ]
 
@@ -87,19 +68,18 @@ class TaxonomyGraphTest(TestCase):
         - 処理: TaxonomyGraph.from_breed_entities を呼び出す。
         - 期待値: 階層パスを使った一意なfallback IDで nodes/edges が生成されること。
         """
-        breed_entity = BreedEntity(
-            {
-                "kingdom_name": "動物界",
-                "phylum_name": "環形動物門",
-                "classification_name": "貧毛綱",
-                "family_name": "ツリミミズ科",
-                "genus_name": "シマミミズ属",
-                "species_name": "シマミミズ種",
-                "breed_name": "シマミミズ",
-                "breed_name_kana": "シマミミズ",
-                "natural_monument_name": None,
-                "breed_tag": "コンポスト",
-            }
+        breed_entity = BreedEntity.from_hierarchy_items(
+            [
+                TaxonomyHierarchyItem("kingdom", None, "動物界"),
+                TaxonomyHierarchyItem("phylum", None, "環形動物門"),
+                TaxonomyHierarchyItem("classification", None, "貧毛綱"),
+                TaxonomyHierarchyItem("family", None, "ツリミミズ科"),
+                TaxonomyHierarchyItem("genus", None, "シマミミズ属"),
+                TaxonomyHierarchyItem("species", None, "シマミミズ種"),
+                TaxonomyHierarchyItem("breed", None, "シマミミズ"),
+            ],
+            breed_kana="シマミミズ",
+            breed_tag="コンポスト",
         )
 
         graph = TaxonomyGraph.from_breed_entities([breed_entity])
@@ -115,30 +95,15 @@ class TaxonomyGraphTest(TestCase):
     def test_breed_entity_returns_hierarchy_items_as_value_objects(self):
         """
         シナリオ:
-        - 入力: phylum_id と phylum_name を持つ品種Entity。
+        - 入力: phylum を TaxonomyHierarchyItem として持つ品種Entity。
         - 処理: get_taxonomy_items を呼び出す。
         - 期待値: id/name/rank が TaxonomyHierarchyItem として返されること。
         """
-        breed_entity = BreedEntity(
-            {
-                "kingdom_id": 1,
-                "kingdom_name": "動物界",
-                "phylum_id": 2,
-                "phylum_name": "脊索動物門",
-                "classification_id": 3,
-                "classification_name": "鳥綱",
-                "family_id": 4,
-                "family_name": "キジ科",
-                "genus_id": 5,
-                "genus_name": "ヤケイ属",
-                "species_id": 6,
-                "species_name": "セキショクヤケイ種",
-                "breed_id": 7,
-                "breed_name": "ボリスブラウン",
-                "breed_name_kana": "ボリスブラウン",
-                "natural_monument_name": None,
-                "breed_tag": None,
-            }
+        breed_entity = BreedEntity.from_hierarchy_items(
+            self._build_chicken_hierarchy(
+                TaxonomyHierarchyItem("breed", 7, "ボリスブラウン")
+            ),
+            breed_kana="ボリスブラウン",
         )
 
         taxonomy_items = breed_entity.get_taxonomy_items()

--- a/taxonomy/tests/domain/test_taxonomy_graph.py
+++ b/taxonomy/tests/domain/test_taxonomy_graph.py
@@ -1,7 +1,10 @@
 from unittest import TestCase
 
 from taxonomy.domain.breed_entity import BreedEntity
-from taxonomy.domain.valueobject.taxonomy_hierarchy import TaxonomyHierarchyItem
+from taxonomy.domain.valueobject.taxonomy_hierarchy import (
+    TaxonomyHierarchy,
+    TaxonomyHierarchyItem,
+)
 from taxonomy.domain.valueobject.taxonomy_graph import TaxonomyGraph
 
 
@@ -112,3 +115,23 @@ class TaxonomyGraphTest(TestCase):
             TaxonomyHierarchyItem("phylum", 2, "脊索動物門"),
             taxonomy_items[1],
         )
+
+    def test_taxonomy_hierarchy_rejects_wrong_rank_order(self):
+        """
+        シナリオ:
+        - 入力: phylum と kingdom の順序が逆になった分類階層VO。
+        - 処理: TaxonomyHierarchy.from_items を呼び出す。
+        - 期待値: 分類階層の順序違いとして ValueError が発生すること。
+        """
+        hierarchy_items = [
+            TaxonomyHierarchyItem("phylum", 2, "脊索動物門"),
+            TaxonomyHierarchyItem("kingdom", 1, "動物界"),
+            TaxonomyHierarchyItem("classification", 3, "鳥綱"),
+            TaxonomyHierarchyItem("family", 4, "キジ科"),
+            TaxonomyHierarchyItem("genus", 5, "ヤケイ属"),
+            TaxonomyHierarchyItem("species", 6, "セキショクヤケイ種"),
+            TaxonomyHierarchyItem("breed", 7, "ボリスブラウン"),
+        ]
+
+        with self.assertRaises(ValueError):
+            TaxonomyHierarchy.from_items(hierarchy_items)

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -90,6 +90,8 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "分類体系の入れ子構造")
         self.assertContains(response, "霊長類の下にヒトが紐づく")
         self.assertContains(response, "Value Object")
+        self.assertContains(response, "分類ドメインの正しさを守る形")
+        self.assertContains(response, "可視化へ渡しやすい形")
         self.assertContains(response, "TaxonomyGraph")
         self.assertContains(response, "TaxonomyHierarchy")
         self.assertContains(response, "TaxonomyHierarchyItem(kingdom)")
@@ -97,6 +99,7 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "分類名そのものを表す点")
         self.assertContains(response, "点と点をつなぐ親子関係の線")
         self.assertContains(response, "edge: 動物界 -> 脊索動物門")
+        self.assertContains(response, "必要なときだけ nodes/edges 形式")
         self.assertContains(response, "<code>id</code> と <code>name</code>")
         self.assertContains(
             response, '<i class="fas fa-chart-area me-1"></i>鶏の観察グラフ'

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -88,8 +88,9 @@ class TaxonomyIndexViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "分類体系の入れ子構造")
-        self.assertContains(response, "霊長類の下にヒトが紐づく")
-        self.assertContains(response, "Value Object")
+        self.assertContains(response, "分類としての正しさ")
+        self.assertContains(response, "d3 に渡しやすい nodes/edges 形式")
+        self.assertContains(response, "固定順で包む")
         self.assertContains(response, "分類ドメインの正しさを守る形")
         self.assertContains(response, "可視化へ渡しやすい形")
         self.assertContains(response, "TaxonomyGraph")

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -94,6 +94,9 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "TaxonomyHierarchy")
         self.assertContains(response, "TaxonomyHierarchyItem(kingdom)")
         self.assertContains(response, "source_id")
+        self.assertContains(response, "分類名そのものを表す点")
+        self.assertContains(response, "点と点をつなぐ親子関係の線")
+        self.assertContains(response, "edge: 動物界 -> 脊索動物門")
         self.assertContains(response, "<code>id</code> と <code>name</code>")
         self.assertContains(
             response, '<i class="fas fa-chart-area me-1"></i>鶏の観察グラフ'

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -90,6 +90,11 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "分類体系の入れ子構造")
         self.assertContains(response, "霊長類の下にヒトが紐づく")
         self.assertContains(response, "Value Object")
+        self.assertContains(response, "TaxonomyGraph")
+        self.assertContains(response, "TaxonomyHierarchy")
+        self.assertContains(response, "TaxonomyHierarchyItem(kingdom)")
+        self.assertContains(response, "source_id")
+        self.assertContains(response, "<code>id</code> と <code>name</code>")
         self.assertContains(
             response, '<i class="fas fa-chart-area me-1"></i>鶏の観察グラフ'
         )

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -4,7 +4,7 @@ import os
 from django.contrib import messages
 from django.http import Http404
 from django.shortcuts import redirect
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.utils.safestring import mark_safe
 from django.views.generic import (
     CreateView,
@@ -35,6 +35,7 @@ from taxonomy.domain.service.livestock_distribution_fetch import (
     SOURCE_STAT_CODE,
     SOURCE_URL,
 )
+from taxonomy.domain.valueobject.taxonomy_graph import TaxonomyGraph
 from taxonomy.forms import (
     BreedForm,
     TaxonomyBreedCreateForm,
@@ -54,10 +55,18 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         # Breed分類ツリーの取得
-        tree = NodeTree(
-            [BreedEntity(record) for record in BreedRepository.get_breed_hierarchy()]
-        )
+        breed_entities = [
+            BreedEntity(record) for record in BreedRepository.get_breed_hierarchy()
+        ]
+        tree = NodeTree(breed_entities)
         context["data"] = json.dumps(tree.export(), ensure_ascii=False)
+        breed_detail_urls = {
+            entity.breed_id: reverse("txo:breed_detail", kwargs={"pk": entity.breed_id})
+            for entity in breed_entities
+            if entity.breed_id is not None
+        }
+        graph = TaxonomyGraph.from_breed_entities(breed_entities, breed_detail_urls)
+        context["graph_data"] = json.dumps(graph.to_payload(), ensure_ascii=False)
 
         return context
 


### PR DESCRIPTION
## Summary
nodes/edges 形式の分類グラフ構造を生成できる Value Object を追加しました。

- `TaxonomyGraphNode` / `TaxonomyGraphEdge` / `TaxonomyGraph` を追加し、BreedEntity の分類階層から nodes/edges を生成
- Repository の分類階層取得に各階層IDを追加し、グラフノードIDと品種詳細URLに利用できるように変更
- Taxonomyトップの context に既存ツリーJSONとは別に `graph_data` を追加
- グラフ変換の重複排除、詳細URL、ID未取得時のfallbackをテストで確認

## 目検による動作確認手順
- [x] Taxonomyトップを開き、既存の分類ツリー表示が崩れていないことを確認する
- [x] Django shell またはテンプレート context で `graph_data` に `nodes` / `edges` が含まれることを確認する

## 自動テストでカバーできた範囲
`python manage.py test taxonomy --keepdb`

- taxonomy アプリ全体の既存テストと、追加した graph VO テストが通ることを確認しました。
- 事前に `python manage.py test taxonomy.tests.domain.test_taxonomy_graph taxonomy.tests.domain.test_node` と `python manage.py test taxonomy.tests.test_views.TaxonomyIndexViewTest --keepdb` も実行済みです。

## 関連Issue
Closes #838
https://github.com/duri0214/portfolio/issues/838
