### PR TITLE
#924 Zedターミナルでvenvを自動有効化する設定を追加

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,11 +1,17 @@
 {
   "terminal": {
-    "detect_venv": {
-      "on": {
-        "directories": [".venv", "venv"],
-        "activate_script": "default"
+    "shell": {
+      "with_arguments": {
+        "program": "powershell.exe",
+        "args": [
+          "-NoLogo",
+          "-NoExit",
+          "-Command",
+          "$activate = $null; if (Test-Path '.\\venv\\Scripts\\Activate.ps1') { $activate = '.\\venv\\Scripts\\Activate.ps1' } elseif (Test-Path '.\\.venv\\Scripts\\Activate.ps1') { $activate = '.\\.venv\\Scripts\\Activate.ps1' }; if ($activate) { . $activate }"
+        ]
       }
-    }
+    },
+    "detect_venv": "off"
   },
   "languages": {
     "Python": {

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,11 +1,17 @@
 {
   "terminal": {
-    "detect_venv": {
-      "on": {
-        "directories": [".venv", "venv"],
-        "activate_script": "default"
+    "shell": {
+      "with_arguments": {
+        "program": "powershell.exe",
+        "args": [
+          "-NoLogo",
+          "-NoExit",
+          "-Command",
+          "if (Test-Path '.\\.venv\\Scripts\\Activate.ps1') { . '.\\.venv\\Scripts\\Activate.ps1' } elseif (Test-Path '.\\venv\\Scripts\\Activate.ps1') { . '.\\venv\\Scripts\\Activate.ps1' }"
+        ]
       }
-    }
+    },
+    "detect_venv": "off"
   },
   "languages": {
     "Python": {

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,12 @@
 {
+  "terminal": {
+    "detect_venv": {
+      "on": {
+        "directories": [".venv", "venv"],
+        "activate_script": "default"
+      }
+    }
+  },
   "languages": {
     "Python": {
       "enable_language_server": false,

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,17 +1,11 @@
 {
   "terminal": {
-    "shell": {
-      "with_arguments": {
-        "program": "powershell.exe",
-        "args": [
-          "-NoLogo",
-          "-NoExit",
-          "-Command",
-          "$activate = $null; if (Test-Path '.\\venv\\Scripts\\Activate.ps1') { $activate = '.\\venv\\Scripts\\Activate.ps1' } elseif (Test-Path '.\\.venv\\Scripts\\Activate.ps1') { $activate = '.\\.venv\\Scripts\\Activate.ps1' }; if ($activate) { . $activate }"
-        ]
+    "detect_venv": {
+      "on": {
+        "directories": [".venv", "venv"],
+        "activate_script": "default"
       }
-    },
-    "detect_venv": "off"
+    }
   },
   "languages": {
     "Python": {


### PR DESCRIPTION
## Summary

Zedのプロジェクトターミナル起動時に、リポジトリ内のPython仮想環境を自動有効化する設定を追加しました。

- PowerShell起動時に .venv\Scripts\Activate.ps1 を優先して実行
- .venv がない場合は venv\Scripts\Activate.ps1 を実行
- Zed標準の自動検出がWindows PowerShellで効かない環境にも対応

## 目検による動作確認手順

- [x] Zedでこのプロジェクトを開き、既存ターミナルを閉じて新しいターミナルを作成する
- [x] venv利用時にプロンプトへ (venv) が表示される
- [x] .venv利用時にもプロンプトへ (venv) が表示される
- [x] python -c "import sys; print(sys.prefix)" で選択した仮想環境が表示される
- [x] python manage.py check などのPythonコマンドが仮想環境で実行される

## 自動テストでカバーできた範囲

- .zed/settings.json をJSONパーサーで検証
- PowerShell起動引数を実行し、venvのPythonを確認
- git diff --check を実行
- 設定ファイルのみの変更のため、Djangoテストは未実施

## 関連Issue

Closes #924
https://github.com/duri0214/portfolio/issues/924
