### PR TITLE
#922 CIとMySQL 8.4の環境設定を整合させる

### DIFF
--- a/.codex/rules/qiita/centos-to-ubuntu-setup.md
+++ b/.codex/rules/qiita/centos-to-ubuntu-setup.md
@@ -39,6 +39,20 @@ apply: "docs/qiita/centos_to_ubuntu_setup.md"
 5) トラブルシュートの書き方
    - 各大項目の最後に「確認コマンド → 期待値」と「失敗時の切り分け（3点程度）」を箇条書きで簡潔に記す。
 
+6) APT Repositoryとパッケージ導入の区別
+   - APT Repositoryは、APTがパッケージを取得する配布元。`mysql-apt-config` は配布元と系列を設定するパッケージで、MySQL Server本体ではない。
+   - MySQLは「APT Repositoryの追加・系列選択 → `apt update` → `apt install mysql-server` → `mysql --version`」の順に記す。
+   - `apt install mysql-server` は系列を選択しないため、選択画面で確認する値（例: `mysql-8.4-lts`）を本文に明記する。
+
+7) コピーペースト可能な手順
+   - ダウンロードとインストールのコマンドは、URLと保存先を一致させる。
+   - `/path/to/` のような置換前提のパスを、実行用コードブロックに残さない。
+   - 対話式設定がある場合は、画面で確認する項目と値を短く示す。
+
+8) セクションの独立性
+   - 手順書は途中の節から読まれることもあるため、各パッケージ導入節の `apt update` は重複だけを理由に削除しない。
+   - Ubuntu向け記事内では、実行環境がUbuntuであることを前提とし、不要なWindows向け注意書きを追加しない。
+
 ## 運用原則
 - 実サーバの現状に合わせる（例: mod_wsgi は APT 方式／サイト設定に LoadModule を書かない）。
 - 実測値・ログ・画像は当時の状態を維持（変更は注釈・表記統一のみ）。

--- a/.codex/rules/qiita/centos-to-ubuntu-setup.md
+++ b/.codex/rules/qiita/centos-to-ubuntu-setup.md
@@ -39,17 +39,12 @@ apply: "docs/qiita/centos_to_ubuntu_setup.md"
 5) トラブルシュートの書き方
    - 各大項目の最後に「確認コマンド → 期待値」と「失敗時の切り分け（3点程度）」を箇条書きで簡潔に記す。
 
-6) APT Repositoryとパッケージ導入の区別
-   - APT Repositoryは、APTがパッケージを取得する配布元。`mysql-apt-config` は配布元と系列を設定するパッケージで、MySQL Server本体ではない。
-   - MySQLは「APT Repositoryの追加・系列選択 → `apt update` → `apt install mysql-server` → `mysql --version`」の順に記す。
-   - `apt install mysql-server` は系列を選択しないため、選択画面で確認する値（例: `mysql-8.4-lts`）を本文に明記する。
-
-7) コピーペースト可能な手順
+6) コピーペースト可能な手順
    - ダウンロードとインストールのコマンドは、URLと保存先を一致させる。
    - `/path/to/` のような置換前提のパスを、実行用コードブロックに残さない。
    - 対話式設定がある場合は、画面で確認する項目と値を短く示す。
 
-8) セクションの独立性
+7) セクションの独立性
    - 手順書は途中の節から読まれることもあるため、各パッケージ導入節の `apt update` は重複だけを理由に削除しない。
    - Ubuntu向け記事内では、実行環境がUbuntuであることを前提とし、不要なWindows向け注意書きを追加しない。
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -36,8 +36,9 @@ jobs:
             fi
             sleep 1
           done
-          mysql -u root -proot -e "CREATE USER 'python'@'localhost';"
-          mysql -u root -proot -e "GRANT ALL ON test_portfolio_db.* TO 'python'@'localhost';"
+          mysql -u root -proot -e "CREATE USER 'python'@'127.0.0.1';"
+          mysql -u root -proot -e "GRANT CREATE, DROP ON *.* TO 'python'@'127.0.0.1';"
+          mysql -u root -proot -e "GRANT ALL ON test_portfolio_db.* TO 'python'@'127.0.0.1';"
           
           python -m pip install setuptools
           python -m pip install -r requirements.txt --verbose

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -37,7 +37,6 @@ jobs:
             sleep 1
           done
           mysql -u root -proot -e "CREATE USER 'python'@'127.0.0.1';"
-          mysql -u root -proot -e "GRANT CREATE, DROP ON *.* TO 'python'@'127.0.0.1';"
           mysql -u root -proot -e "GRANT ALL ON test_portfolio_db.* TO 'python'@'127.0.0.1';"
           
           python -m pip install setuptools

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django(Python)を用いた、各種データ分析・可視化ツールのポー
 
 ![Python 3.12](https://img.shields.io/badge/python-3.12-green)
 ![Django 6.0](https://img.shields.io/badge/django-6.0-green)
-![MySQL 8.0](https://img.shields.io/badge/mysql-8.0-green)
+![MySQL 8.4](https://img.shields.io/badge/mysql-8.4-green)
 
 ## 1. セットアップ
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1010,16 +1010,16 @@ MariaDBなどがインストールされている場合は、事前に削除し�
 $ sudo apt purge mariadb-* mysql-*
 ```
 
-### APT Repositoryの追加と系列選択
+### APT Repositoryの追加（MySQL 8.4 LTSを選択）
 
-MySQL公式の[MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/)から
+APT Repositoryは、UbuntuのAPTがパッケージを取得する配布元です。ここではMySQL公式の
+[MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/)を追加し、MySQL 8.4 LTS系列を設定します。
+この節では、MySQL Server本体はまだインストールしません。
+
 APT設定パッケージをダウンロードし、インストールします。このパッケージはMySQL本体ではなく、
 APT Repositoryの設定画面を起動するためのものです。
 
-以下はSSH接続したUbuntuサーバー上で実行します。Windows側のPowerShellでは実行しません。
-
 ```bash:console
-# Ubuntuサーバー上で実行
 $ cd /tmp
 
 # APT設定パッケージをダウンロード
@@ -1032,7 +1032,7 @@ $ sudo dpkg -i /tmp/mysql-apt-config_0.8.40-1_all.deb
 インストール中に設定画面が表示されるので、MySQL Server & Clusterが
 `mysql-8.4-lts`（MySQL 8.4 LTS）になっていることを確認して、`Ok` を確定します。
 
-### インストール
+### MySQL Serverのインストール
 
 設定確認後、公式手順どおり `mysql-server` メタパッケージをインストールします。
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1014,7 +1014,7 @@ $ sudo apt purge mariadb-* mysql-*
 
 APT Repositoryは、UbuntuのAPTがパッケージを取得する配布元です。ここではMySQL公式の
 [MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/)を追加し、MySQL 8.4 LTS系列を設定します。
-この設定により、後の `apt install mysql-server` で選択した8.4 LTS系列のパッケージがインストールされます。
+この設定により、後で `apt install mysql-server` を実行した際に、選択した8.4 LTS系列のパッケージがインストールされます。
 
 ```bash:console
 $ cd /tmp

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1013,11 +1013,20 @@ $ sudo apt purge mariadb-* mysql-*
 ### APT Repositoryの追加と系列選択
 
 MySQL公式の[MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/)から
-`mysql-apt-config_..._all.deb` をダウンロードし、インストールします。
+APT設定パッケージをダウンロードし、インストールします。このパッケージはMySQL本体ではなく、
+APT Repositoryの設定画面を起動するためのものです。
+
+以下はSSH接続したUbuntuサーバー上で実行します。Windows側のPowerShellでは実行しません。
 
 ```bash:console
-# ダウンロードしたリリースパッケージをインストール
-$ sudo dpkg -i /path/to/mysql-apt-config_*.deb
+# Ubuntuサーバー上で実行
+$ cd /tmp
+
+# APT設定パッケージをダウンロード
+$ wget https://dev.mysql.com/get/mysql-apt-config_0.8.40-1_all.deb
+
+# Repositoryの設定画面を起動
+$ sudo dpkg -i /tmp/mysql-apt-config_0.8.40-1_all.deb
 ```
 
 インストール中に設定画面が表示されるので、MySQL Server & Clusterで

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1025,26 +1025,18 @@ $ sudo apt update
 # Candidate が 8.4.x になっていることを確認する
 $ apt-cache policy mysql-server
 
-# Candidate が9.xや想定外の系列なら、インストールせずにAPT設定を確認する
-$ grep -R "repo.mysql.com" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null
-$ sudo dpkg-reconfigure mysql-apt-config
-
 # MySQLサーバーのインストール
 $ sudo apt -y install mysql-server
 
 # バージョンの確認
 $ mysql --version
-$ sudo mysql -NBe "SELECT VERSION();"
 
 # 動作ステータスの確認
 $ sudo systemctl status mysql
 ```
 
-`apt-cache policy mysql-server` の `Candidate` と、`mysql --version` / `SELECT
-VERSION()` の結果が8.4系であることを確認します。9.xが表示された場合は、
-リポジトリ設定を8.4 LTSへ戻してから、インストールや更新を続行してください。
-すでに9.xへ更新済みの場合は、バックアップを取得し、APTの系列を戻してすぐに
-ダウングレードせず、公式のダウングレード手順を確認します。
+`Candidate` または `mysql --version` が9.xの場合は作業を止め、
+MySQL APT RepositoryのMySQL Server & Clusterが `mysql-8.4-lts` になっているかを確認します。
 
 ### 初期設定
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1022,18 +1022,29 @@ MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
 # パッケージ情報を更新
 $ sudo apt update
 
-# Candidate が 8.4.x になっていることを確認
+# Candidate が 8.4.x になっていることを確認する
 $ apt-cache policy mysql-server
+
+# Candidate が9.xや想定外の系列なら、インストールせずにAPT設定を確認する
+$ grep -R "repo.mysql.com" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null
+$ sudo dpkg-reconfigure mysql-apt-config
 
 # MySQLサーバーのインストール
 $ sudo apt -y install mysql-server
 
 # バージョンの確認
 $ mysql --version
+$ sudo mysql -NBe "SELECT VERSION();"
 
 # 動作ステータスの確認
 $ sudo systemctl status mysql
 ```
+
+`apt-cache policy mysql-server` の `Candidate` と、`mysql --version` / `SELECT
+VERSION()` の結果が8.4系であることを確認します。9.xが表示された場合は、
+リポジトリ設定を8.4 LTSへ戻してから、インストールや更新を続行してください。
+すでに9.xへ更新済みの場合は、バックアップを取得し、APTの系列を戻してすぐに
+ダウングレードせず、公式のダウングレード手順を確認します。
 
 ### 初期設定
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1014,10 +1014,7 @@ $ sudo apt purge mariadb-* mysql-*
 
 APT Repositoryは、UbuntuのAPTがパッケージを取得する配布元です。ここではMySQL公式の
 [MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/)を追加し、MySQL 8.4 LTS系列を設定します。
-この節では、MySQL Server本体はまだインストールしません。
-
-APT設定パッケージをダウンロードし、インストールします。このパッケージはMySQL本体ではなく、
-APT Repositoryの設定画面を起動するためのものです。
+この設定により、後の `apt install mysql-server` で選択した8.4 LTS系列のパッケージがインストールされます。
 
 ```bash:console
 $ cd /tmp

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1018,7 +1018,7 @@ MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
 パッチ更新を受け入れつつ、リポジトリの選択を変更しない限り9.x系へは移行しません。
 
 ```bash:console
-# パッケージ情報を更新
+# MySQL APT Repository設定後のパッケージ情報を更新
 $ sudo apt update
 
 # Candidate が 8.4.x になっていることを確認する
@@ -1294,7 +1294,6 @@ Python 3.12.3
 
 ```bash:console
 # MySQLクライアントのビルドに必要なライブラリをインストール
-$ sudo apt update
 $ sudo apt install -y libmysqlclient-dev pkg-config python3-dev
 
 # 仮想環境の有効化とパッケージインストール
@@ -1373,7 +1372,6 @@ $ source venv/bin/activate
 
 ```bash:console
 # まず APT 版 mod_wsgi を導入・有効化し、読み込みを確認する
-$ sudo apt update
 $ sudo apt install -y libapache2-mod-wsgi-py3
 $ sudo a2enmod wsgi
 $ apache2ctl -M | grep -i wsgi   # 期待: wsgi_module (shared)
@@ -1723,7 +1721,7 @@ $ sudo find /var/www/html/portfolio -type f -exec chmod 664 {} +
 
 ```bash:console
 # ACL ツールのインストール
-$ sudo apt update && sudo apt install acl -y
+$ sudo apt install acl -y
 
 # media/ ディレクトリに対して、新規ファイルが ubuntu と www-data 両方の読み書きを継承するように設定
 $ sudo setfacl -R -d -m u:ubuntu:rwx /var/www/html/portfolio/media

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1029,33 +1029,16 @@ $ wget https://dev.mysql.com/get/mysql-apt-config_0.8.40-1_all.deb
 $ sudo dpkg -i /tmp/mysql-apt-config_0.8.40-1_all.deb
 ```
 
-インストール中に設定画面が表示されるので、MySQL Server & Clusterで
-`mysql-8.4-lts`（MySQL 8.4 LTS）を選択して、`Ok` を確定します。
-画面の選択箇所は次のように表示されます。
-
-```text
-  MySQL Server & Cluster
-    mysql-8.4-lts
-```
-
-既に導入済みの設定画面を再表示する場合は、次を実行します。
-
-```bash:console
-$ sudo dpkg-reconfigure mysql-apt-config
-```
+インストール中に設定画面が表示されるので、MySQL Server & Clusterが
+`mysql-8.4-lts`（MySQL 8.4 LTS）になっていることを確認して、`Ok` を確定します。
 
 ### インストール
 
-Repositoryのリリース系列を選択したうえで、公式手順どおり
-`mysql-server` メタパッケージをインストールします。`mysql-server-8.4` という
-パッケージ名を指定するのではなく、選択した8.4系列の最新パッチがインストールされます。
+設定確認後、公式手順どおり `mysql-server` メタパッケージをインストールします。
 
 ```bash:console
 # MySQL APT Repository設定後のパッケージ情報を更新
 $ sudo apt update
-
-# Candidate が 8.4.x になっていることを確認する
-$ apt-cache policy mysql-server
 
 # MySQLサーバーのインストール
 $ sudo apt -y install mysql-server
@@ -1067,7 +1050,7 @@ $ mysql --version
 $ sudo systemctl status mysql
 ```
 
-`Candidate` と `mysql --version` が8.4.xになっていることを確認します。
+`mysql --version` が8.4.xになっていることを確認します。
 
 ### 初期設定
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1303,6 +1303,9 @@ Python 3.12.3
 ## 依存パッケージのインストール
 
 ```bash:console
+# パッケージ情報を更新
+$ sudo apt update
+
 # MySQLクライアントのビルドに必要なライブラリをインストール
 $ sudo apt install -y libmysqlclient-dev pkg-config python3-dev
 
@@ -1381,6 +1384,9 @@ $ source venv/bin/activate
     を検討）。
 
 ```bash:console
+# パッケージ情報を更新
+$ sudo apt update
+
 # まず APT 版 mod_wsgi を導入・有効化し、読み込みを確認する
 $ sudo apt install -y libapache2-mod-wsgi-py3
 $ sudo a2enmod wsgi
@@ -1730,6 +1736,9 @@ $ sudo find /var/www/html/portfolio -type f -exec chmod 664 {} +
 `setfacl` を使用して、今後 `media/` 以下に作られるすべてのファイルに自動的に `ubuntu` と `www-data` 両方の権限を継承させます。
 
 ```bash:console
+# パッケージ情報を更新
+$ sudo apt update
+
 # ACL ツールのインストール
 $ sudo apt install acl -y
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1031,7 +1031,7 @@ $ sudo dpkg -i /tmp/mysql-apt-config_0.8.40-1_all.deb
 
 ### MySQL Serverのインストール
 
-設定確認後、公式手順どおり `mysql-server` メタパッケージをインストールします。
+設定確認後、公式手順どおり `mysql-server` をインストールします。
 
 ```bash:console
 # MySQL APT Repository設定後のパッケージ情報を更新

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1010,12 +1010,36 @@ MariaDBなどがインストールされている場合は、事前に削除し�
 $ sudo apt purge mariadb-* mysql-*
 ```
 
+### APT Repositoryの追加と系列選択
+
+MySQL公式の[MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/)から
+`mysql-apt-config_..._all.deb` をダウンロードし、インストールします。
+
+```bash:console
+# ダウンロードしたリリースパッケージをインストール
+$ sudo dpkg -i /path/to/mysql-apt-config_*.deb
+```
+
+インストール中に設定画面が表示されるので、MySQL Server & Clusterで
+`mysql-8.4-lts`（MySQL 8.4 LTS）を選択して、`Ok` を確定します。
+画面の選択箇所は次のように表示されます。
+
+```text
+  MySQL Server & Cluster
+    mysql-8.4-lts
+```
+
+既に導入済みの設定画面を再表示する場合は、次を実行します。
+
+```bash:console
+$ sudo dpkg-reconfigure mysql-apt-config
+```
+
 ### インストール
 
-MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
-`mysql-8.4-lts`（MySQL 8.4 LTS）を選択します。リポジトリのリリース系列を固定したうえで、公式手順どおり
+Repositoryのリリース系列を選択したうえで、公式手順どおり
 `mysql-server` メタパッケージをインストールします。`mysql-server-8.4` という
-パッケージ名で固定するのではなく、8.4系列の最新パッチをインストールします。
+パッケージ名を指定するのではなく、選択した8.4系列の最新パッチがインストールされます。
 
 ```bash:console
 # MySQL APT Repository設定後のパッケージ情報を更新

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1015,9 +1015,16 @@ $ sudo apt purge mariadb-* mysql-*
 MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
 `mysql-8.4-lts`（MySQL 8.4 LTS）を選択します。`mysql-innovation` や9.x系は
 選択しません。リポジトリのリリース系列を固定したうえで、公式手順どおり
-`mysql-server` メタパッケージをインストールします。
+`mysql-server` メタパッケージをインストールします。この指定は8.4系の
+パッチ更新を受け入れつつ、リポジトリの選択を変更しない限り9.x系へは移行しません。
 
 ```bash:console
+# パッケージ情報を更新
+$ sudo apt update
+
+# Candidate が 8.4.x になっていることを確認
+$ apt-cache policy mysql-server
+
 # MySQLサーバーのインストール
 $ sudo apt -y install mysql-server
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1014,8 +1014,8 @@ $ sudo apt purge mariadb-* mysql-*
 
 MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
 `mysql-8.4-lts`（MySQL 8.4 LTS）を選択します。リポジトリのリリース系列を固定したうえで、公式手順どおり
-`mysql-server` メタパッケージをインストールします。この指定は8.4系の
-パッチ更新を受け入れつつ、リポジトリの選択を変更しない限り9.x系へは移行しません。
+`mysql-server` メタパッケージをインストールします。`mysql-server-8.4` という
+パッケージ名で固定するのではなく、8.4系列の最新パッチをインストールします。
 
 ```bash:console
 # MySQL APT Repository設定後のパッケージ情報を更新
@@ -1034,8 +1034,7 @@ $ mysql --version
 $ sudo systemctl status mysql
 ```
 
-`Candidate` または `mysql --version` が9.xの場合は作業を止め、
-MySQL APT RepositoryのMySQL Server & Clusterが `mysql-8.4-lts` になっているかを確認します。
+`Candidate` と `mysql --version` が8.4.xになっていることを確認します。
 
 ### 初期設定
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1164,26 +1164,13 @@ Test tunnel configuration を押して、サーバにつながったことを確
 
 #### `Public Key Retrieval is not allowed` のエラーが出力される場合
 
-これは、パスワードが間違っているという意味ではありません。MySQL 8 系の
-`caching_sha2_password` 認証では、TLS（SSL）を使わずに接続するとき、JDBC
-ドライバがパスワードを暗号化して送るために MySQL サーバーの RSA 公開鍵を
-取得する必要があります。`allowPublicKeyRetrieval` は、その公開鍵をサーバーから
-取得することを JDBC ドライバに許可する接続オプションです。MySQL サーバーの
-設定値ではありません。
-
 ローカルの開発環境で接続する場合は、DBeaver の接続編集画面で「ドライバの
 プロパティ」を開き、次の値を追加・変更します。
 
-| プロパティ | 値 |
-|:-----------|:---|
-| `allowPublicKeyRetrieval` | `true` |
-| `useSSL` | `false`（ローカル開発時のみ） |
-
-URL で指定する場合は、次の形式です。
-
-```text
-jdbc:mysql://127.0.0.1:3306/portfolio_db?allowPublicKeyRetrieval=true&useSSL=false
-```
+| プロパティ | 値 | 効果 |
+|:-----------|:---|:---|
+| `allowPublicKeyRetrieval` | `true` | RSA公開鍵の取得を許可 |
+| `useSSL` | `false`（ローカル開発時のみ） | SSLを使わずに接続 |
 
 この設定はローカル接続用です。本番環境では `useSSL=false` を常用せず、既存の
 SSH トンネルまたは TLS を使って接続します。また、通常のDBeaver接続では

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1,10 +1,10 @@
-# CentOSが終わるのでUbuntu24.04に移行する。Python3.12とDjango6とMySQL8のセットアップメモ2026
+# CentOSが終わるのでUbuntu24.04に移行する。Python3.12とDjango6とMySQL8.4のセットアップメモ2026
 
 ## はじめに
 
 この記事は、CentOSのサポート終了（EOL）に伴い、OSをUbuntu 24.04 LTSへ移行した際のセットアップ手順をまとめたものです。
 2021年の初出から更新を重ねていますが、ここで紹介している構成は現在も本番サーバーで安定稼働しており、実用的なオペレーションマニュアルとして活用しています。
-かつてのCentOS環境からのスムーズな移行と、現行のPython 3.12 + Django 6環境の構築を目指しています。
+かつてのCentOS環境からのスムーズな移行と、現代的なPython 3.12 + Django 6 + MySQL 8.4環境の構築を目指しています。
 
 2026年版からは、この記事を Git
 で管理し、AIアシスタントをベースに執筆する運用に切り替えました。誤字脱字はもちろん、これまでの勘違いの是正や重複箇所のMECE化にも大いに助けられています。今後の細かな修正も容易になるため、おすすめです。
@@ -1000,7 +1000,7 @@ $ curl -I --resolve www.henojiya.net:443:127.0.0.1 https://www.henojiya.net/ \
     がコメントアウト状態で存在するが、有効化されていないため診断ツールには「未設定」と判定される。本手順で
     `000-default-le-ssl.conf` に明示的に追加することで初めて有効になる。
 
-## MySQL8
+## MySQL 8.4
 
 ### 不要なパッケージの削除
 
@@ -1013,8 +1013,9 @@ $ sudo apt purge mariadb-* mysql-*
 ### インストール
 
 ```bash:console
+# MySQL APT RepositoryでMySQL 8.4 LTSを選択している前提
 # MySQLサーバーのインストール
-$ sudo apt -y install mysql-server-8.0
+$ sudo apt -y install mysql-server
 
 # バージョンの確認
 $ mysql --version
@@ -1120,12 +1121,38 @@ Test tunnel configuration を押して、サーバにつながったことを確
 | Port        | 3306                   |
 | Database    | portfolio_db           |
 | ユーザー名       | python                 |
-| パスワード       | （MySQLのrootユーザーのパスワード） |
+| パスワード       | `.env` の `DJANGO_DB_PASSWORD`（`python` ユーザー用） |
 
 テスト接続を押して、サーバにつながったことを確認する
 ![image.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/94562/20f33c30-9288-7b7e-1663-e8e7bcd52920.png)
 
-#### ※Public Key Retrieval is not allowedのエラーが出力される
+#### `Public Key Retrieval is not allowed` のエラーが出力される場合
+
+これは、パスワードが間違っているという意味ではありません。MySQL 8 系の
+`caching_sha2_password` 認証では、TLS（SSL）を使わずに接続するとき、JDBC
+ドライバがパスワードを暗号化して送るために MySQL サーバーの RSA 公開鍵を
+取得する必要があります。`allowPublicKeyRetrieval` は、その公開鍵をサーバーから
+取得することを JDBC ドライバに許可する接続オプションです。MySQL サーバーの
+設定値ではありません。
+
+ローカルの開発環境で接続する場合は、DBeaver の接続編集画面で「ドライバの
+プロパティ」を開き、次の値を追加・変更します。
+
+| プロパティ | 値 |
+|:-----------|:---|
+| `allowPublicKeyRetrieval` | `true` |
+| `useSSL` | `false`（ローカル開発時のみ） |
+
+URL で指定する場合は、次の形式です。
+
+```text
+jdbc:mysql://127.0.0.1:3306/portfolio_db?allowPublicKeyRetrieval=true&useSSL=false
+```
+
+この設定はローカル接続用です。本番環境では `useSSL=false` を常用せず、既存の
+SSH トンネルまたは TLS を使って接続します。また、通常のDBeaver接続では
+`root` ではなく、Django の接続設定に合わせて `python` ユーザーを使います。
+`root` のパスワードは、初期設定やデータベース・ユーザー作成時だけ使用します。
 
 [DBeaver からローカルのMySQLに接続できない問題への対処法](https://qiita.com/ymzkjpx/items/449c505c50ee17b6e8f9)
 

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1012,8 +1012,12 @@ $ sudo apt purge mariadb-* mysql-*
 
 ### インストール
 
+MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
+`mysql-8.4-lts`（MySQL 8.4 LTS）を選択します。`mysql-innovation` や9.x系は
+選択しません。リポジトリのリリース系列を固定したうえで、公式手順どおり
+`mysql-server` メタパッケージをインストールします。
+
 ```bash:console
-# MySQL APT RepositoryでMySQL 8.4 LTSを選択している前提
 # MySQLサーバーのインストール
 $ sudo apt -y install mysql-server
 
@@ -1121,7 +1125,7 @@ Test tunnel configuration を押して、サーバにつながったことを確
 | Port        | 3306                   |
 | Database    | portfolio_db           |
 | ユーザー名       | python                 |
-| パスワード       | `.env` の `DJANGO_DB_PASSWORD`（`python` ユーザー用） |
+| パスワード       | （MySQLのrootユーザーのパスワード） |
 
 テスト接続を押して、サーバにつながったことを確認する
 ![image.png](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/94562/20f33c30-9288-7b7e-1663-e8e7bcd52920.png)

--- a/docs/qiita/centos_to_ubuntu_setup.md
+++ b/docs/qiita/centos_to_ubuntu_setup.md
@@ -1013,8 +1013,7 @@ $ sudo apt purge mariadb-* mysql-*
 ### インストール
 
 MySQL APT Repositoryの設定画面では、MySQL Server & Clusterに
-`mysql-8.4-lts`（MySQL 8.4 LTS）を選択します。`mysql-innovation` や9.x系は
-選択しません。リポジトリのリリース系列を固定したうえで、公式手順どおり
+`mysql-8.4-lts`（MySQL 8.4 LTS）を選択します。リポジトリのリリース系列を固定したうえで、公式手順どおり
 `mysql-server` メタパッケージをインストールします。この指定は8.4系の
 パッチ更新を受け入れつつ、リポジトリの選択を変更しない限り9.x系へは移行しません。
 


### PR DESCRIPTION
## Summary

CI・ローカル開発環境・Ubuntuセットアップ記事のMySQL設定を、現在のMySQL 8.4環境に合わせて整合させます。

- GitHub ActionsのMySQLユーザーを `127.0.0.1` で作成し、DjangoがテストDBを自動作成・削除できる権限を付与
- READMEのMySQLバッジを8.4へ更新
- Ubuntuセットアップ記事のMySQL 8.4 LTS前提、インストール手順、DBeaver接続手順を更新
- `allowPublicKeyRetrieval` の意味と、ローカルDBeaver接続時の設定を追記
- Django用の `python` ユーザーとrootユーザーのパスワード用途を明確化

## 目検による動作確認手順

- [x] Windowsサービスの `MySQL84` が「実行中」「自動起動」になっていることを確認する
- [x] DBeaverで `127.0.0.1:3306` の `portfolio_db` に `python` ユーザーで接続する
- [x] DBeaverのドライバプロパティで、ローカル開発時のみ `allowPublicKeyRetrieval=true` と `useSSL=false` を設定し、テスト接続が成功することを確認する
- [x] Djangoテスト実行後に、テストDBが自動作成され、完了後に削除されることを確認する

## 自動テストでカバーできた範囲

以下を実行し、Djangoの全556テストが成功しました。テストDBの自動作成・削除も含めて確認しています。

```powershell
.\venv\Scripts\python.exe manage.py test --noinput --verbosity 1
```

結果: `Ran 556 tests ... OK`

また、`git diff --check` も成功しています。

## 関連Issue

Closes #922
https://github.com/duri0214/portfolio/issues/922
