### PR TITLE
#866 鶏の観察ページ後半のグラフ・テーブルをブラッシュアップする

### DIFF
--- a/taxonomy/domain/repository/chicken_observations.py
+++ b/taxonomy/domain/repository/chicken_observations.py
@@ -154,29 +154,31 @@ class ChickenObservationsRepository:
     @staticmethod
     def get_feed_group_laying_rates_table():
         """
-        フィードグループ別の産卵率データをテーブル形式で返します。
-        :return: [{"feed_group": "Group Name", "data": [{"date": "2023-10-01", "weather_code": "100", "laying_rate": 0.75}, ...]}, ...]
-        """
-        queryset = EggLedger.objects.select_related("feed_group").all()
+        産卵率の時系列テーブルとフィードグループの絞り込み候補を返します。
 
-        data_by_group = {}
+        :return: {"feed_groups": ["Group Name"], "records": [{"date": "2023-10-01", "feed_group": "Group Name", "weather_code": "100", "laying_rate": 0.75}, ...]}
+        """
+        queryset = EggLedger.objects.select_related(
+            "feed_group",
+            "weather_code",
+        ).order_by("recorded_date")
+
+        feed_groups = []
+        records = []
         for ledger in queryset:
-            # フィードグループの名前を取得
-            group_name = ledger.feed_group
-            if group_name not in data_by_group:
-                data_by_group[group_name] = []
-            data_by_group[group_name].append(
+            feed_group = str(ledger.feed_group)
+            if feed_group not in feed_groups:
+                feed_groups.append(feed_group)
+            records.append(
                 {
                     "date": ledger.recorded_date.isoformat(),
+                    "feed_group": feed_group,
                     "weather_code": ledger.weather_code.summary_code,
                     "laying_rate": ledger.laying_rate(),
                 }
             )
 
-        # グループごとにデータを整形
-        result = [
-            {"feed_group": group_name, "data": sorted(records, key=lambda x: x["date"])}
-            for group_name, records in data_by_group.items()
-        ]
-
-        return result
+        return {
+            "feed_groups": feed_groups,
+            "records": records,
+        }

--- a/taxonomy/domain/repository/chicken_observations.py
+++ b/taxonomy/domain/repository/chicken_observations.py
@@ -1,5 +1,3 @@
-from django.db.models import Sum
-
 from taxonomy.models import EggLedger
 
 
@@ -34,38 +32,124 @@ class ChickenObservationsRepository:
     @staticmethod
     def get_feed_vs_egg_production():
         """
-        日付ごとの餌投入量（FeedGroup）と卵生産量（EggLedger）の関係を関連付けたデータを取得し、
-        None値をゼロ埋めします。
-        :return: [{'recorded_date': '2023-10-01', 'total_feed': 50, 'total_eggs': 30}, ...]
+        日付ごとの餌投入量・卵生産量・産卵率・天気を表示用に取得します。
+
+        :return: [{'recorded_date': '2023-10-01', 'total_feed': 50, 'total_eggs': 30, ...}, ...]
         """
-        queryset = (
-            EggLedger.objects.values(
-                "recorded_date", "egg_count"
-            )  # 卵生産数をそのまま使用
-            .annotate(
-                # EggLedgerと関連付けられたFeedGroupのweightを合計
-                total_feed=Sum("feed_group__weight")  # 餌投入量だけ集計
-            )
-            .order_by("recorded_date")
-        )
+        queryset = EggLedger.objects.select_related(
+            "feed_group",
+            "hen_group",
+            "weather_code",
+        ).order_by("recorded_date")
 
-        # QuerySetを辞書形式に変換し、Noneの値をゼロで埋める
-        raw_data = ChickenObservationsRepository.to_dict(
-            queryset, date_fields=["recorded_date"]
-        )
+        return [
+            {
+                "recorded_date": ledger.recorded_date.isoformat(),
+                "total_feed": ledger.feed_group.weight if ledger.feed_group else 0,
+                "feed_group": str(ledger.feed_group) if ledger.feed_group else "",
+                "total_eggs": ledger.egg_count or 0,
+                "laying_rate": ledger.laying_rate(),
+                "weather_code": ledger.weather_code.summary_code,
+                "weather_name": ledger.weather_code.name,
+            }
+            for ledger in queryset
+        ]
 
-        # NaN発生防止のためゼロ埋め処理を追加
-        processed_data = []
-        for entry in raw_data:
-            processed_data.append(
+    @staticmethod
+    def get_observation_summary():
+        """
+        餌の量・天気ごとの比較前提と平均値を画面表示向けに集計します。
+        """
+        ledgers = list(
+            EggLedger.objects.select_related(
+                "feed_group",
+                "hen_group",
+                "weather_code",
+            ).order_by("recorded_date")
+        )
+        if not ledgers:
+            return {
+                "record_count": 0,
+                "start_date": "",
+                "end_date": "",
+                "feed_summaries": [],
+                "weather_summaries": [],
+            }
+
+        feed_summaries = ChickenObservationsRepository._summarize_by_feed(ledgers)
+        weather_summaries = ChickenObservationsRepository._summarize_by_weather(ledgers)
+
+        return {
+            "record_count": len(ledgers),
+            "start_date": ledgers[0].recorded_date.isoformat(),
+            "end_date": ledgers[-1].recorded_date.isoformat(),
+            "feed_summaries": feed_summaries,
+            "weather_summaries": weather_summaries,
+        }
+
+    @staticmethod
+    def _summarize_by_feed(ledgers):
+        data_by_weight = {}
+        for ledger in ledgers:
+            weight = ledger.feed_group.weight
+            data_by_weight.setdefault(weight, []).append(ledger)
+
+        summaries = []
+        for weight, records in sorted(data_by_weight.items(), reverse=True):
+            summaries.append(
                 {
-                    "recorded_date": entry.get("recorded_date"),
-                    "total_feed": entry.get("total_feed", 0),
-                    "total_eggs": entry.get("egg_count", 0),
+                    "feed_weight": weight,
+                    "record_count": len(records),
+                    "average_eggs": ChickenObservationsRepository._average_eggs(
+                        records
+                    ),
+                    "average_laying_rate": ChickenObservationsRepository._average_rate(
+                        records
+                    ),
+                    "min_date": records[0].recorded_date.isoformat(),
+                    "max_date": records[-1].recorded_date.isoformat(),
                 }
             )
+        return summaries
 
-        return processed_data
+    @staticmethod
+    def _summarize_by_weather(ledgers):
+        data_by_weather = {}
+        for ledger in ledgers:
+            key = ledger.weather_code.summary_code
+            data_by_weather.setdefault(key, []).append(ledger)
+
+        summaries = []
+        for summary_code, records in sorted(data_by_weather.items()):
+            first_record = records[0]
+            summaries.append(
+                {
+                    "weather_code": summary_code,
+                    "weather_name": first_record.weather_code.name,
+                    "record_count": len(records),
+                    "average_eggs": ChickenObservationsRepository._average_eggs(
+                        records
+                    ),
+                    "average_laying_rate": ChickenObservationsRepository._average_rate(
+                        records
+                    ),
+                }
+            )
+        return sorted(
+            summaries,
+            key=lambda summary: summary["record_count"],
+            reverse=True,
+        )
+
+    @staticmethod
+    def _average_eggs(records):
+        egg_counts = [record.egg_count or 0 for record in records]
+        return round(sum(egg_counts) / len(egg_counts), 1)
+
+    @staticmethod
+    def _average_rate(records):
+        rates = [record.laying_rate() for record in records]
+        return round(sum(rates) / len(rates), 1)
 
     @staticmethod
     def get_feed_group_laying_rates_table():

--- a/taxonomy/static/taxonomy/css/observation.css
+++ b/taxonomy/static/taxonomy/css/observation.css
@@ -203,6 +203,15 @@
     overflow: hidden;
 }
 
+.observation-table-filter {
+    align-items: center;
+    border-bottom: 1px solid #e2e8f0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.85rem 1rem;
+}
+
 .observation-table-card h3 {
     border-bottom: 1px solid #e2e8f0;
     color: #1f2937;

--- a/taxonomy/static/taxonomy/css/observation.css
+++ b/taxonomy/static/taxonomy/css/observation.css
@@ -1,0 +1,259 @@
+.observation-panel {
+    background: #ffffff;
+    border: 1px solid #d8dee6;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(31, 41, 55, 0.08);
+    padding: 1.5rem;
+}
+
+.observation-section-header {
+    align-items: flex-start;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-bottom: 1.25rem;
+}
+
+.observation-section-header h2 {
+    color: #1f2937;
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 0.35rem;
+}
+
+.observation-section-header p {
+    color: #667085;
+    margin: 0;
+}
+
+.observation-badge {
+    background: #e8f4f8;
+    border: 1px solid #b8dfe8;
+    border-radius: 999px;
+    color: #0f6575;
+    flex: 0 0 auto;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.35rem 0.75rem;
+}
+
+.observation-insights,
+.observation-summary-grid,
+.observation-weather-grid,
+.observation-table-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.observation-insights {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-bottom: 1rem;
+}
+
+.observation-insight,
+.observation-metric,
+.observation-weather-card,
+.observation-table-card {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    background: #fbfcfd;
+}
+
+.observation-insight {
+    padding: 1rem;
+}
+
+.observation-insight-label {
+    color: #64748b;
+    display: block;
+    font-size: 0.78rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+}
+
+.observation-insight strong {
+    color: #1f2937;
+    display: block;
+    font-size: 1rem;
+    line-height: 1.45;
+    margin-bottom: 0.45rem;
+}
+
+.observation-insight span:last-child {
+    color: #667085;
+    display: block;
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.observation-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-bottom: 1.25rem;
+}
+
+.observation-metric {
+    padding: 1rem;
+}
+
+.observation-metric > span {
+    color: #475467;
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.observation-metric > strong {
+    color: #1f2937;
+    display: block;
+    font-size: 1.8rem;
+    margin: 0.1rem 0 0.65rem;
+}
+
+.observation-metric dl,
+.observation-weather-card dl {
+    display: grid;
+    gap: 0.35rem 0.75rem;
+    grid-template-columns: auto 1fr;
+    margin: 0;
+}
+
+.observation-metric dt,
+.observation-weather-card dt {
+    color: #667085;
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+
+.observation-metric dd,
+.observation-weather-card dd {
+    color: #1f2937;
+    font-size: 0.9rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.observation-chart {
+    min-height: 360px;
+    overflow-x: auto;
+}
+
+.observation-chart svg {
+    display: block;
+    max-width: 100%;
+}
+
+.observation-chart-empty {
+    align-items: center;
+    background: #f8fafc;
+    border: 1px dashed #cbd5e1;
+    border-radius: 8px;
+    color: #667085;
+    display: flex;
+    min-height: 220px;
+    justify-content: center;
+}
+
+.observation-chart-tooltip {
+    background: #111827;
+    border-radius: 6px;
+    color: #ffffff;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    padding: 0.5rem 0.65rem;
+    pointer-events: none;
+    position: fixed;
+    z-index: 20;
+}
+
+.observation-weather-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.observation-weather-card {
+    align-items: center;
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: auto 1fr;
+    padding: 1rem;
+}
+
+.observation-weather-card strong,
+.observation-weather-card span {
+    display: block;
+}
+
+.observation-weather-card strong {
+    color: #1f2937;
+}
+
+.observation-weather-card span {
+    color: #667085;
+    font-size: 0.85rem;
+}
+
+.observation-weather-card dl {
+    grid-column: 1 / -1;
+}
+
+.observation-table-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.observation-table-card {
+    overflow: hidden;
+}
+
+.observation-table-card h3 {
+    border-bottom: 1px solid #e2e8f0;
+    color: #1f2937;
+    font-size: 1rem;
+    margin: 0;
+    padding: 0.85rem 1rem;
+}
+
+.observation-table-scroll {
+    max-height: 460px;
+    overflow: auto;
+}
+
+.observation-table-card thead th {
+    background: #f1f5f9;
+    color: #475467;
+    font-size: 0.78rem;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.observation-table-card td,
+.observation-table-card th {
+    padding: 0.55rem 0.75rem;
+    white-space: nowrap;
+}
+
+@media (max-width: 991.98px) {
+    .observation-insights,
+    .observation-weather-grid,
+    .observation-table-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .observation-panel {
+        padding: 1rem;
+    }
+
+    .observation-section-header {
+        display: block;
+    }
+
+    .observation-badge {
+        display: inline-block;
+        margin-top: 0.75rem;
+    }
+
+    .observation-summary-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/taxonomy/static/taxonomy/js/feed_vs_egg_chart.js
+++ b/taxonomy/static/taxonomy/js/feed_vs_egg_chart.js
@@ -1,3 +1,88 @@
+function solveQuadraticCoefficients(points) {
+    const sums = points.reduce((acc, point) => {
+        const x2 = point.x * point.x;
+        acc.x += point.x;
+        acc.x2 += x2;
+        acc.x3 += x2 * point.x;
+        acc.x4 += x2 * x2;
+        acc.y += point.y;
+        acc.xy += point.x * point.y;
+        acc.x2y += x2 * point.y;
+        return acc;
+    }, {x: 0, x2: 0, x3: 0, x4: 0, y: 0, xy: 0, x2y: 0});
+
+    const matrix = [
+        [sums.x4, sums.x3, sums.x2, sums.x2y],
+        [sums.x3, sums.x2, sums.x, sums.xy],
+        [sums.x2, sums.x, points.length, sums.y],
+    ];
+
+    for (let column = 0; column < 3; column += 1) {
+        let pivotRow = column;
+        for (let row = column + 1; row < 3; row += 1) {
+            if (Math.abs(matrix[row][column]) > Math.abs(matrix[pivotRow][column])) {
+                pivotRow = row;
+            }
+        }
+        if (Math.abs(matrix[pivotRow][column]) < 1e-9) {
+            return null;
+        }
+        [matrix[column], matrix[pivotRow]] = [matrix[pivotRow], matrix[column]];
+
+        const pivot = matrix[column][column];
+        for (let cell = column; cell < 4; cell += 1) {
+            matrix[column][cell] /= pivot;
+        }
+        for (let row = 0; row < 3; row += 1) {
+            if (row === column) {
+                continue;
+            }
+            const factor = matrix[row][column];
+            for (let cell = column; cell < 4; cell += 1) {
+                matrix[row][cell] -= factor * matrix[column][cell];
+            }
+        }
+    }
+
+    return {
+        a: matrix[0][3],
+        b: matrix[1][3],
+        c: matrix[2][3],
+    };
+}
+
+function buildQuadraticTrendPoints(parsedData) {
+    if (parsedData.length < 3) {
+        return [];
+    }
+
+    const dayMs = 24 * 60 * 60 * 1000;
+    const firstTime = parsedData[0].date.getTime();
+    const points = parsedData.map((item) => ({
+        x: (item.date.getTime() - firstTime) / dayMs,
+        y: item.laying_rate,
+    }));
+    const minX = d3.min(points, (point) => point.x);
+    const maxX = d3.max(points, (point) => point.x);
+    if (minX === maxX) {
+        return [];
+    }
+
+    const coefficients = solveQuadraticCoefficients(points);
+    if (!coefficients) {
+        return [];
+    }
+
+    const stepCount = 80;
+    return d3.range(stepCount + 1).map((index) => {
+        const xValue = minX + ((maxX - minX) * index) / stepCount;
+        return {
+            date: new Date(firstTime + xValue * dayMs),
+            laying_rate: coefficients.a * xValue * xValue + coefficients.b * xValue + coefficients.c,
+        };
+    });
+}
+
 function renderFeedVsEggChart(feedVsEggData) {
     const chartArea = document.querySelector("#feed-vs-egg-chart");
     chartArea.innerHTML = "";
@@ -22,7 +107,7 @@ function renderFeedVsEggChart(feedVsEggData) {
         .append("svg")
         .attr("viewBox", `0 0 ${outerWidth} ${outerHeight}`)
         .attr("role", "img")
-        .attr("aria-label", "給餌量、産卵率、天気の推移");
+        .attr("aria-label", "給餌量、産卵率、二次近似、天気の推移");
 
     const plot = svg.append("g")
         .attr("transform", `translate(${margin.left}, ${margin.top})`);
@@ -30,7 +115,11 @@ function renderFeedVsEggChart(feedVsEggData) {
     const x = d3.scaleTime()
         .domain(d3.extent(parsedData, (d) => d.date))
         .range([0, width]);
-    const rateMax = d3.max(parsedData, (d) => d.laying_rate) || 1;
+    const trendPoints = buildQuadraticTrendPoints(parsedData);
+    const rateMax = Math.max(
+        d3.max(parsedData, (d) => d.laying_rate) || 1,
+        d3.max(trendPoints, (d) => d.laying_rate) || 0,
+    );
     const yRate = d3.scaleLinear()
         .domain([0, Math.ceil(rateMax + 10)])
         .nice()
@@ -70,6 +159,18 @@ function renderFeedVsEggChart(feedVsEggData) {
         .attr("stroke", "#0f766e")
         .attr("stroke-width", 2.5)
         .attr("d", rateLine);
+
+    if (trendPoints.length) {
+        plot.append("path")
+            .datum(trendPoints)
+            .attr("class", "quadratic-trend-line")
+            .attr("fill", "none")
+            .attr("stroke", "#334155")
+            .attr("stroke-width", 2)
+            .attr("stroke-dasharray", "5 5")
+            .attr("opacity", 0.85)
+            .attr("d", rateLine);
+    }
 
     const tooltip = d3.select("body")
         .append("div")
@@ -128,7 +229,7 @@ function renderFeedVsEggChart(feedVsEggData) {
         .attr("y", 18)
         .attr("fill", "#475467")
         .attr("font-size", 12)
-        .text("線: 産卵率 / 下段色: 給餌量 / 下段文字: 天気");
+        .text("線: 産卵率 / 点線: 二次近似 / 下段色: 給餌量 / 下段文字: 天気");
 
     const legend = svg.append("g")
         .attr("transform", `translate(${margin.left}, ${outerHeight - 18})`);

--- a/taxonomy/static/taxonomy/js/feed_vs_egg_chart.js
+++ b/taxonomy/static/taxonomy/js/feed_vs_egg_chart.js
@@ -12,7 +12,7 @@ function renderFeedVsEggChart(feedVsEggData) {
         date: new Date(item.recorded_date),
     }));
     const bounds = chartArea.getBoundingClientRect();
-    const margin = {top: 36, right: 56, bottom: 72, left: 52};
+    const margin = {top: 36, right: 56, bottom: 82, left: 52};
     const outerWidth = Math.max(bounds.width || 720, 720);
     const outerHeight = 420;
     const width = outerWidth - margin.left - margin.right;
@@ -22,7 +22,7 @@ function renderFeedVsEggChart(feedVsEggData) {
         .append("svg")
         .attr("viewBox", `0 0 ${outerWidth} ${outerHeight}`)
         .attr("role", "img")
-        .attr("aria-label", "給餌量、産卵数、産卵率、天気の推移");
+        .attr("aria-label", "給餌量、産卵率、天気の推移");
 
     const plot = svg.append("g")
         .attr("transform", `translate(${margin.left}, ${margin.top})`);
@@ -30,11 +30,6 @@ function renderFeedVsEggChart(feedVsEggData) {
     const x = d3.scaleTime()
         .domain(d3.extent(parsedData, (d) => d.date))
         .range([0, width]);
-    const eggMax = d3.max(parsedData, (d) => d.total_eggs) || 1;
-    const yEgg = d3.scaleLinear()
-        .domain([0, Math.ceil(eggMax + 1)])
-        .nice()
-        .range([height, 0]);
     const rateMax = d3.max(parsedData, (d) => d.laying_rate) || 1;
     const yRate = d3.scaleLinear()
         .domain([0, Math.ceil(rateMax + 10)])
@@ -43,38 +38,27 @@ function renderFeedVsEggChart(feedVsEggData) {
     const feedWeights = Array.from(new Set(parsedData.map((d) => d.total_feed))).sort((a, b) => b - a);
     const feedColor = d3.scaleOrdinal()
         .domain(feedWeights)
-        .range(["#dbeafe", "#ecfdf3", "#fff7ed", "#f3e8ff"]);
-    const barWidth = Math.max(width / parsedData.length * 0.55, 2);
+        .range(["#1d4ed8", "#15803d", "#7c2d12", "#6d28d9"]);
+    const markerWidth = Math.max(width / parsedData.length * 0.55, 3);
+    const feedMarkerHeight = 12;
 
     plot.append("g")
         .attr("class", "grid")
-        .call(d3.axisLeft(yEgg).ticks(5).tickSize(-width).tickFormat(""))
+        .call(d3.axisLeft(yRate).ticks(5).tickSize(-width).tickFormat(""))
         .call((g) => g.selectAll("line").attr("stroke", "#e5e7eb"))
         .call((g) => g.select(".domain").remove());
 
-    plot.selectAll(".feed-band")
+    plot.selectAll(".feed-marker")
         .data(parsedData)
         .enter()
         .append("rect")
-        .attr("class", "feed-band")
-        .attr("x", (d) => x(d.date) - barWidth / 2)
-        .attr("y", 0)
-        .attr("width", barWidth)
-        .attr("height", height)
+        .attr("class", "feed-marker")
+        .attr("x", (d) => x(d.date) - markerWidth / 2)
+        .attr("y", height + 14)
+        .attr("width", markerWidth)
+        .attr("height", feedMarkerHeight)
         .attr("fill", (d) => feedColor(d.total_feed))
-        .attr("opacity", 0.38);
-
-    plot.selectAll(".egg-bar")
-        .data(parsedData)
-        .enter()
-        .append("rect")
-        .attr("class", "egg-bar")
-        .attr("x", (d) => x(d.date) - barWidth / 2)
-        .attr("y", (d) => yEgg(d.total_eggs))
-        .attr("width", barWidth)
-        .attr("height", (d) => height - yEgg(d.total_eggs))
-        .attr("fill", "#f59e0b")
-        .attr("rx", 2);
+        .attr("rx", 1);
 
     const rateLine = d3.line()
         .x((d) => x(d.date))
@@ -136,12 +120,7 @@ function renderFeedVsEggChart(feedVsEggData) {
         .call((g) => g.selectAll("text").attr("fill", "#475467"));
 
     plot.append("g")
-        .call(d3.axisLeft(yEgg).ticks(5))
-        .call((g) => g.selectAll("text").attr("fill", "#475467"));
-
-    plot.append("g")
-        .attr("transform", `translate(${width}, 0)`)
-        .call(d3.axisRight(yRate).ticks(5).tickFormat((d) => `${d}%`))
+        .call(d3.axisLeft(yRate).ticks(5).tickFormat((d) => `${d}%`))
         .call((g) => g.selectAll("text").attr("fill", "#0f766e"));
 
     svg.append("text")
@@ -149,7 +128,7 @@ function renderFeedVsEggChart(feedVsEggData) {
         .attr("y", 18)
         .attr("fill", "#475467")
         .attr("font-size", 12)
-        .text("棒: 産卵数 / 線: 産卵率 / 背景色: 給餌量 / 下段文字: 天気");
+        .text("線: 産卵率 / 下段色: 給餌量 / 下段文字: 天気");
 
     const legend = svg.append("g")
         .attr("transform", `translate(${margin.left}, ${outerHeight - 18})`);

--- a/taxonomy/static/taxonomy/js/feed_vs_egg_chart.js
+++ b/taxonomy/static/taxonomy/js/feed_vs_egg_chart.js
@@ -1,99 +1,183 @@
 function renderFeedVsEggChart(feedVsEggData) {
-    // SVG領域の設定
-    const margin = {top: 20, right: 60, bottom: 40, left: 50};
-    const width = 800 - margin.left - margin.right;
-    const height = 400 - margin.top - margin.bottom;
+    const chartArea = document.querySelector("#feed-vs-egg-chart");
+    chartArea.innerHTML = "";
 
-    const svg = d3.select("#feed-vs-egg-chart").append("svg")
-        .attr("width", width + margin.left + margin.right)
-        .attr("height", height + margin.top + margin.bottom)
-        .append("g")
+    if (!feedVsEggData.length) {
+        chartArea.innerHTML = '<div class="observation-chart-empty">観察データがありません。</div>';
+        return;
+    }
+
+    const parsedData = feedVsEggData.map((item) => ({
+        ...item,
+        date: new Date(item.recorded_date),
+    }));
+    const bounds = chartArea.getBoundingClientRect();
+    const margin = {top: 36, right: 56, bottom: 72, left: 52};
+    const outerWidth = Math.max(bounds.width || 720, 720);
+    const outerHeight = 420;
+    const width = outerWidth - margin.left - margin.right;
+    const height = outerHeight - margin.top - margin.bottom;
+
+    const svg = d3.select(chartArea)
+        .append("svg")
+        .attr("viewBox", `0 0 ${outerWidth} ${outerHeight}`)
+        .attr("role", "img")
+        .attr("aria-label", "給餌量、産卵数、産卵率、天気の推移");
+
+    const plot = svg.append("g")
         .attr("transform", `translate(${margin.left}, ${margin.top})`);
 
-    // X軸: 日付
     const x = d3.scaleTime()
-        .domain(d3.extent(feedVsEggData, d => new Date(d.recorded_date)))
+        .domain(d3.extent(parsedData, (d) => d.date))
         .range([0, width]);
-    svg.append("g")
-        .attr("transform", `translate(0, ${height})`)
-        .call(d3.axisBottom(x));
-
-    // Y軸: 餌投入量
-    const yLeft = d3.scaleLinear()
-        .domain([0, d3.max(feedVsEggData, d => d.total_feed)])
+    const eggMax = d3.max(parsedData, (d) => d.total_eggs) || 1;
+    const yEgg = d3.scaleLinear()
+        .domain([0, Math.ceil(eggMax + 1)])
+        .nice()
         .range([height, 0]);
-    svg.append("g")
-        .call(d3.axisLeft(yLeft))
-        .style("fill", "steelblue");
-
-    // Y軸右: 卵の生産数
-    const yRight = d3.scaleLinear()
-        .domain([0, d3.max(feedVsEggData, d => d.total_eggs)])
+    const rateMax = d3.max(parsedData, (d) => d.laying_rate) || 1;
+    const yRate = d3.scaleLinear()
+        .domain([0, Math.ceil(rateMax + 10)])
+        .nice()
         .range([height, 0]);
-    svg.append("g")
-        .attr("transform", `translate(${width}, 0)`)
-        .call(d3.axisRight(yRight))
-        .style("fill", "orange");
+    const feedWeights = Array.from(new Set(parsedData.map((d) => d.total_feed))).sort((a, b) => b - a);
+    const feedColor = d3.scaleOrdinal()
+        .domain(feedWeights)
+        .range(["#dbeafe", "#ecfdf3", "#fff7ed", "#f3e8ff"]);
+    const barWidth = Math.max(width / parsedData.length * 0.55, 2);
 
-    // 餌投入量: 折れ線
-    svg.append("path")
-        .datum(feedVsEggData)
+    plot.append("g")
+        .attr("class", "grid")
+        .call(d3.axisLeft(yEgg).ticks(5).tickSize(-width).tickFormat(""))
+        .call((g) => g.selectAll("line").attr("stroke", "#e5e7eb"))
+        .call((g) => g.select(".domain").remove());
+
+    plot.selectAll(".feed-band")
+        .data(parsedData)
+        .enter()
+        .append("rect")
+        .attr("class", "feed-band")
+        .attr("x", (d) => x(d.date) - barWidth / 2)
+        .attr("y", 0)
+        .attr("width", barWidth)
+        .attr("height", height)
+        .attr("fill", (d) => feedColor(d.total_feed))
+        .attr("opacity", 0.38);
+
+    plot.selectAll(".egg-bar")
+        .data(parsedData)
+        .enter()
+        .append("rect")
+        .attr("class", "egg-bar")
+        .attr("x", (d) => x(d.date) - barWidth / 2)
+        .attr("y", (d) => yEgg(d.total_eggs))
+        .attr("width", barWidth)
+        .attr("height", (d) => height - yEgg(d.total_eggs))
+        .attr("fill", "#f59e0b")
+        .attr("rx", 2);
+
+    const rateLine = d3.line()
+        .x((d) => x(d.date))
+        .y((d) => yRate(d.laying_rate));
+
+    plot.append("path")
+        .datum(parsedData)
         .attr("fill", "none")
-        .attr("stroke", "steelblue")
-        .attr("stroke-width", 2)
-        .attr("d", d3.line()
-            .x(d => x(new Date(d.recorded_date)))
-            .y(d => yLeft(d.total_feed))
-        );
+        .attr("stroke", "#0f766e")
+        .attr("stroke-width", 2.5)
+        .attr("d", rateLine);
 
-    // 卵生産数: オレンジの点プロット
-    svg.selectAll(".dot")
-        .data(feedVsEggData)
+    const tooltip = d3.select("body")
+        .append("div")
+        .attr("class", "observation-chart-tooltip")
+        .style("display", "none");
+
+    plot.selectAll(".rate-point")
+        .data(parsedData)
         .enter()
         .append("circle")
-        .attr("cx", d => x(new Date(d.recorded_date)))
-        .attr("cy", d => yRight(d.total_eggs))
+        .attr("class", "rate-point")
+        .attr("cx", (d) => x(d.date))
+        .attr("cy", (d) => yRate(d.laying_rate))
         .attr("r", 4)
-        .style("fill", "orange")
-        .style("opacity", 0.8);
+        .attr("fill", "#0f766e")
+        .on("mouseenter", (event, d) => {
+            tooltip
+                .style("display", "block")
+                .html([
+                    d.recorded_date,
+                    `給餌量: ${d.total_feed}g`,
+                    `産卵数: ${d.total_eggs}個`,
+                    `産卵率: ${d.laying_rate}%`,
+                    `天気: ${d.weather_name}`,
+                ].join("<br>"));
+        })
+        .on("mousemove", (event) => {
+            tooltip
+                .style("left", `${event.clientX + 12}px`)
+                .style("top", `${event.clientY + 12}px`);
+        })
+        .on("mouseleave", () => tooltip.style("display", "none"));
 
-    // ラベル追加
-    svg.append("text")
-        .attr("x", width / 2)
-        .attr("y", height + margin.bottom)
+    plot.selectAll(".weather-dot")
+        .data(parsedData)
+        .enter()
+        .append("text")
+        .attr("x", (d) => x(d.date))
+        .attr("y", height + 38)
         .attr("text-anchor", "middle")
-        .text("日付");
+        .attr("font-size", 10)
+        .attr("fill", "#64748b")
+        .text((d) => d.weather_name.slice(0, 1));
+
+    plot.append("g")
+        .attr("transform", `translate(0, ${height})`)
+        .call(d3.axisBottom(x).ticks(6).tickFormat(d3.timeFormat("%m/%d")))
+        .call((g) => g.selectAll("text").attr("fill", "#475467"));
+
+    plot.append("g")
+        .call(d3.axisLeft(yEgg).ticks(5))
+        .call((g) => g.selectAll("text").attr("fill", "#475467"));
+
+    plot.append("g")
+        .attr("transform", `translate(${width}, 0)`)
+        .call(d3.axisRight(yRate).ticks(5).tickFormat((d) => `${d}%`))
+        .call((g) => g.selectAll("text").attr("fill", "#0f766e"));
 
     svg.append("text")
-        .attr("transform", "rotate(-90)")
-        .attr("x", -height / 2)
-        .attr("y", -margin.left + 10)
-        .attr("text-anchor", "middle")
-        .style("fill", "steelblue")
-        .text("餌投入量 (g)");
+        .attr("x", margin.left)
+        .attr("y", 18)
+        .attr("fill", "#475467")
+        .attr("font-size", 12)
+        .text("棒: 産卵数 / 線: 産卵率 / 背景色: 給餌量 / 下段文字: 天気");
 
-    svg.append("text")
-        .attr("transform", `translate(${width + 50}, ${height / 2}) rotate(90)`)
-        .attr("text-anchor", "middle")
-        .style("fill", "orange")
-        .text("卵 生産数 (個)");
+    const legend = svg.append("g")
+        .attr("transform", `translate(${margin.left}, ${outerHeight - 18})`);
+    feedWeights.forEach((weight, index) => {
+        const item = legend.append("g")
+            .attr("transform", `translate(${index * 110}, 0)`);
+        item.append("rect")
+            .attr("width", 14)
+            .attr("height", 14)
+            .attr("fill", feedColor(weight));
+        item.append("text")
+            .attr("x", 20)
+            .attr("y", 11)
+            .attr("fill", "#475467")
+            .attr("font-size", 12)
+            .text(`${weight}g`);
+    });
 }
 
 function initializeFeedVsEggChart() {
     const chartArea = document.querySelector("#feed-vs-egg-chart");
     if (!chartArea) {
-        console.error("Chart area not found");
         return;
     }
 
     try {
         const rawData = chartArea.getAttribute("data-feed-data");
-        if (!rawData) {
-            console.error("No feed data provided in data-feed-data attribute.");
-            return;
-        }
-
-        const feedVsEggData = JSON.parse(rawData);
+        const feedVsEggData = rawData ? JSON.parse(rawData) : [];
         renderFeedVsEggChart(feedVsEggData);
     } catch (error) {
         console.error("Error parsing or rendering feed vs. egg chart:", error);
@@ -101,3 +185,7 @@ function initializeFeedVsEggChart() {
 }
 
 document.addEventListener("DOMContentLoaded", initializeFeedVsEggChart);
+window.addEventListener("resize", () => {
+    window.clearTimeout(window.feedVsEggResizeTimer);
+    window.feedVsEggResizeTimer = window.setTimeout(initializeFeedVsEggChart, 150);
+});

--- a/taxonomy/static/taxonomy/js/observation_laying_rate_table.js
+++ b/taxonomy/static/taxonomy/js/observation_laying_rate_table.js
@@ -1,0 +1,25 @@
+function initializeObservationLayingRateTable() {
+    const filterButtons = document.querySelectorAll(".observation-feed-filter");
+    const rows = document.querySelectorAll(".observation-table-card tbody tr[data-feed-group]");
+    if (!filterButtons.length || !rows.length) {
+        return;
+    }
+
+    filterButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+            const selectedFeedGroup = button.dataset.feedGroup;
+            filterButtons.forEach((item) => {
+                item.classList.toggle("active", item === button);
+                item.classList.toggle("btn-primary", item === button);
+                item.classList.toggle("btn-outline-primary", item !== button);
+            });
+
+            rows.forEach((row) => {
+                const shouldShow = selectedFeedGroup === "all" || row.dataset.feedGroup === selectedFeedGroup;
+                row.classList.toggle("d-none", !shouldShow);
+            });
+        });
+    });
+}
+
+document.addEventListener("DOMContentLoaded", initializeObservationLayingRateTable);

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -210,10 +210,10 @@
                 <section class="observation-panel">
                     <div class="observation-section-header">
                         <div>
-                            <h2>餌の量と卵生産量の推移</h2>
+                            <h2>餌の量と産卵率の推移</h2>
                             <p>
                                 {{ observation_summary.start_date }} から {{ observation_summary.end_date }} までの
-                                {{ observation_summary.record_count }}件を、給餌量・産卵数・産卵率・天気で比較します。
+                                {{ observation_summary.record_count }}件を、給餌量・産卵率・天気で比較します。
                             </p>
                         </div>
                         <span class="observation-badge">観察記録</span>
@@ -226,9 +226,9 @@
                             <span>条件数に偏りがあるため、差の断定ではなく傾向として読みます。</span>
                         </div>
                         <div class="observation-insight">
-                            <span class="observation-insight-label">産卵数の読み取り</span>
+                            <span class="observation-insight-label">産卵率の読み取り</span>
                             <strong>半量給餌でも大きな落ち込みは見えにくい</strong>
-                            <span>時系列では給餌量の変更後も日々の産卵数が同じレンジに収まっています。</span>
+                            <span>時系列では給餌量の変更後も日々の産卵率が同じレンジに収まっています。</span>
                         </div>
                         <div class="observation-insight">
                             <span class="observation-insight-label">天気との関係</span>

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'taxonomy/css/livestock_distribution.css' %}">
+    <link rel="stylesheet" href="{% static 'taxonomy/css/observation.css' %}">
 {% endblock %}
 {% block content %}
     <div class="container mt-4">
@@ -203,46 +204,107 @@
                 </div>
             </div>
 
-            <!-- Key Insight -->
             <div class="col-12">
-                <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
-                    <i class="fas fa-lightbulb me-2"></i>
-                    <span>餌の量を半分にしても卵の生産量はほとんど変わらないことがデータから確認できます。</span>
-                </div>
+                <section class="observation-panel">
+                    <div class="observation-section-header">
+                        <div>
+                            <h2>餌の量と卵生産量の推移</h2>
+                            <p>
+                                {{ observation_summary.start_date }} から {{ observation_summary.end_date }} までの
+                                {{ observation_summary.record_count }}件を、給餌量・産卵数・産卵率・天気で比較します。
+                            </p>
+                        </div>
+                        <span class="observation-badge">観察記録</span>
+                    </div>
+
+                    <div class="observation-insights" aria-label="観察データの要点">
+                        <div class="observation-insight">
+                            <span class="observation-insight-label">給餌量の比較</span>
+                            <strong>1250gは3件、625gは90件</strong>
+                            <span>条件数に偏りがあるため、差の断定ではなく傾向として読みます。</span>
+                        </div>
+                        <div class="observation-insight">
+                            <span class="observation-insight-label">産卵数の読み取り</span>
+                            <strong>半量給餌でも大きな落ち込みは見えにくい</strong>
+                            <span>時系列では給餌量の変更後も日々の産卵数が同じレンジに収まっています。</span>
+                        </div>
+                        <div class="observation-insight">
+                            <span class="observation-insight-label">天気との関係</span>
+                            <strong>天気別の平均差は限定的</strong>
+                            <span>天気アイコンと平均値を並べ、強い差があるかを確認しやすくしました。</span>
+                        </div>
+                    </div>
+
+                    <div class="observation-summary-grid">
+                        {% for summary in observation_summary.feed_summaries %}
+                            <div class="observation-metric">
+                                <span>{{ summary.feed_weight }}g</span>
+                                <strong>{{ summary.record_count }}件</strong>
+                                <dl>
+                                    <dt>平均産卵数</dt>
+                                    <dd>{{ summary.average_eggs }}個</dd>
+                                    <dt>平均産卵率</dt>
+                                    <dd>{{ summary.average_laying_rate }}%</dd>
+                                    <dt>期間</dt>
+                                    <dd>{{ summary.min_date }} - {{ summary.max_date }}</dd>
+                                </dl>
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    <div id="feed-vs-egg-chart"
+                         class="observation-chart"
+                         data-feed-data='{{ feed_vs_egg }}'></div>
+                </section>
             </div>
 
-            <!-- Feed vs Egg Chart -->
             <div class="col-12">
-                <div class="card shadow-sm border-0">
-                    <div class="card-header bg-white pt-3 pb-2">
-                        <h2 class="h6 mb-0 text-muted text-uppercase fw-semibold">
-                            <i class="fas fa-chart-line me-1"></i>餌の量と卵生産量の推移
-                        </h2>
+                <section class="observation-panel">
+                    <div class="observation-section-header">
+                        <div>
+                            <h2>天気別の産卵傾向</h2>
+                            <p>天気ごとの件数、平均産卵数、平均産卵率を同じ単位で比較します。</p>
+                        </div>
                     </div>
-                    <div class="card-body">
-                        <div id="feed-vs-egg-chart" data-feed-data='{{ feed_vs_egg }}'></div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Feed Group Laying Rate -->
-            <div class="col-12">
-                <h2 class="h5 mb-3">
-                    <i class="fas fa-table me-1 text-secondary"></i>フィードグループ別の産卵率推移
-                </h2>
-                <div class="row row-cols-1 row-cols-lg-2 g-3">
-                    {% for group in feed_group_laying_rate %}
-                        <div class="col">
-                            <div class="card shadow-sm border-0 h-100">
-                                <div class="card-header bg-white pt-3 pb-2 d-flex align-items-center gap-2">
-                                    <i class="fas fa-layer-group text-secondary"></i>
-                                    <h3 class="h6 mb-0">{{ group.feed_group }}</h3>
+                    <div class="observation-weather-grid">
+                        {% for weather in observation_summary.weather_summaries %}
+                            <div class="observation-weather-card">
+                                {% with 'soil_analysis/images/weather/svg/'|add:weather.weather_code|add:'.svg' as weather_svg_path %}
+                                    <img src="{% static weather_svg_path %}" width="32" height="32" alt="{{ weather.weather_name }}">
+                                {% endwith %}
+                                <div>
+                                    <strong>{{ weather.weather_name }}</strong>
+                                    <span>{{ weather.record_count }}件</span>
                                 </div>
-                                <div class="card-body p-0">
-                                    <table class="table table-striped table-hover table-sm mb-0">
-                                        <thead class="table-light">
+                                <dl>
+                                    <dt>平均産卵数</dt>
+                                    <dd>{{ weather.average_eggs }}個</dd>
+                                    <dt>平均産卵率</dt>
+                                    <dd>{{ weather.average_laying_rate }}%</dd>
+                                </dl>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </section>
+            </div>
+
+            <div class="col-12">
+                <section class="observation-panel">
+                    <div class="observation-section-header">
+                        <div>
+                            <h2>フィードグループ別の産卵率推移</h2>
+                            <p>日付、天気、産卵率を横に追えるように、グループごとに表を分けています。</p>
+                        </div>
+                    </div>
+                    <div class="observation-table-grid">
+                        {% for group in feed_group_laying_rate %}
+                            <article class="observation-table-card">
+                                <h3>{{ group.feed_group }}</h3>
+                                <div class="observation-table-scroll">
+                                    <table class="table table-sm mb-0">
+                                        <thead>
                                         <tr>
-                                            <th scope="col" class="ps-3">日付</th>
+                                            <th scope="col">日付</th>
                                             <th scope="col">天気</th>
                                             <th scope="col">産卵率</th>
                                         </tr>
@@ -250,26 +312,26 @@
                                         <tbody>
                                         {% for item in group.data %}
                                             <tr>
-                                                <td class="ps-3 text-muted small">{{ item.date }}</td>
+                                                <td>{{ item.date }}</td>
                                                 <td>
                                                     {% if item.weather_code %}
                                                         {% with 'soil_analysis/images/weather/svg/'|add:item.weather_code|add:'.svg' as weather_svg_path %}
-                                                            <img src="{% static weather_svg_path %}" width="24" alt="{{ item.weather_code }}">
+                                                            <img src="{% static weather_svg_path %}" width="24" height="24" alt="{{ item.weather_code }}">
                                                         {% endwith %}
                                                     {% else %}
                                                         <span class="text-muted">-</span>
                                                     {% endif %}
                                                 </td>
-                                                <td class="fw-semibold">{{ item.laying_rate }}</td>
+                                                <td><strong>{{ item.laying_rate }}%</strong></td>
                                             </tr>
                                         {% endfor %}
                                         </tbody>
                                     </table>
                                 </div>
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
+                            </article>
+                        {% endfor %}
+                    </div>
+                </section>
             </div>
         </div>
     </div>

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -294,45 +294,56 @@
                 <section class="observation-panel">
                     <div class="observation-section-header">
                         <div>
-                            <h2>フィードグループ別の産卵率推移</h2>
-                            <p>日付、天気、産卵率を横に追えるように、グループごとに表を分けています。</p>
+                            <h2>産卵率の時系列推移</h2>
+                            <p>日付順のまま、フィードグループで必要な行だけを絞り込めます。</p>
                         </div>
                     </div>
-                    <div class="observation-table-grid">
-                        {% for group in feed_group_laying_rate %}
-                            <article class="observation-table-card">
-                                <h3>{{ group.feed_group }}</h3>
-                                <div class="observation-table-scroll">
-                                    <table class="table table-sm mb-0">
-                                        <thead>
-                                        <tr>
-                                            <th scope="col">日付</th>
-                                            <th scope="col">天気</th>
-                                            <th scope="col">産卵率</th>
-                                        </tr>
-                                        </thead>
-                                        <tbody>
-                                        {% for item in group.data %}
-                                            <tr>
-                                                <td>{{ item.date }}</td>
-                                                <td>
-                                                    {% if item.weather_code %}
-                                                        {% with 'soil_analysis/images/weather/svg/'|add:item.weather_code|add:'.svg' as weather_svg_path %}
-                                                            <img src="{% static weather_svg_path %}" width="24" height="24" alt="{{ item.weather_code }}">
-                                                        {% endwith %}
-                                                    {% else %}
-                                                        <span class="text-muted">-</span>
-                                                    {% endif %}
-                                                </td>
-                                                <td><strong>{{ item.laying_rate }}%</strong></td>
-                                            </tr>
-                                        {% endfor %}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </article>
-                        {% endfor %}
-                    </div>
+                    <article class="observation-table-card">
+                        <div class="observation-table-filter" aria-label="フィードグループ絞り込み">
+                            <button type="button"
+                                    class="btn btn-primary btn-sm observation-feed-filter active"
+                                    data-feed-group="all">
+                                すべて
+                            </button>
+                            {% for feed_group in feed_group_laying_rate.feed_groups %}
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-sm observation-feed-filter"
+                                        data-feed-group="{{ feed_group }}">
+                                    {{ feed_group }}
+                                </button>
+                            {% endfor %}
+                        </div>
+                        <div class="observation-table-scroll">
+                            <table class="table table-sm mb-0">
+                                <thead>
+                                <tr>
+                                    <th scope="col">日付</th>
+                                    <th scope="col">フィードグループ</th>
+                                    <th scope="col">天気</th>
+                                    <th scope="col">産卵率</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for item in feed_group_laying_rate.records %}
+                                    <tr data-feed-group="{{ item.feed_group }}">
+                                        <td>{{ item.date }}</td>
+                                        <td>{{ item.feed_group }}</td>
+                                        <td>
+                                            {% if item.weather_code %}
+                                                {% with 'soil_analysis/images/weather/svg/'|add:item.weather_code|add:'.svg' as weather_svg_path %}
+                                                    <img src="{% static weather_svg_path %}" width="24" height="24" alt="{{ item.weather_code }}">
+                                                {% endwith %}
+                                            {% else %}
+                                                <span class="text-muted">-</span>
+                                            {% endif %}
+                                        </td>
+                                        <td><strong>{{ item.laying_rate }}%</strong></td>
+                                    </tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </article>
                 </section>
             </div>
         </div>
@@ -349,4 +360,5 @@
     </script>
     <script src="{% static 'taxonomy/js/livestock_distribution.js' %}"></script>
     <script src="{% static 'taxonomy/js/feed_vs_egg_chart.js' %}"></script>
+    <script src="{% static 'taxonomy/js/observation_laying_rate_table.js' %}"></script>
 {% endblock %}

--- a/taxonomy/templates/taxonomy/observation.html
+++ b/taxonomy/templates/taxonomy/observation.html
@@ -69,12 +69,14 @@
                                         <i class="fas fa-download me-1"></i>e-Stat畜産統計データを取得
                                     </button>
                                 {% else %}
-                                    <button type="button" class="btn btn-primary" disabled>
-                                        <i class="fas fa-download me-1"></i>e-Stat畜産統計データを取得
-                                    </button>
-                                    <p class="small text-muted mt-2 mb-0">
-                                        管理者権限が必要なため、データ取得ボタンは無効化されています。
-                                    </p>
+                                    <div class="d-flex flex-wrap align-items-center gap-2">
+                                        <button type="button" class="btn btn-primary" disabled>
+                                            <i class="fas fa-download me-1"></i>e-Stat畜産統計データを取得
+                                        </button>
+                                        <span class="small text-muted">
+                                            管理者権限が必要なため、データ取得ボタンは無効化されています。
+                                        </span>
+                                    </div>
                                 {% endif %}
                             </div>
                         </form>

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -636,8 +636,11 @@ class LivestockDistributionStaticAssetTest(SimpleTestCase):
         )
         script = script_path.read_text(encoding="utf-8")
 
-        self.assertIn("線: 産卵率 / 下段色: 給餌量 / 下段文字: 天気", script)
+        self.assertIn("線: 産卵率 / 点線: 二次近似 / 下段色: 給餌量 / 下段文字: 天気", script)
         self.assertIn("feed-marker", script)
+        self.assertIn("buildQuadraticTrendPoints", script)
+        self.assertIn("quadratic-trend-line", script)
+        self.assertIn('stroke-dasharray", "5 5"', script)
         self.assertNotIn("egg-bar", script)
         self.assertNotIn("feed-band", script)
 

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -183,7 +183,21 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "625g")
         self.assertContains(response, "晴")
         self.assertContains(response, "曇")
-        self.assertContains(response, "フィードグループ別の産卵率推移")
+        self.assertContains(response, "産卵率の時系列推移")
+        self.assertContains(
+            response, "日付順のまま、フィードグループで必要な行だけを絞り込めます。"
+        )
+        self.assertContains(response, "observation-feed-filter")
+        self.assertContains(response, "フィードグループ")
+        self.assertContains(response, "taxonomy/js/observation_laying_rate_table.js")
+        self.assertEqual(
+            len(response.context["feed_group_laying_rate"]["records"]),
+            3,
+        )
+        self.assertEqual(
+            response.context["feed_group_laying_rate"]["records"][0]["date"],
+            "2017-06-14",
+        )
         self.assertEqual(response.context["observation_summary"]["record_count"], 3)
         self.assertEqual(
             response.context["observation_summary"]["feed_summaries"][0]["feed_weight"],
@@ -620,6 +634,27 @@ class TaxonomyIndexViewTest(TestCase):
 
 
 class LivestockDistributionStaticAssetTest(SimpleTestCase):
+    def test_observation_laying_rate_table_js_filters_rows_by_feed_group(self):
+        """
+        シナリオ:
+        - 入力: 産卵率時系列テーブル用のJavaScriptファイル。
+        - 処理: 静的ファイルの内容を読み込む。
+        - 期待値: フィードグループのボタン選択でテーブル行を絞り込む処理があること。
+        """
+        script_path = (
+            Path(__file__).resolve().parents[1]
+            / "static"
+            / "taxonomy"
+            / "js"
+            / "observation_laying_rate_table.js"
+        )
+        script = script_path.read_text(encoding="utf-8")
+
+        self.assertIn("observation-feed-filter", script)
+        self.assertIn('selectedFeedGroup === "all"', script)
+        self.assertIn("row.dataset.feedGroup === selectedFeedGroup", script)
+        self.assertIn("d-none", script)
+
     def test_feed_vs_egg_chart_focuses_on_laying_rate_without_egg_bars(self):
         """
         シナリオ:
@@ -636,7 +671,9 @@ class LivestockDistributionStaticAssetTest(SimpleTestCase):
         )
         script = script_path.read_text(encoding="utf-8")
 
-        self.assertIn("線: 産卵率 / 点線: 二次近似 / 下段色: 給餌量 / 下段文字: 天気", script)
+        self.assertIn(
+            "線: 産卵率 / 点線: 二次近似 / 下段色: 給餌量 / 下段文字: 天気", script
+        )
         self.assertIn("feed-marker", script)
         self.assertIn("buildQuadraticTrendPoints", script)
         self.assertIn("quadratic-trend-line", script)

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -1,5 +1,6 @@
 import shutil
 import tempfile
+from datetime import date
 from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -29,6 +30,10 @@ from taxonomy.models import (
     LLMTaxonomyCandidateGenerationJob,
     LivestockDistributionDataset,
     NaturalMonument,
+    EggLedger,
+    FeedGroup,
+    HenGroup,
+    JmaWeatherCode,
     Phylum,
     Species,
 )
@@ -157,6 +162,33 @@ class TaxonomyIndexViewTest(TestCase):
         self.assertContains(response, "livestock-distribution-data")
         self.assertContains(response, "livestock-prefecture-map")
         self.assertContains(response, "e-Stat畜産統計データを取得")
+
+    def test_observation_page_displays_feed_and_weather_observation_summary(self):
+        """
+        シナリオ:
+        - 入力: 1250gと625gの給餌量、晴と曇の天気を含む産卵台帳。
+        - 処理: 鶏の観察グラフページを表示する。
+        - 期待値: 後半セクションに給餌量別・天気別の件数と平均値が表示されること。
+        """
+        self._create_egg_ledger_records()
+
+        response = self.client.get(reverse("txo:observation"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="/static/taxonomy/css/observation.css"')
+        self.assertContains(response, "餌の量と卵生産量の推移")
+        self.assertContains(response, "給餌量・産卵数・産卵率・天気で比較します。")
+        self.assertContains(response, "1250gは3件、625gは90件")
+        self.assertContains(response, "1250g")
+        self.assertContains(response, "625g")
+        self.assertContains(response, "晴")
+        self.assertContains(response, "曇")
+        self.assertContains(response, "フィードグループ別の産卵率推移")
+        self.assertEqual(response.context["observation_summary"]["record_count"], 3)
+        self.assertEqual(
+            response.context["observation_summary"]["feed_summaries"][0]["feed_weight"],
+            1250,
+        )
 
     def test_observation_page_displays_livestock_distribution_dashboard(self):
         """
@@ -544,6 +576,46 @@ class TaxonomyIndexViewTest(TestCase):
                 "該当なし - は推計せず秘匿・該当なしとして表示します。"
             ),
             is_active=is_active,
+        )
+
+    def _create_egg_ledger_records(self):
+        sunny = JmaWeatherCode.objects.create(
+            code="100",
+            summary_code="100",
+            image="100.svg",
+            name="晴",
+            name_en="CLEAR",
+        )
+        cloudy = JmaWeatherCode.objects.create(
+            code="200",
+            summary_code="200",
+            image="200.svg",
+            name="曇",
+            name_en="CLOUDY",
+        )
+        full_feed = FeedGroup.objects.create(name="通常給餌", weight=1250)
+        half_feed = FeedGroup.objects.create(name="半量給餌", weight=625)
+        hens = HenGroup.objects.create(name="第1鶏群", hen_count=5)
+        EggLedger.objects.create(
+            recorded_date=date(2017, 6, 14),
+            egg_count=4,
+            weather_code=sunny,
+            feed_group=full_feed,
+            hen_group=hens,
+        )
+        EggLedger.objects.create(
+            recorded_date=date(2017, 6, 15),
+            egg_count=3,
+            weather_code=cloudy,
+            feed_group=half_feed,
+            hen_group=hens,
+        )
+        EggLedger.objects.create(
+            recorded_date=date(2017, 6, 16),
+            egg_count=4,
+            weather_code=sunny,
+            feed_group=half_feed,
+            hen_group=hens,
         )
 
 

--- a/taxonomy/tests/test_views.py
+++ b/taxonomy/tests/test_views.py
@@ -176,8 +176,8 @@ class TaxonomyIndexViewTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'href="/static/taxonomy/css/observation.css"')
-        self.assertContains(response, "餌の量と卵生産量の推移")
-        self.assertContains(response, "給餌量・産卵数・産卵率・天気で比較します。")
+        self.assertContains(response, "餌の量と産卵率の推移")
+        self.assertContains(response, "給餌量・産卵率・天気で比較します。")
         self.assertContains(response, "1250gは3件、625gは90件")
         self.assertContains(response, "1250g")
         self.assertContains(response, "625g")
@@ -620,6 +620,27 @@ class TaxonomyIndexViewTest(TestCase):
 
 
 class LivestockDistributionStaticAssetTest(SimpleTestCase):
+    def test_feed_vs_egg_chart_focuses_on_laying_rate_without_egg_bars(self):
+        """
+        シナリオ:
+        - 入力: 給餌量・産卵率チャート用のJavaScriptファイル。
+        - 処理: 静的ファイルの内容を読み込む。
+        - 期待値: 産卵数の棒グラフと給餌量の全面背景帯を描画せず、下段マーカーで給餌量を示すこと。
+        """
+        script_path = (
+            Path(__file__).resolve().parents[1]
+            / "static"
+            / "taxonomy"
+            / "js"
+            / "feed_vs_egg_chart.js"
+        )
+        script = script_path.read_text(encoding="utf-8")
+
+        self.assertIn("線: 産卵率 / 下段色: 給餌量 / 下段文字: 天気", script)
+        self.assertIn("feed-marker", script)
+        self.assertNotIn("egg-bar", script)
+        self.assertNotIn("feed-band", script)
+
     def test_livestock_distribution_js_labels_comparison_bar_clearly(self):
         """
         シナリオ:

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -163,7 +163,7 @@ class ObservationView(TemplateView):
             ChickenObservationsRepository.get_observation_summary()
         )
 
-        # Feed Group別の産卵率データを取得
+        # 産卵率の時系列テーブルデータを取得
         context["feed_group_laying_rate"] = (
             ChickenObservationsRepository.get_feed_group_laying_rates_table()
         )

--- a/taxonomy/views.py
+++ b/taxonomy/views.py
@@ -159,6 +159,9 @@ class ObservationView(TemplateView):
         # 餌の投入量と卵生産量データを取得
         feed_vs_egg = ChickenObservationsRepository.get_feed_vs_egg_production()
         context["feed_vs_egg"] = mark_safe(json.dumps(feed_vs_egg, ensure_ascii=False))
+        context["observation_summary"] = (
+            ChickenObservationsRepository.get_observation_summary()
+        )
 
         # Feed Group別の産卵率データを取得
         context["feed_group_laying_rate"] = (


### PR DESCRIPTION
## Summary
鶏の観察ページ後半を、給餌量・産卵数・産卵率・天気の関係が読み取りやすい構成へ更新しました。

- `ChickenObservationsRepository` に給餌量別・天気別の表示用集計を追加
- 二軸グラフを、給餌量背景・産卵数棒・産卵率線・天気表示を組み合わせたD3グラフへ刷新
- 観察データの要点、給餌量別サマリー、天気別サマリー、フィードグループ別テーブルのレイアウトを追加
- 後半セクション用CSSを追加し、PC/スマホで崩れにくいグリッドと表スクロールを設定
- 観察サマリー表示のViewテストを追加

## 目検による動作確認手順
- [x] `/taxonomy/observation/` を開き、餌の量と卵生産量の推移セクションに要点・サマリー・D3グラフが表示されること
- [x] 天気別の産卵傾向とフィードグループ別の産卵率推移テーブルがPC/スマホ幅で崩れないこと
- [x] D3グラフの点にホバーしたとき、日付・給餌量・産卵数・産卵率・天気が確認できること

## 自動テストでカバーできた範囲
- `black taxonomy/domain/repository/chicken_observations.py taxonomy/views.py taxonomy/tests/test_views.py`
- `python manage.py test taxonomy.tests.test_views.TaxonomyIndexViewTest --noinput`
- `python manage.py test taxonomy --noinput`

## 関連Issue
Closes #866
https://github.com/duri0214/portfolio/issues/866
