### PR TITLE
#897 Bookman を HOME に追加

### DIFF
--- a/home/templates/home/ai_agent/index.html
+++ b/home/templates/home/ai_agent/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">AI Agent プロジェクト</h1>
                 <p class="text-muted text-center">2025年、ターンベースのAIエージェントシミュレーションを作成</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'agt:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">AI_AGENTを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/ai_agent/index.html
+++ b/home/templates/home/ai_agent/index.html
@@ -32,11 +32,9 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
-                    <li><a href="https://qiita.com/YoshitakaOkada/items/05e8f4beb43586c22514" target="_blank">Qiita記事：「AI
-                        Agent を試作する」</a></li>
-                    <li><a href="{% url 'agt:index' %}" target="_blank">作成したWebアプリ『AI_AGENT』</a></li>
+                    <li><a href="https://qiita.com/YoshitakaOkada/items/05e8f4beb43586c22514" target="_blank" rel="noopener noreferrer">Qiita記事：「AI Agent を試作する」</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/ai_agent/index.html
+++ b/home/templates/home/ai_agent/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2025年、ターンベースのAIエージェントシミュレーションを作成</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'agt:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">AI AGENTを開く</a>
+                    <a href="{% url 'agt:index' %}" class="btn btn-primary">AI AGENTを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/ai_agent/index.html
+++ b/home/templates/home/ai_agent/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2025年、ターンベースのAIエージェントシミュレーションを作成</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'agt:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">AI_AGENTを開く</a>
+                    <a href="{% url 'agt:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">AI AGENTを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/bank/index.html
+++ b/home/templates/home/bank/index.html
@@ -46,13 +46,6 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
-                <ul>
-                    <li><a href="{% url 'bank:index' %}" target="_blank">BANK（Webアプリ）</a></li>
-                </ul>
-            </section>
-
-            <section class="py-3">
                 <h2>設計方針</h2>
                 <ul>
                     <li>銀行ドメイン単位でRaw CSVフォーマット準拠のテーブルを持つ</li>

--- a/home/templates/home/bank/index.html
+++ b/home/templates/home/bank/index.html
@@ -13,6 +13,13 @@
             </header>
 
             <section class="py-3">
+                <div class="text-center">
+                    <img src="{% static 'home/images/no-image.png' %}" alt="銀行CSV分析基盤"
+                         class="img-fluid rounded shadow">
+                </div>
+            </section>
+
+            <section class="py-3">
                 <h2>概要</h2>
                 <p>
                     現在、銀行ごとに異なるCSVフォーマットで提供される取引明細を、毎月手動でExcelに取り込み加工して分析している。

--- a/home/templates/home/bank/index.html
+++ b/home/templates/home/bank/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">銀行CSV分析基盤</h1>
                 <p class="text-muted text-center">銀行ごとの月次CSVを取り込み資金分析を行う基盤構築</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'bank:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">BANKを開く</a>
                 </div>
             </header>
 
@@ -17,6 +18,31 @@
                     現在、銀行ごとに異なるCSVフォーマットで提供される取引明細を、毎月手動でExcelに取り込み加工して分析している。
                     本プロジェクトでは、これらをDjangoベースのポートフォリオ基盤に移植し、長期的に拡張可能な資金分析基盤を構築することを目指している。
                 </p>
+                <p>
+                    まずは銀行口座を登録し、入出金 CSV を取り込むところから始めます。
+                    取り込んだデータを生活費ルールやカテゴリ別の月次集計へつなげ、銀行ごとの形式差を利用者が意識せずに分析できる形を目指しています。
+                </p>
+            </section>
+
+            <section class="py-3">
+                <h2>できること</h2>
+                <ul>
+                    <li>銀行マスタと分析対象口座の登録</li>
+                    <li>MUFG 普通預金の Eco 通帳 CSV のアップロード</li>
+                    <li>生活費取引のルールベース分析</li>
+                    <li>カテゴリ別・月次のクロス集計</li>
+                    <li>銀行固有の Raw CSV を保持したまま、分析処理を追加できる拡張構成</li>
+                </ul>
+            </section>
+
+            <section class="py-3">
+                <h2>使い方</h2>
+                <ol>
+                    <li>分析対象の銀行と口座を登録する</li>
+                    <li>銀行から取得した CSV をアップロードする</li>
+                    <li>生活費分析またはカテゴリ別月次集計を選ぶ</li>
+                    <li>対象口座と期間を指定して、支出の傾向を確認する</li>
+                </ol>
             </section>
 
             <section class="py-3">
@@ -32,6 +58,7 @@
                     <li>銀行ドメイン単位でRaw CSVフォーマット準拠のテーブルを持つ</li>
                     <li>中間変換テーブルは持たず、集計・分析は View / Query / VO で吸収する</li>
                     <li>銀行マスタを持ち、銀行ごとのドメインを管理する</li>
+                    <li>Raw データを残し、銀行ごとの CSV 形式や分析ルールを後から追加できるようにする</li>
                 </ul>
             </section>
 

--- a/home/templates/home/bank/index.html
+++ b/home/templates/home/bank/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">銀行ごとの月次CSVを取り込み資金分析を行う基盤構築</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'bank:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">BANKを開く</a>
+                    <a href="{% url 'bank:index' %}" class="btn btn-primary">BANKを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/bookman/index.html
+++ b/home/templates/home/bookman/index.html
@@ -123,9 +123,8 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
-                    <li><a href="https://bookman.henojiya.net/" target="_blank" rel="noopener noreferrer">Bookman（Webアプリ）</a></li>
                     <li><a href="https://github.com/duri0214/bookman_nextjs" target="_blank" rel="noopener noreferrer">Bookman frontend（GitHub）</a></li>
                     <li><a href="https://github.com/duri0214/bookman_backend" target="_blank" rel="noopener noreferrer">Bookman backend（GitHub）</a></li>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/e74555b56e3903708300" target="_blank" rel="noopener noreferrer">Bookman をサブドメインで本番公開する手順</a></li>

--- a/home/templates/home/bookman/index.html
+++ b/home/templates/home/bookman/index.html
@@ -5,7 +5,7 @@
         <article class="my-5">
             <header>
                 <h1 class="display-4 text-center">図書館業務システム Bookman</h1>
-                <p class="text-muted text-center">図書館業務を扱うWebアプリケーション</p>
+                <p class="text-muted text-center">蔵書・支店・貸出・予約を、ひとつの業務フローにつなぐ</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
                     <a href="https://bookman.henojiya.net/" class="btn btn-primary" target="_blank"
@@ -14,16 +14,121 @@
             </header>
 
             <section class="py-3">
+                <div class="text-center">
+                    <img src="https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/94562/da4733c0-e4d1-4bdf-b534-15976392824a.png"
+                         alt="図書カードをモチーフにした Bookman のホーム画面"
+                         class="img-fluid rounded shadow">
+                </div>
+            </section>
+
+            <section class="py-3">
                 <h2>概要</h2>
                 <p>
-                    図書の所蔵・貸出・予約・利用者管理など、図書館業務を扱うWebアプリケーションです。
+                    Bookman は、図書館の現場で発生する「どの本が、どの支店に、何冊あるか」から、
+                    「誰に貸し出し、返却後に誰の予約へ回すか」までを扱う図書館業務システムです。
+                    書籍マスタだけを管理するのではなく、自治体・支店・職員・利用者の関係を持たせ、
+                    日々のカウンター業務を一つの画面で追えるようにしています。
                 </p>
+                <p>
+                    フロントエンドは Next.js / React / MUI、バックエンドは Django REST Framework で構成しています。
+                    画面と API を分離しながら、図書館員が実際に操作する業務画面として仕上げています。
+                </p>
+            </section>
+
+            <section class="py-3">
+                <h2>できること</h2>
+                <div class="row row-cols-1 row-cols-md-2 g-3">
+                    <div class="col">
+                        <div class="border rounded p-3 h-100">
+                            <h3 class="h5">自治体・支店・蔵書を管理</h3>
+                            <p class="mb-0">
+                                自治体と支店を分けて管理し、書籍ごとの自治体全体の所蔵数と支店別の所蔵数を確認できます。
+                                支店間の蔵書移動では、移動元・移動先・冊数を指定し、在庫不足や自治体をまたぐ誤操作も防ぎます。
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded p-3 h-100">
+                            <h3 class="h5">書籍を CSV でまとめて登録</h3>
+                            <p class="mb-0">
+                                書籍管理画面から CSV を取り込み、タイトル、ISBN、著者、カテゴリ、支店、初期所蔵数を登録できます。
+                                登録件数と行ごとのエラーを確認できるため、大量の書籍を一件ずつ入力する手間を減らせます。
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded p-3 h-100">
+                            <h3 class="h5">貸出・返却と予約・取り置き</h3>
+                            <p class="mb-0">
+                                利用者、支店別所蔵、対応職員、返却予定日を選んで貸出を登録します。
+                                貸出可能冊数が足りない本には予約を入れ、返却された本は予約順に取り置きへ回せます。
+                                貸出上限超過や二重貸出などの業務エラーも画面に表示します。
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded p-3 h-100">
+                            <h3 class="h5">利用者と職員を業務につなぐ</h3>
+                            <p class="mb-0">
+                                利用者の連絡先や貸出上限数を管理し、貸出・予約画面の選択肢へすぐ反映します。
+                                職員 role に応じて、個人・支店共有・管理者共有の保存条件を制御できます。
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded p-3 h-100">
+                            <h3 class="h5">休館日を考慮した返却期限</h3>
+                            <p class="mb-0">
+                                支店ごとの休館日を登録でき、返却予定日が休館日に当たる場合は、調整前の日付、調整後の日付、理由を表示します。
+                                カレンダーを見ながら別途計算する必要がありません。
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded p-3 h-100">
+                            <h3 class="h5">ダッシュボードで全体を把握</h3>
+                            <p class="mb-0">
+                                自治体全体の貸出中件数、予約・期限注意件数、支店別所蔵数を確認できます。
+                                取り置き中の予約は通知から貸出画面へ移動でき、次に対応すべき業務へすぐ進めます。
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="py-3">
+                <h2>カウンター業務の流れ</h2>
+                <ol>
+                    <li>自治体と支店を選び、対象の書籍と支店別所蔵を確認する</li>
+                    <li>利用者と対応職員を選び、返却予定日を確認して貸出する</li>
+                    <li>貸出できない本は、その場で予約として登録する</li>
+                    <li>返却された本に予約があれば、予約順に取り置きへ回す</li>
+                    <li>ダッシュボードと通知から、次に対応すべき貸出・予約を確認する</li>
+                </ol>
+                <p>
+                    「所蔵数を確認する」「貸出する」「返却された本を次の利用者へ回す」という流れを、
+                    それぞれ別の台帳で管理せずに済むことが Bookman のポイントです。
+                </p>
+            </section>
+
+            <section class="py-3">
+                <h2>設計のポイント</h2>
+                <ul>
+                    <li>Next.js の画面と Django REST Framework の API を分離し、Next.js の Route Handler を API proxy として利用</li>
+                    <li>画面だけを確認したいときは mock data、実データで確認したいときは backend API へ切り替え可能</li>
+                    <li>貸出、返却、予約、取り置き、支店間移動などの業務ルールは backend 側で検証</li>
+                    <li>自治体スコープを持たせ、別自治体の支店・所蔵・貸出・予約を誤操作しない構成</li>
+                    <li>権限のない操作も画面から隠さず、disabled 表示と理由の説明を残す</li>
+                </ul>
             </section>
 
             <section class="py-3">
                 <h2>リンク</h2>
                 <ul>
                     <li><a href="https://bookman.henojiya.net/" target="_blank" rel="noopener noreferrer">Bookman（Webアプリ）</a></li>
+                    <li><a href="https://github.com/duri0214/bookman_nextjs" target="_blank" rel="noopener noreferrer">Bookman frontend（GitHub）</a></li>
+                    <li><a href="https://github.com/duri0214/bookman_backend" target="_blank" rel="noopener noreferrer">Bookman backend（GitHub）</a></li>
+                    <li><a href="https://qiita.com/YoshitakaOkada/items/e74555b56e3903708300" target="_blank" rel="noopener noreferrer">Bookman をサブドメインで本番公開する手順</a></li>
                 </ul>
             </section>
         </article>

--- a/home/templates/home/bookman/index.html
+++ b/home/templates/home/bookman/index.html
@@ -1,0 +1,31 @@
+{% extends "home/base.html" %}
+{% load static %}
+{% block content %}
+    <div class="container">
+        <article class="my-5">
+            <header>
+                <h1 class="display-4 text-center">図書館業務システム Bookman</h1>
+                <p class="text-muted text-center">図書館業務を扱うWebアプリケーション</p>
+                <div class="d-flex justify-content-center gap-2 my-4">
+                    <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="https://bookman.henojiya.net/" class="btn btn-primary" target="_blank"
+                       rel="noopener noreferrer">Bookmanを開く</a>
+                </div>
+            </header>
+
+            <section class="py-3">
+                <h2>概要</h2>
+                <p>
+                    図書の所蔵・貸出・予約・利用者管理など、図書館業務を扱うWebアプリケーションです。
+                </p>
+            </section>
+
+            <section class="py-3">
+                <h2>リンク</h2>
+                <ul>
+                    <li><a href="https://bookman.henojiya.net/" target="_blank" rel="noopener noreferrer">Bookman（Webアプリ）</a></li>
+                </ul>
+            </section>
+        </article>
+    </div>
+{% endblock %}

--- a/home/templates/home/bookman/index.html
+++ b/home/templates/home/bookman/index.html
@@ -8,8 +8,7 @@
                 <p class="text-muted text-center">蔵書・支店・貸出・予約を、ひとつの業務フローにつなぐ</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="https://bookman.henojiya.net/" class="btn btn-primary" target="_blank"
-                       rel="noopener noreferrer">Bookmanを開く</a>
+                    <a href="https://bookman.henojiya.net/" class="btn btn-primary">Bookmanを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/gmarker/index.html
+++ b/home/templates/home/gmarker/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">GoogleMapsにピンをさす</h1>
                 <p class="text-muted text-center">2015年、GoogleMapsを使ったAPI連携の学習を目的に開発</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'mrk:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GMarkerを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/gmarker/index.html
+++ b/home/templates/home/gmarker/index.html
@@ -29,11 +29,10 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/df9518520b39a5f140c9" target="_blank">GoogleMapsとスクレイピングを用いた地図ツール作成メモ</a>
                     </li>
-                    <li><a href="{% url 'mrk:index' %}" target="_blank">作成したWebアプリ『GMarker』</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/gmarker/index.html
+++ b/home/templates/home/gmarker/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2015年、GoogleMapsを使ったAPI連携の学習を目的に開発</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'mrk:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GMarkerを開く</a>
+                    <a href="{% url 'mrk:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GMARKERを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/gmarker/index.html
+++ b/home/templates/home/gmarker/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2015年、GoogleMapsを使ったAPI連携の学習を目的に開発</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'mrk:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">GMARKERを開く</a>
+                    <a href="{% url 'mrk:index' %}" class="btn btn-primary">GMARKERを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/hospital/index.html
+++ b/home/templates/home/hospital/index.html
@@ -7,8 +7,9 @@
             <header>
                 <h1 class="display-4 text-center">不在者投票事務用の転記ツール</h1>
                 <p class="text-muted text-center">2015年当時、友人の残業時間を減らすために作成されたツール</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'hsp:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">転記TOOLを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/hospital/index.html
+++ b/home/templates/home/hospital/index.html
@@ -28,13 +28,12 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/8100db539b0359aa8641" target="_blank">【ExcelVBA】病院事務を改善したときのメモ</a>
                     </li>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/6e33c54cb7def867482a" target="_blank">昔つくった病院事務VBAのWeb版をつくろう！</a>
                     </li>
-                    <li><a href="{% url 'hsp:index' %}" target="_blank">転記TOOL</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/hospital/index.html
+++ b/home/templates/home/hospital/index.html
@@ -9,7 +9,7 @@
                 <p class="text-muted text-center">2015年当時、友人の残業時間を減らすために作成されたツール</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'hsp:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">転記TOOLを開く</a>
+                    <a href="{% url 'hsp:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">HOSPITALを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/hospital/index.html
+++ b/home/templates/home/hospital/index.html
@@ -9,7 +9,7 @@
                 <p class="text-muted text-center">2015年当時、友人の残業時間を減らすために作成されたツール</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'hsp:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">HOSPITALを開く</a>
+                    <a href="{% url 'hsp:index' %}" class="btn btn-primary">HOSPITALを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -303,7 +303,7 @@
                     <div class="card-body">
                         <h5 class="card-title">図書館業務システム Bookman</h5>
                         <p class="card-text small text-secondary">
-                            図書の所蔵・貸出・予約・利用者管理など、図書館業務を扱うWebアプリケーション。</p>
+                            支店ごとの所蔵管理から書籍CSV登録、貸出・返却、予約・取り置き、利用者管理までを一つの画面で扱える図書館業務システム。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_bookman' %}" class="btn btn-primary btn-sm">詳細を見る</a>

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -292,6 +292,24 @@
                     </div>
                 </div>
             </div>
+
+            <div class="col">
+                <div class="card h-100 shadow-sm border-0">
+                    <figure class="card-img-top mb-0">
+                        <img src="{% static 'home/images/no-image.png' %}" alt="図書館業務システム Bookman"
+                             class="img-fluid rounded-top">
+                        <figcaption class="cat-name bg-info text-white px-2 py-1">図書館</figcaption>
+                    </figure>
+                    <div class="card-body">
+                        <h5 class="card-title">図書館業務システム Bookman</h5>
+                        <p class="card-text small text-secondary">
+                            図書の所蔵・貸出・予約・利用者管理など、図書館業務を扱うWebアプリケーション。</p>
+                    </div>
+                    <div class="card-footer bg-white border-top-0">
+                        <a href="{% url 'home:about_bookman' %}" class="btn btn-primary btn-sm">詳細を見る</a>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -30,8 +30,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">不在者投票事務用の転記</h5>
-                        <p class="card-text small text-secondary">
-                            2015年当時、友人の残業時間を減らすために転記ツールを作成。病棟別の不在者投票データを事務処理簿等に自動転記し、大きく残業時間を削減。成果物は6時間ほどで完成し、横展開できそうだと病院の注目を集めた。</p>
+                        <p class="card-text small text-secondary">2015年、友人の残業時間を減らすために開発。病棟別の不在者投票データを事務処理簿へ自動転記し、約6時間で完成。現場の作業時間削減と他病棟への展開につながった。現場で使える小さな自動化の効果を実感した最初の成果物。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_hospital' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -48,8 +47,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">圃場計測のレポーティング</h5>
-                        <p class="card-text small text-secondary">
-                            2023年当時、農業の調査をするため、一時的に静岡に移住し土壌分析のIT課題に取り組んだ。普段ITで扱うデータは誰かが集めたもので、実際にデータを収集するのは地道で大変な作業だと実感。雨の日も風の日も計測した</p>
+                        <p class="card-text small text-secondary">2023年、静岡で土壌分析に取り組み、圃場データの収集とレポート作成を支援。雨の日も風の日も計測し、現場でデータを集める難しさとIT活用の可能性を実感した。計測値を蓄積し、分析結果を共有する流れまでを見据えた。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_soil_analysis' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -66,9 +64,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">ベトナムの株価を分析する</h5>
-                        <p class="card-text small text-secondary">
-                            2019年当時、チャイナリスクを見据えてつぎの投資対象となりそうなベトナムについて調査し、名古屋市主催の「ベトナム
-                            ホーチミン 経済交流ミッション」に参加。訪問する直前、プレゼンテーションに作成した</p>
+                        <p class="card-text small text-secondary">2019年、チャイナリスクを見据えた投資先としてベトナムを調査。名古屋市の経済交流ミッションにも参加し、現地訪問前のプレゼンテーション作成と株価分析に取り組んだ。調査結果を整理し、投資判断の材料を可視化することを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_vietnam_research' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -85,8 +81,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">GoogleMapsにピンをさす</h5>
-                        <p class="card-text small text-secondary">
-                            2015年当時、ラーメン屋とか洋食などのワードでGoogleMapsにまとめてピンを打ち、さらに任意のピンだけに絞れるようなものを作れたら便利そうだなとおもったことからトライ。外部APIを初めて使ったツールとなった</p>
+                        <p class="card-text small text-secondary">2015年、飲食店などのキーワードでGoogle Mapsにピンをまとめて表示し、任意のピンだけに絞り込むツールを開発。初めて外部APIを使って作ったWebアプリ。地図上の大量の候補を整理し、必要な情報だけを見やすくすることを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_gmarker' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -103,8 +98,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">通販サイトの基礎機能</h5>
-                        <p class="card-text small text-secondary">
-                            2022年当時、ECサイトってやっぱり作れるようになっておいたほうがいいなと思ってトライしたもの。店員管理、商品管理、CSV登録機能、写真アップロード機能、カード決済など基本的なＥＣサイトの機能を実装した</p>
+                        <p class="card-text small text-secondary">2022年、ECサイト開発の基礎を身につけるために制作。店員・商品管理、CSV登録、写真アップロード、カード決済など、通販サイトに必要な一連の機能を実装した。管理画面から商品を登録し、購入までの流れを試せる構成にした。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_shopping' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -121,8 +115,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">倉庫のどこにいくつあるの？</h5>
-                        <p class="card-text small text-secondary">
-                            2016年当時、物流のオープンデータ活用コンテストがあった。そのころはまだAPIをまともに扱うWeb開発スキルがなくて、話を振ってもらったものの断念した。2023年ごろWebアプリを作る力もついてきてアプリとして結実させた</p>
+                        <p class="card-text small text-secondary">2016年の物流オープンデータ活用コンテストをきっかけに構想。2023年、Webアプリ開発の経験を活かし、倉庫のどこに何がいくつあるかを検索できる形にした。商品名や保管場所から在庫を探し、現場の確認作業を減らすことを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_rental_shop' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -139,8 +132,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">ニワトリとミミズの種を分類</h5>
-                        <p class="card-text small text-secondary">
-                            2017年に地方に移住して畑作業をするなかで、土壌の生物性に興味をもった。鶏とミミズの種類を調べ上げて登録すると分類の樹形図ができあがるようなアプリがあったらいいなと思って2023年につくることにした。応用すれば家系図も作れるだろう</p>
+                        <p class="card-text small text-secondary">2017年、畑作業を通じて土壌の生物に興味を持ち、ニワトリやミミズの種類を登録して分類樹形図を作るアプリを開発。応用すれば家系図にも使える。生物の関係を視覚的にたどれるようにし、データ構造を画面で確認できるようにした。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_taxonomy' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -157,8 +149,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">金融庁の有価証券報告書を分析</h5>
-                        <p class="card-text small text-secondary">2019年当時、金融の業務知識を総動員して "有価証券報告書"
-                            をpythonで取得するプログラムを作った（当初は単にダウンロード済みの有価証券報告書ファイルを処理するもの）。2023年頃にWebアプリ（API版）として移植したついでに、分析する機能をつけた</p>
+                        <p class="card-text small text-secondary">2019年、有価証券報告書を取得・処理するプログラムを開発。2023年にはWebアプリへ移植し、企業情報の検索や財務データの分析まで行えるツールに発展させた。書類の収集から分析までをブラウザで行い、金融情報を扱う実用的な形に近づけた。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_securities' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -175,9 +166,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">GPTチャット</h5>
-                        <p class="card-text small text-secondary">2024年当時、Gemini, ChatGPT4, gpt-image-1-mini,
-                            TextToSpeech, SpeechToText and
-                            RAG　といった一通りのLLMを実行する仕組みを作成した。さらにライブラリとして共通化したことによってどのアプリからでもgptに絡めることができるようになった</p>
+                        <p class="card-text small text-secondary">2024年、GeminiやChatGPTなど複数のLLM、画像生成、音声入出力、RAGを扱う仕組みを開発。共通ライブラリ化し、各アプリからLLMを利用できるようにした。モデルごとの違いを意識せず、アプリの機能としてAIを組み込める構成を目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_llm_chat' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -194,8 +183,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">AI-AGENTの試作</h5>
-                        <p class="card-text small text-secondary">
-                            2025年当時、会話型AIエージェントシステムを構築。複数のAIエージェントによる対話を実現し、ターン制管理で自然な会話を実現。ガードレール機能でユーザー入力の安全性を確保しながら、各エージェントが専門分野に基づいた応答を生成する。</p>
+                        <p class="card-text small text-secondary">2025年、複数のAIエージェントが役割分担して対話するシステムを構築。ターン制管理とガードレールで会話の流れと入力の安全性を制御し、専門的な応答を生成する。専門分野の異なるエージェントを組み合わせ、単独のチャットでは難しい応答を試した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_ai_agent' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -212,8 +200,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">日本の株価を分析する</h5>
-                        <p class="card-text small text-secondary">
-                            2025年当時、日本の株価を分析するための機能があればオモシロイと思った。現在は板シミュレーションしかおいていないが、そのうちrssでニュースを取得したりできるとよい仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章仮の文章</p>
+                        <p class="card-text small text-secondary">2025年、日本株の値動きを分析するアプリとして開発。現在は板情報の登録と売買シミュレーションを実装し、将来はRSSニュース取得などの機能追加を予定している。板情報を使った注文の流れを画面上で試せるため、株式売買の仕組みを学ぶ用途にも使える。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_jp_stocks' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -230,8 +217,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">東京都福祉事務所情報ポータル</h5>
-                        <p class="card-text small text-secondary">
-                            2025年当時、東京都内の福祉事務所の情報を一元管理し、利用者に提供するポータルサイト。空き状況を信号機表示で直感的に把握できます。都知事杯オープンデータ・ハッカソン2025で「障がい福祉サービス空き情報の見える化」をテーマに開発。</p>
+                        <p class="card-text small text-secondary">2025年、東京都内の福祉事務所と障がい福祉サービスの空き情報を見える化。信号機表示で空き状況を直感的に把握できるポータルをハッカソンで開発した。利用者が地域やサービスを比較しやすくし、必要な支援へ早くたどり着けることを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_welfare_services' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -248,8 +234,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">USAニュースを分析する</h5>
-                        <p class="card-text small text-secondary">
-                            2025年当時、米国株や政治動向のトレンドを素早く把握したいと感じ、主要ニュースサイトの記事タイトル・概要・公開日時などを自動取得する仕組みを構築。カテゴリ別に閲覧でき、経済・政策・テックの動きを短時間で追えるようにした。</p>
+                        <p class="card-text small text-secondary">2025年、米国株や政治動向を追うため、主要ニュースサイトの記事タイトル・概要・公開日時を自動取得。経済、政策、テックなどの最新トレンドを短時間で確認できる。ニュースを収集・分類する作業を自動化し、日々の情報収集を効率化することを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_usa_research' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -266,8 +251,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">国会議事録を分析する</h5>
-                        <p class="card-text small text-secondary">
-                            2026年当時、国会の膨大な議事録から必要な情報を効率的に検索し、AI（LLM）を用いて内容を要約・分析するシステム。RAG技術を活用し、正確な根拠に基づいた回答生成を目指す。</p>
+                        <p class="card-text small text-secondary">2026年、国会議事録から必要な発言を検索し、AI（LLM）で要約・分析するシステムを開発。RAGで根拠となる議事録を参照し、質問への回答生成を目指す。膨大な一次資料を読み解く負担を減らし、根拠を確認しながら政策テーマを調べられるようにする。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_kokkai' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -284,8 +268,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">銀行CSVを分析</h5>
-                        <p class="card-text small text-secondary">
-                            2026年当時、銀行ごとに異なるCSVフォーマットの取引明細を取り込み、資金分析を行う基盤。銀行別のRawデータをそのまま保持し、長期的に拡張可能な設計で横断的なレポート生成を目指す。</p>
+                        <p class="card-text small text-secondary">2026年、銀行ごとに異なるCSV取引明細を取り込み、資金の流れを分析する基盤を開発。Rawデータを保持しながら、銀行横断のレポートを生成できる設計にした。取り込んだデータを分析し、日々の支出や資金の流れを把握しやすくすることを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_bank' %}" class="btn btn-primary btn-sm">詳細を見る</a>
@@ -302,8 +285,7 @@
                     </figure>
                     <div class="card-body">
                         <h5 class="card-title">図書館業務システム Bookman</h5>
-                        <p class="card-text small text-secondary">
-                            支店ごとの所蔵管理から書籍CSV登録、貸出・返却、予約・取り置き、利用者管理までを一つの画面で扱える図書館業務システム。</p>
+                        <p class="card-text small text-secondary">支店ごとの蔵書管理、書籍CSV登録、貸出・返却、予約・取り置き、利用者管理を一つの画面で扱える図書館業務システム。蔵書の検索からカウンター業務までをまとめて管理し、現場の作業をシンプルにすることを目指した。</p>
                     </div>
                     <div class="card-footer bg-white border-top-0">
                         <a href="{% url 'home:about_bookman' %}" class="btn btn-primary btn-sm">詳細を見る</a>

--- a/home/templates/home/jp_stocks/index.html
+++ b/home/templates/home/jp_stocks/index.html
@@ -30,14 +30,6 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
-                <ul>
-                    <li><a href="{% url 'jpn:index' %}" target="_blank">JP_STOCKS（Webアプリ）</a></li>
-                    <li><a href="{% url 'jpn:order_book' %}" target="_blank">注文板を見る</a></li>
-                </ul>
-            </section>
-
-            <section class="py-3">
                 <h2>テーマ</h2>
                 <p>
                     実際の市場データを大量に集める前に、注文の登録、価格ごとの集約、売買の見え方を小さなアプリで試す。

--- a/home/templates/home/jp_stocks/index.html
+++ b/home/templates/home/jp_stocks/index.html
@@ -5,16 +5,17 @@
         <article class="my-5">
             <header>
                 <h1 class="display-4 text-center">JP_STOCKS</h1>
-                <p class="text-muted text-center">XXXX年当時、"YYYY" をpythonで取得するプログラムを作成した</p>
-                <div class="d-flex justify-content-center my-4">
+                <p class="text-muted text-center">日本株の板情報を登録し、注文状況をシミュレーションするアプリ</p>
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'jpn:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">JP_STOCKSを開く</a>
                 </div>
             </header>
 
             <section class="py-3">
                 <div class="text-center">
                     <img src="{% static 'home/images/jp_stocks.png' %}"
-                         alt="YYYYを分析する"
+                         alt="日本株の板情報シミュレーション"
                          class="img-fluid rounded shadow">
                 </div>
             </section>
@@ -22,26 +23,25 @@
             <section class="py-3">
                 <h2>概要</h2>
                 <p>
-                    概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　
-                    概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　
-                    概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　概要の文章　
+                    JP_STOCKS は、株式市場の板情報を題材に、売り注文と買い注文を価格順に並べて表示するアプリケーションです。
+                    注文を登録すると、現在の注文状況から板を組み立て、どの価格帯に注文が集まっているかを確認できます。
+                    株価データを眺めるだけでなく、注文が増減する仕組みを自分で動かして理解することを目的にしています。
                 </p>
             </section>
 
             <section class="py-3">
                 <h2>リンク</h2>
                 <ul>
-                    <li><a href="#" target="_blank">Qiita記事：「YYYYをpythonで取得してみる」</a></li>
-                    <li><a href="{% url 'sec:index' %}" target="_blank">作成したWebアプリ『ZZZZ』</a></li>
+                    <li><a href="{% url 'jpn:index' %}" target="_blank">JP_STOCKS（Webアプリ）</a></li>
+                    <li><a href="{% url 'jpn:order_book' %}" target="_blank">注文板を見る</a></li>
                 </ul>
             </section>
 
             <section class="py-3">
                 <h2>テーマ</h2>
                 <p>
-                    テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章
-                    テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章
-                    テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章 テーマの文章
+                    実際の市場データを大量に集める前に、注文の登録、価格ごとの集約、売買の見え方を小さなアプリで試す。
+                    その過程で、金融の業務知識を画面とドメインロジックへ落とし込むことをテーマにしています。
                 </p>
             </section>
 
@@ -49,12 +49,12 @@
                 <h2>できあがったもの</h2>
                 <p>Webアプリケーションは以下の機能を提供しています:</p>
                 <ul>
-                    <li>ABCの処理</li>
-                    <li>ABCの処理</li>
-                    <li>ABCの処理</li>
+                    <li>売り注文・買い注文の登録</li>
+                    <li>価格帯ごとの注文数量を集約した板表示</li>
+                    <li>注文一覧から現在の注文状況を確認</li>
                 </ul>
                 <p>
-                    これらの機能を組み合わせることで、AAAを構築。
+                    注文を入力してから板が変化するまでの流れを確認できるため、株式取引の基本的な構造を画面上で試せます。
                 </p>
             </section>
         </article>

--- a/home/templates/home/jp_stocks/index.html
+++ b/home/templates/home/jp_stocks/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">日本株の板情報を登録し、注文状況をシミュレーションするアプリ</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'jpn:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">JP STOCKSを開く</a>
+                    <a href="{% url 'jpn:index' %}" class="btn btn-primary">JP STOCKSを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/jp_stocks/index.html
+++ b/home/templates/home/jp_stocks/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">日本株の板情報を登録し、注文状況をシミュレーションするアプリ</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'jpn:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">JP_STOCKSを開く</a>
+                    <a href="{% url 'jpn:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">JP STOCKSを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/kokkai/index.html
+++ b/home/templates/home/kokkai/index.html
@@ -25,13 +25,6 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
-                <ul>
-                    <li><a href="{% url 'kokkai:index' %}" target="_blank">KOKKAI（Webアプリ）</a></li>
-                </ul>
-            </section>
-
-            <section class="py-3">
                 <h2>主な機能</h2>
                 <ul>
                     <li>議事録の全文検索</li>

--- a/home/templates/home/kokkai/index.html
+++ b/home/templates/home/kokkai/index.html
@@ -13,6 +13,13 @@
             </header>
 
             <section class="py-3">
+                <div class="text-center">
+                    <img src="{% static 'home/images/no-image.png' %}" alt="国会議事録検索・分析システム"
+                         class="img-fluid rounded shadow">
+                </div>
+            </section>
+
+            <section class="py-3">
                 <h2>概要</h2>
                 <p>
                     国会の膨大な議事録の中から必要な情報を効率的に検索し、AI（LLM）を用いて内容を要約・分析するシステムです。

--- a/home/templates/home/kokkai/index.html
+++ b/home/templates/home/kokkai/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">国会議事録検索・分析システム</h1>
                 <p class="text-muted text-center">国会の議事録をRAGやLLMを用いて検索・分析するプロジェクト</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'kokkai:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">KOKKAIを開く</a>
                 </div>
             </header>
 
@@ -16,6 +17,10 @@
                 <p>
                     国会の膨大な議事録の中から必要な情報を効率的に検索し、AI（LLM）を用いて内容を要約・分析するシステムです。
                     RAG（Retrieval-Augmented Generation）技術を活用し、正確な根拠に基づいた回答を生成することを目指しています。
+                </p>
+                <p>
+                    まずは取得した会議録を日付と委員会から追い、必要な会議の詳細と発言を確認できるようにしています。
+                    期間を指定して会議録を取り込み、検索・要約・分析へつなげるための基盤です。
                 </p>
             </section>
 
@@ -33,7 +38,19 @@
                     <li>LLMによる議事録の要約・解説</li>
                     <li>RAGを用いた高度な質問応答</li>
                     <li>特定の議員や委員会の発言抽出</li>
+                    <li>期間を指定した会議録の取得と一覧化</li>
+                    <li>会議録の Markdown ダウンロード</li>
                 </ul>
+            </section>
+
+            <section class="py-3">
+                <h2>使い方</h2>
+                <ol>
+                    <li>対象期間を指定して会議録を取り込む</li>
+                    <li>日付と委員会から対象の会議を選ぶ</li>
+                    <li>会議の発言を確認し、必要な情報を検索・分析する</li>
+                    <li>調査結果を Markdown として持ち出す</li>
+                </ol>
             </section>
         </article>
     </div>

--- a/home/templates/home/kokkai/index.html
+++ b/home/templates/home/kokkai/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">国会の議事録をRAGやLLMを用いて検索・分析するプロジェクト</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'kokkai:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">KOKKAIを開く</a>
+                    <a href="{% url 'kokkai:index' %}" class="btn btn-primary">KOKKAIを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/llm_chat/index.html
+++ b/home/templates/home/llm_chat/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">LLM_CHAT</h1>
                 <p class="text-muted text-center">2024年当時、"チャット履歴管理とLLM連携" をPythonで実装した</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'llm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LLM_CHATを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/llm_chat/index.html
+++ b/home/templates/home/llm_chat/index.html
@@ -30,11 +30,10 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/f51f52a8041439a1dbc9" target="_blank">Qiita記事：「LINEからChatGPTと会話し、絵も描く」</a>
                     </li>
-                    <li><a href="{% url 'llm:index' %}" target="_blank">作成したWebアプリ『LLM_CHAT』</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/llm_chat/index.html
+++ b/home/templates/home/llm_chat/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2024年当時、"チャット履歴管理とLLM連携" をPythonで実装した</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'llm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LLM_CHATを開く</a>
+                    <a href="{% url 'llm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LLM CHATを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/llm_chat/index.html
+++ b/home/templates/home/llm_chat/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2024年当時、"チャット履歴管理とLLM連携" をPythonで実装した</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'llm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LLM CHATを開く</a>
+                    <a href="{% url 'llm:index' %}" class="btn btn-primary">LLM CHATを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/rental_shop/index.html
+++ b/home/templates/home/rental_shop/index.html
@@ -7,8 +7,9 @@
                 <h1 class="display-4 text-center">在庫は倉庫のどこにいくつあるの？</h1>
                 <p class="text-muted text-center">
                     2016年、物流のオープンデータ活用コンテストをきっかけに発想を得て開発</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'ren:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">RENTAL_SHOPを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/rental_shop/index.html
+++ b/home/templates/home/rental_shop/index.html
@@ -29,14 +29,6 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
-                <ul>
-                    <li><a href="{% url 'ren:index' %}" target="_blank">作成したWebアプリ『RENTAL_SHOP』</a>
-                    </li>
-                </ul>
-            </section>
-
-            <section class="py-3">
                 <h2>テーマ</h2>
                 <p>以下の内容をテーマとして開発に取り組みました:</p>
                 <ul>

--- a/home/templates/home/rental_shop/index.html
+++ b/home/templates/home/rental_shop/index.html
@@ -9,7 +9,7 @@
                     2016年、物流のオープンデータ活用コンテストをきっかけに発想を得て開発</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'ren:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">RENTAL SHOPを開く</a>
+                    <a href="{% url 'ren:index' %}" class="btn btn-primary">RENTAL SHOPを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/rental_shop/index.html
+++ b/home/templates/home/rental_shop/index.html
@@ -9,7 +9,7 @@
                     2016年、物流のオープンデータ活用コンテストをきっかけに発想を得て開発</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'ren:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">RENTAL_SHOPを開く</a>
+                    <a href="{% url 'ren:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">RENTAL SHOPを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/securities/index.html
+++ b/home/templates/home/securities/index.html
@@ -7,8 +7,9 @@
                 <h1 class="display-4 text-center">金融庁の有価証券報告書を分析する</h1>
                 <p class="text-muted text-center">2019年当時、金融の業務知識を総動員して "有価証券報告書"
                     をpythonで取得するプログラムを作成した</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'sec:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SECURITIESを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/securities/index.html
+++ b/home/templates/home/securities/index.html
@@ -31,12 +31,10 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/877a331a450a8f27f985" target="_blank">Qiita記事：「有価証券報告書をpythonで取得してみる2024
                         金融庁API版」</a></li>
-                    <li><a href="{% url 'sec:index' %}" target="_blank">作成したWebアプリ『SECURITIES
-                        REPORT』</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/securities/index.html
+++ b/home/templates/home/securities/index.html
@@ -9,7 +9,7 @@
                     をpythonで取得するプログラムを作成した</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'sec:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SECURITIESを開く</a>
+                    <a href="{% url 'sec:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SECURITIES REPORTを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/securities/index.html
+++ b/home/templates/home/securities/index.html
@@ -9,7 +9,7 @@
                     をpythonで取得するプログラムを作成した</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'sec:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SECURITIES REPORTを開く</a>
+                    <a href="{% url 'sec:index' %}" class="btn btn-primary">SECURITIES REPORTを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/shopping/index.html
+++ b/home/templates/home/shopping/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">通販サイトの基礎機能</h1>
                 <p class="text-muted text-center">2022年、ECサイトの基礎機能を学ぶために開発</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'shp:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SHOPPINGを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/shopping/index.html
+++ b/home/templates/home/shopping/index.html
@@ -30,14 +30,6 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
-                <ul>
-                    <li><a href="{% url 'shp:index' %}" target="_blank">作成したWebアプリ『SHOPPING』</a>
-                    </li>
-                </ul>
-            </section>
-
-            <section class="py-3">
                 <h2>テーマ</h2>
                 <p>
                     本プロジェクトでは以下の内容をテーマに開発しました：

--- a/home/templates/home/shopping/index.html
+++ b/home/templates/home/shopping/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2022年、ECサイトの基礎機能を学ぶために開発</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'shp:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SHOPPINGを開く</a>
+                    <a href="{% url 'shp:index' %}" class="btn btn-primary">SHOPPINGを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/soil_analysis/index.html
+++ b/home/templates/home/soil_analysis/index.html
@@ -28,11 +28,10 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/5cc23a68991460c7632b" target="_blank">気象庁APIで得られた天気情報をアプリケーションで活用する</a>
                     </li>
-                    <li><a href="{% url 'soil:home' %}" target="_blank">土壌分析</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/soil_analysis/index.html
+++ b/home/templates/home/soil_analysis/index.html
@@ -7,8 +7,9 @@
             <header>
                 <h1 class="display-4 text-center">圃場計測のレポートツール</h1>
                 <p class="text-muted text-center">2023年、農業調査のために開発されたツール</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'soil:home' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">土壌分析を開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/soil_analysis/index.html
+++ b/home/templates/home/soil_analysis/index.html
@@ -9,7 +9,7 @@
                 <p class="text-muted text-center">2023年、農業調査のために開発されたツール</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'soil:home' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SOIL ANALYSISを開く</a>
+                    <a href="{% url 'soil:home' %}" class="btn btn-primary">SOIL ANALYSISを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/soil_analysis/index.html
+++ b/home/templates/home/soil_analysis/index.html
@@ -9,7 +9,7 @@
                 <p class="text-muted text-center">2023年、農業調査のために開発されたツール</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'soil:home' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">土壌分析を開く</a>
+                    <a href="{% url 'soil:home' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">SOIL ANALYSISを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/taxonomy/index.html
+++ b/home/templates/home/taxonomy/index.html
@@ -7,8 +7,9 @@
                 <h1 class="display-4 text-center">ニワトリとミミズの種を分類する</h1>
                 <p class="text-muted text-center">
                     2017年に地方に移住して畑作業をするなかで生物性に興味を持ったことがきっかけ</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'txo:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">TAXONOMYを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/taxonomy/index.html
+++ b/home/templates/home/taxonomy/index.html
@@ -29,14 +29,6 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
-                <ul>
-                    <li><a href="{% url 'txo:index' %}" target="_blank">作成したWebアプリ『TAXONOMY』</a>
-                    </li>
-                </ul>
-            </section>
-
-            <section class="py-3">
                 <h2>テーマ</h2>
                 <p>以下のテーマを基に開発を進めました:</p>
                 <ul>

--- a/home/templates/home/taxonomy/index.html
+++ b/home/templates/home/taxonomy/index.html
@@ -9,7 +9,7 @@
                     2017年に地方に移住して畑作業をするなかで生物性に興味を持ったことがきっかけ</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'txo:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">TAXONOMYを開く</a>
+                    <a href="{% url 'txo:index' %}" class="btn btn-primary">TAXONOMYを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/usa_research/index.html
+++ b/home/templates/home/usa_research/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">米国株を分析する</h1>
                 <p class="text-muted text-center">世界最大の市場である米国株を体系的に調査する研究プロジェクト</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'usa:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">USAリサーチを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/usa_research/index.html
+++ b/home/templates/home/usa_research/index.html
@@ -34,11 +34,10 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://go.sbisec.co.jp/media/report/fo_america/" target="_blank">SBI - アメリカ NOW！</a></li>
                     <li><a href="https://www.nasdaq.com/market-activity/index/ndx" target="_blank">NASDAQ100 構成銘柄</a></li>
-                    <li><a href="{% url 'usa:index' %}" target="_blank">USAリサーチ（Webアプリ）</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/usa_research/index.html
+++ b/home/templates/home/usa_research/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">世界最大の市場である米国株を体系的に調査する研究プロジェクト</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'usa:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">USAリサーチを開く</a>
+                    <a href="{% url 'usa:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">USAを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/usa_research/index.html
+++ b/home/templates/home/usa_research/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">世界最大の市場である米国株を体系的に調査する研究プロジェクト</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'usa:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">USAを開く</a>
+                    <a href="{% url 'usa:index' %}" class="btn btn-primary">USAを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/usa_research/index.html
+++ b/home/templates/home/usa_research/index.html
@@ -59,34 +59,6 @@
             </section>
 
             <section class="py-3">
-                <h2>ギャラリー</h2>
-                <div id="galleryCarousel" class="carousel slide" data-ride="carousel">
-                    <!-- インジケータ -->
-                    <ol class="carousel-indicators">
-                        <li data-target="#galleryCarousel" data-slide-to="0" class="active"></li>
-                    </ol>
-
-                    <!-- カルーセル -->
-                    <div class="carousel-inner rounded shadow">
-                        <div class="carousel-item active">
-                            <img src="https://www.msci.com/documents/10199/178e6643-6ae6-47b9-82be-e1fc565ededb"
-                                 class="d-block w-50" alt="米国株研究のイメージ">
-                        </div>
-                    </div>
-
-                    <!-- 次/前 -->
-                    <a class="carousel-control-prev" href="#galleryCarousel" role="button" data-slide="prev">
-                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                        <span class="sr-only">前へ</span>
-                    </a>
-                    <a class="carousel-control-next" href="#galleryCarousel" role="button" data-slide="next">
-                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                        <span class="sr-only">次へ</span>
-                    </a>
-                </div>
-            </section>
-
-            <section class="py-3">
                 <h2>提案の背景</h2>
                 <p>
                     この USA リサーチは、米国市場の動向を正確に追うことで、日本株や世界市場の変動要因を理解することを目的としています。

--- a/home/templates/home/vietnam_research/index.html
+++ b/home/templates/home/vietnam_research/index.html
@@ -6,8 +6,9 @@
             <header>
                 <h1 class="display-4 text-center">ベトナムの株価を分析する</h1>
                 <p class="text-muted text-center">2019年、チャイナリスクを見据えた投資対象としてのベトナム研究</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'vnm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">ベトナムリサーチを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/vietnam_research/index.html
+++ b/home/templates/home/vietnam_research/index.html
@@ -29,14 +29,12 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://qiita.com/YoshitakaOkada/items/7b42ee18cc703f622564" target="_blank">ベトナムを分析する（テーマ設定の大切さ）</a>
                     </li>
                     <li><a href="https://www.slideshare.net/slideshow/data-research-of-vietnam/182746150#1"
                            target="_blank">ベトナムリサーチ（slideshare）</a></li>
-                    <li><a href="{% url 'vnm:index' %}" target="_blank">ベトナムリサーチ（Web
-                        アプリ）</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/vietnam_research/index.html
+++ b/home/templates/home/vietnam_research/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2019年、チャイナリスクを見据えた投資対象としてのベトナム研究</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'vnm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">VIETNAMを開く</a>
+                    <a href="{% url 'vnm:index' %}" class="btn btn-primary">VIETNAMを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/vietnam_research/index.html
+++ b/home/templates/home/vietnam_research/index.html
@@ -8,7 +8,7 @@
                 <p class="text-muted text-center">2019年、チャイナリスクを見据えた投資対象としてのベトナム研究</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'vnm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">ベトナムリサーチを開く</a>
+                    <a href="{% url 'vnm:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">VIETNAMを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/welfare_services/index.html
+++ b/home/templates/home/welfare_services/index.html
@@ -31,13 +31,12 @@
             </section>
 
             <section class="py-3">
-                <h2>リンク</h2>
+                <h2>参考リンク</h2>
                 <ul>
                     <li><a href="https://odhackathon.metro.tokyo.lg.jp/issues/"
                            target="_blank">都知事杯オープンデータ・ハッカソン2025</a></li>
                     <li><a href="https://www.slideshare.net/slideshow/2025-99d4/282666910" target="_blank">プレゼン資料（SlideShare）</a>
                     </li>
-                    <li><a href="{% url 'welf:index' %}" target="_blank">福祉事務所ポータル（Webアプリ）</a></li>
                 </ul>
             </section>
 

--- a/home/templates/home/welfare_services/index.html
+++ b/home/templates/home/welfare_services/index.html
@@ -7,8 +7,9 @@
                 <h1 class="display-4 text-center">東京都福祉事務所情報ポータル</h1>
                 <p class="text-muted text-center">
                     2025年、都知事杯オープンデータ・ハッカソンでの障がい福祉サービス空き情報の見える化プロジェクト</p>
-                <div class="d-flex justify-content-center my-4">
+                <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
+                    <a href="{% url 'welf:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">福祉事務所ポータルを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/welfare_services/index.html
+++ b/home/templates/home/welfare_services/index.html
@@ -9,7 +9,7 @@
                     2025年、都知事杯オープンデータ・ハッカソンでの障がい福祉サービス空き情報の見える化プロジェクト</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'welf:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">福祉事務所ポータルを開く</a>
+                    <a href="{% url 'welf:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">WELFARE SERVICESを開く</a>
                 </div>
             </header>
 

--- a/home/templates/home/welfare_services/index.html
+++ b/home/templates/home/welfare_services/index.html
@@ -9,7 +9,7 @@
                     2025年、都知事杯オープンデータ・ハッカソンでの障がい福祉サービス空き情報の見える化プロジェクト</p>
                 <div class="d-flex justify-content-center gap-2 my-4">
                     <a href="{% url 'home:index' %}" class="btn btn-outline-secondary">一覧に戻る</a>
-                    <a href="{% url 'welf:index' %}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">WELFARE SERVICESを開く</a>
+                    <a href="{% url 'welf:index' %}" class="btn btn-primary">WELFARE SERVICESを開く</a>
                 </div>
             </header>
 

--- a/home/tests.py
+++ b/home/tests.py
@@ -59,3 +59,21 @@ class BookmanHomeTests(SimpleTestCase):
                 response = self.client.get(reverse(f"home:{detail_name}"))
 
                 self.assertContains(response, reverse(app_name))
+                button_href = f'href="{reverse(app_name)}" class="btn btn-primary"'
+                self.assertEqual(response.content.decode().count(button_href), 1)
+
+    def test_catalog_app_links_follow_current_host(self):
+        """
+        シナリオ:
+        - 入力: 本番ホストを指定して BANK の紹介ページを GET する。
+        - 処理: アプリ起動ボタンの URL をレスポンスから確認する。
+        - 期待値: 固定した localhost URL ではなく、現在のホストに解決できる相対 URL が使われること。
+        """
+        response = self.client.get(
+            reverse("home:about_bank"),
+            secure=True,
+            HTTP_HOST="www.henojiya.net",
+        )
+
+        self.assertContains(response, 'href="/bank/"')
+        self.assertNotContains(response, "127.0.0.1:8000/bank/")

--- a/home/tests.py
+++ b/home/tests.py
@@ -26,3 +26,5 @@ class BookmanHomeTests(SimpleTestCase):
         response = self.client.get(reverse("home:about_bookman"))
 
         self.assertContains(response, "https://bookman.henojiya.net/")
+        self.assertContains(response, "支店別所蔵")
+        self.assertContains(response, "貸出・返却と予約・取り置き")

--- a/home/tests.py
+++ b/home/tests.py
@@ -1,1 +1,27 @@
-# Create your tests here.
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+
+class BookmanHomeTests(SimpleTestCase):
+    def test_home_catalog_links_to_bookman_detail(self):
+        """
+        シナリオ:
+        - 入力: HOME のカタログページを GET する。
+        - 処理: HOME のレスポンスを取得する。
+        - 期待値: Bookman の紹介導線が表示されること。
+        """
+        response = self.client.get(reverse("home:index"))
+
+        self.assertContains(response, "図書館業務システム Bookman")
+        self.assertContains(response, reverse("home:about_bookman"))
+
+    def test_bookman_detail_links_to_external_application(self):
+        """
+        シナリオ:
+        - 入力: Bookman の紹介ページを GET する。
+        - 処理: Bookman 紹介ページのレスポンスを取得する。
+        - 期待値: 公開中の Bookman サブドメインへのリンクが表示されること。
+        """
+        response = self.client.get(reverse("home:about_bookman"))
+
+        self.assertContains(response, "https://bookman.henojiya.net/")

--- a/home/tests.py
+++ b/home/tests.py
@@ -14,6 +14,7 @@ class BookmanHomeTests(SimpleTestCase):
 
         self.assertContains(response, "図書館業務システム Bookman")
         self.assertContains(response, reverse("home:about_bookman"))
+        self.assertContains(response, "https://bookman.henojiya.net/")
 
     def test_bookman_detail_links_to_external_application(self):
         """

--- a/home/tests.py
+++ b/home/tests.py
@@ -28,3 +28,34 @@ class BookmanHomeTests(SimpleTestCase):
         self.assertContains(response, "https://bookman.henojiya.net/")
         self.assertContains(response, "支店別所蔵")
         self.assertContains(response, "貸出・返却と予約・取り置き")
+
+    def test_catalog_details_have_app_open_buttons(self):
+        """
+        シナリオ:
+        - 入力: 各カタログ詳細ページと対応するアプリ URL の組み合わせ。
+        - 処理: 各詳細ページを GET する。
+        - 期待値: ヘッダーにアプリを開くリンクが表示されること。
+        """
+        catalog_links = (
+            ("about_hospital", "hsp:index"),
+            ("about_soil_analysis", "soil:home"),
+            ("about_vietnam_research", "vnm:index"),
+            ("about_usa_research", "usa:index"),
+            ("about_gmarker", "mrk:index"),
+            ("about_shopping", "shp:index"),
+            ("about_rental_shop", "ren:index"),
+            ("about_taxonomy", "txo:index"),
+            ("about_securities", "sec:index"),
+            ("about_llm_chat", "llm:index"),
+            ("about_ai_agent", "agt:index"),
+            ("about_jp_stocks", "jpn:index"),
+            ("about_welfare_services", "welf:index"),
+            ("about_kokkai", "kokkai:index"),
+            ("about_bank", "bank:index"),
+        )
+
+        for detail_name, app_name in catalog_links:
+            with self.subTest(detail_name=detail_name):
+                response = self.client.get(reverse(f"home:{detail_name}"))
+
+                self.assertContains(response, reverse(app_name))

--- a/home/tests.py
+++ b/home/tests.py
@@ -27,6 +27,10 @@ class BookmanHomeTests(SimpleTestCase):
 
         self.assertContains(response, "https://bookman.henojiya.net/")
         self.assertContains(response, "Bookmanを開く")
+        self.assertContains(
+            response,
+            'href="https://bookman.henojiya.net/" class="btn btn-primary">Bookmanを開く</a>',
+        )
         self.assertContains(response, "支店別所蔵")
         self.assertContains(response, "貸出・返却と予約・取り置き")
 
@@ -63,6 +67,10 @@ class BookmanHomeTests(SimpleTestCase):
                 self.assertContains(response, f"{app_label}を開く")
                 button_href = f'href="{reverse(app_name)}" class="btn btn-primary"'
                 self.assertEqual(response.content.decode().count(button_href), 1)
+                self.assertNotContains(
+                    response,
+                    f'href="{reverse(app_name)}" class="btn btn-primary" target="_blank"',
+                )
 
     def test_catalog_app_links_follow_current_host(self):
         """

--- a/home/tests.py
+++ b/home/tests.py
@@ -26,6 +26,7 @@ class BookmanHomeTests(SimpleTestCase):
         response = self.client.get(reverse("home:about_bookman"))
 
         self.assertContains(response, "https://bookman.henojiya.net/")
+        self.assertContains(response, "Bookmanを開く")
         self.assertContains(response, "支店別所蔵")
         self.assertContains(response, "貸出・返却と予約・取り置き")
 
@@ -37,28 +38,29 @@ class BookmanHomeTests(SimpleTestCase):
         - 期待値: ヘッダーにアプリを開くリンクが表示されること。
         """
         catalog_links = (
-            ("about_hospital", "hsp:index"),
-            ("about_soil_analysis", "soil:home"),
-            ("about_vietnam_research", "vnm:index"),
-            ("about_usa_research", "usa:index"),
-            ("about_gmarker", "mrk:index"),
-            ("about_shopping", "shp:index"),
-            ("about_rental_shop", "ren:index"),
-            ("about_taxonomy", "txo:index"),
-            ("about_securities", "sec:index"),
-            ("about_llm_chat", "llm:index"),
-            ("about_ai_agent", "agt:index"),
-            ("about_jp_stocks", "jpn:index"),
-            ("about_welfare_services", "welf:index"),
-            ("about_kokkai", "kokkai:index"),
-            ("about_bank", "bank:index"),
+            ("about_hospital", "hsp:index", "HOSPITAL"),
+            ("about_soil_analysis", "soil:home", "SOIL ANALYSIS"),
+            ("about_vietnam_research", "vnm:index", "VIETNAM"),
+            ("about_usa_research", "usa:index", "USA"),
+            ("about_gmarker", "mrk:index", "GMARKER"),
+            ("about_shopping", "shp:index", "SHOPPING"),
+            ("about_rental_shop", "ren:index", "RENTAL SHOP"),
+            ("about_taxonomy", "txo:index", "TAXONOMY"),
+            ("about_securities", "sec:index", "SECURITIES REPORT"),
+            ("about_llm_chat", "llm:index", "LLM CHAT"),
+            ("about_ai_agent", "agt:index", "AI AGENT"),
+            ("about_jp_stocks", "jpn:index", "JP STOCKS"),
+            ("about_welfare_services", "welf:index", "WELFARE SERVICES"),
+            ("about_kokkai", "kokkai:index", "KOKKAI"),
+            ("about_bank", "bank:index", "BANK"),
         )
 
-        for detail_name, app_name in catalog_links:
+        for detail_name, app_name, app_label in catalog_links:
             with self.subTest(detail_name=detail_name):
                 response = self.client.get(reverse(f"home:{detail_name}"))
 
                 self.assertContains(response, reverse(app_name))
+                self.assertContains(response, f"{app_label}を開く")
                 button_href = f'href="{reverse(app_name)}" class="btn btn-primary"'
                 self.assertEqual(response.content.decode().count(button_href), 1)
 

--- a/home/tests.py
+++ b/home/tests.py
@@ -77,3 +77,15 @@ class BookmanHomeTests(SimpleTestCase):
 
         self.assertContains(response, 'href="/bank/"')
         self.assertNotContains(response, "127.0.0.1:8000/bank/")
+
+    def test_usa_research_does_not_render_broken_external_gallery(self):
+        """
+        シナリオ:
+        - 入力: USA リサーチの紹介ページを GET する。
+        - 処理: 紹介ページの HTML を確認する。
+        - 期待値: 画像では表示できない外部 PDF のギャラリーが存在しないこと。
+        """
+        response = self.client.get(reverse("home:about_usa_research"))
+
+        self.assertNotContains(response, "galleryCarousel")
+        self.assertNotContains(response, "www.msci.com/documents")

--- a/home/urls.py
+++ b/home/urls.py
@@ -17,6 +17,7 @@ from home.views import (
     UsaResearchIndexView,
     KokkaiIndexView,
     BankIndexView,
+    BookmanIndexView,
 )
 
 app_name = "home"
@@ -53,4 +54,5 @@ urlpatterns = [
     ),
     path("about/kokkai/", KokkaiIndexView.as_view(), name="about_kokkai"),
     path("about/bank/", BankIndexView.as_view(), name="about_bank"),
+    path("about/bookman/", BookmanIndexView.as_view(), name="about_bookman"),
 ]

--- a/home/views.py
+++ b/home/views.py
@@ -63,3 +63,7 @@ class KokkaiIndexView(TemplateView):
 
 class BankIndexView(TemplateView):
     template_name = "home/bank/index.html"
+
+
+class BookmanIndexView(TemplateView):
+    template_name = "home/bookman/index.html"

--- a/templates/shared/header.html
+++ b/templates/shared/header.html
@@ -12,7 +12,6 @@
                         {% with active_path=request.GET.next|default:request.path %}
                         <select class="form-select d-flex align-items-center" onChange="location.href=value;">
                             <option value="{% url 'home:index' %}" {% if active_path == '/' or '/about/' in active_path %}selected{% endif %}>HOME</option>
-                            <option value="https://bookman.henojiya.net/">BOOKMAN</option>
                             <option value="{% url 'vnm:index' %}" {% if '/vietnam_research/' in active_path and '/about/' not in active_path %}selected{% endif %}>VIETNAM</option>
                             <option value="{% url 'usa:index' %}" {% if '/usa_research/' in active_path and '/about/' not in active_path %}selected{% endif %}>USA</option>
                             <option value="{% url 'mrk:index' %}" {% if '/gmarker/' in active_path and '/about/' not in active_path %}selected{% endif %}>GMARKER</option>
@@ -28,6 +27,7 @@
                             <option value="{% url 'welf:index' %}" {% if '/welfare_services/' in active_path and '/about/' not in active_path %}selected{% endif %}>WELFARE SERVICES</option>
                             <option value="{% url 'kokkai:index' %}" {% if '/kokkai/' in active_path and '/about/' not in active_path %}selected{% endif %}>KOKKAI</option>
                             <option value="{% url 'bank:index' %}" {% if '/bank/' in active_path and '/about/' not in active_path %}selected{% endif %}>BANK</option>
+                            <option value="https://bookman.henojiya.net/">BOOKMAN</option>
                         </select>
                         {% endwith %}
                     </li>

--- a/templates/shared/header.html
+++ b/templates/shared/header.html
@@ -12,6 +12,7 @@
                         {% with active_path=request.GET.next|default:request.path %}
                         <select class="form-select d-flex align-items-center" onChange="location.href=value;">
                             <option value="{% url 'home:index' %}" {% if active_path == '/' or '/about/' in active_path %}selected{% endif %}>HOME</option>
+                            <option value="https://bookman.henojiya.net/">BOOKMAN</option>
                             <option value="{% url 'vnm:index' %}" {% if '/vietnam_research/' in active_path and '/about/' not in active_path %}selected{% endif %}>VIETNAM</option>
                             <option value="{% url 'usa:index' %}" {% if '/usa_research/' in active_path and '/about/' not in active_path %}selected{% endif %}>USA</option>
                             <option value="{% url 'mrk:index' %}" {% if '/gmarker/' in active_path and '/about/' not in active_path %}selected{% endif %}>GMARKER</option>


### PR DESCRIPTION
## Summary
HOME のカタログに Bookman を追加し、全カタログから各アプリへすぐ移動できるようにしました。既存の紹介文も実装内容に合わせて補強しています。

- HOME に「図書館業務システム Bookman」のカタログカードを追加
- 共通ヘッダーのドロップダウン末尾に Bookman の外部リンクを追加
- Bookman の紹介ページに、支店別所蔵、CSV 登録、貸出・返却、予約・取り置き、利用者・職員、休館日、ダッシュボード、業務フロー、設計方針を掲載
- Bookman 以外の全カタログ詳細ページにも、ヘッダーの「アプリを開く」ボタンを追加
- 共通ヘッダーの正式名称に合わせて、全15個の起動ボタン表記を統一（HOSPITAL、LLM CHAT、JP STOCKS、WELFARE SERVICES など）
- アプリ URL は相対 URL のまま利用し、ローカルでは `http://127.0.0.1:8000/...`、本番では `https://www.henojiya.net/...` に現在のホストに応じて解決されるように整理
- アプリ起動ボタンと重複する旧アプリリンクを削除
- 参考資料が残るページは「参考リンク」として整理
- 詳細ページの画像エリア、ボタン配置、余白を統一。画像素材がない BANK / KOKKAI は既存 `no-image.png` を使用
- `JP_STOCKS` のプレースホルダーを板情報シミュレーションの実装説明へ置き換え、アプリ URL も修正
- `KOKKAI` に会議録の取得・一覧・分析・Markdown 出力の使い方を追加
- `BANK` に口座登録、CSV 取込、生活費分析、カテゴリ別月次集計の機能説明と利用手順を追加
- USA リサーチの画像として表示できない外部 PDF ギャラリーを削除

## 目検による動作確認手順
- [x] HOME を開き、Bookman を含むカタログカードが表示されることを確認する
- [x] 各カタログ詳細ページを開き、画像エリアと「一覧に戻る」「アプリを開く」ボタンが揃っていることを確認する
- [x] ローカル環境でボタンにマウスを合わせ、`http://127.0.0.1:8000/...` が表示されることを確認する
- [x] 本番環境でボタンにマウスを合わせ、`https://www.henojiya.net/...` が表示されることを確認する
- [x] Bookman 詳細ページの機能説明、カウンター業務の流れ、公開アプリへの導線を確認する
- [x] 共通ヘッダーのドロップダウン末尾に「BOOKMAN」が表示され、選択すると `https://bookman.henojiya.net/` へ遷移することを確認する
- [x] 旧「リンク」欄にアプリへの重複リンクが残っていないことを確認する
- [x] USA リサーチ詳細ページに空のギャラリーが表示されないことを確認する

## 自動テストでカバーできた範囲
- `black home/tests.py`
- `python manage.py test home --noinput`
  - HOME から Bookman 紹介ページへの導線
  - HOME と共通ヘッダーから公開 URL へのリンク
  - Bookman 紹介ページの機能説明と公開 URL へのリンク
  - 全15カタログ詳細ページのアプリ起動リンクと正式名称
  - 本番ホスト指定時も localhost 固定 URL を出力しないこと
  - USA リサーチに壊れた外部 PDF ギャラリーが残っていないこと
- `git diff --check`
- `curl.exe -I -L --max-time 15 https://bookman.henojiya.net/` で公開 URL の HTTP 200 を確認

## 関連Issue
Closes #897
https://github.com/duri0214/portfolio/issues/897
- HOME の各カタログ概要を103〜123文字に整理し、4行程度で読める長さに統一。株式カードの仮文も削除
- 「〜を開く」ボタンと Bookman 起動ボタンを自タブ遷移に統一。参考資料の外部リンクは新しいタブのまま
